### PR TITLE
Fixes reading VCPU struct values.

### DIFF
--- a/rig/machine_control/consts.py
+++ b/rig/machine_control/consts.py
@@ -14,6 +14,7 @@ SPINNAKER_RTR_BASE = 0xE1000000  # Unbuffered
 SPINNAKER_RTR_P2P = SPINNAKER_RTR_BASE + 0x10000
 """Base address of P2P routing table."""
 
+
 class SCPCommands(enum.IntEnum):
     """Command codes used in SCP packets."""
     sver = 0  # Get the software version


### PR DESCRIPTION
This is one option for fixing reading the vcpu struct.  It maintains the
same API that we had before (`read_struct_field`) but as a result hides
some magic... I'm not sure if we're happy with doing it this way.

 - [ ] Run test against real board.