### PR TITLE
Add `loading_routing_tables`

### DIFF
--- a/rig/machine_control/machine_controller.py
+++ b/rig/machine_control/machine_controller.py
@@ -816,15 +816,44 @@ class MachineController(ContextMixin):
         self._send_scp(0, 0, 0, SCPCommands.signal, arg1, arg2, arg3)
 
     @ContextMixin.use_contextual_arguments
+    def load_routing_tables(self, routing_tables, app_id=Required):
+        """Allocate space for an load multicast routing tables.
+
+        Parameters
+        ----------
+        routing_tables : {(x, y): [RoutingTableEntry(...), ...], ...}
+            Map of chip co-ordinates to routing table entries, as produced, for
+            example by
+            :py:func:`~rig.place_and_route.util.build_routing_tables`.
+
+        Raises
+        ------
+        SpiNNakerRouterError
+            If it is not possible to allocate sufficient routing table entries.
+        """
+        for (x, y), table in iteritems(routing_tables):
+            self.load_routing_table_entries(table, x=x, y=y, app_id=app_id)
+
+    @ContextMixin.use_contextual_arguments
     def load_routing_table_entries(self, entries, x=Required, y=Required,
                                    app_id=Required):
         """Allocate space for and load multicast routing table entries into the
         router of a SpiNNaker chip.
 
+        .. note::
+            This method only loads routing table entries for a single chip.
+            Most users should use `.load_routing_tables` which loads routing
+            tables to multiple chips.
+
         Parameters
         ----------
         entries : [RoutingTableEntry(...), ...]
             List of :py:class:`rig.routing_table.RoutingTableEntry`\ s.
+
+        Raises
+        ------
+        SpiNNakerRouterError
+            If it is not possible to allocate sufficient routing table entries.
         """
         count = len(entries)
 

--- a/rig/machine_control/tests/test_machine_controller.py
+++ b/rig/machine_control/tests/test_machine_controller.py
@@ -1216,6 +1216,25 @@ class TestMachineController(object):
         assert "100" in str(excinfo.value)
         assert "(0, 4)" in str(excinfo.value)
 
+    @pytest.mark.parametrize(
+        "routing_tables",
+        [{(0, 1): [RoutingTableEntry({Routes.core_1}, 0x00ff0000, 0xffff0000)],
+          (1, 1): [RoutingTableEntry({Routes.east}, 0x00ff0000, 0xffff0000)],
+          }])
+    def test_loading_routing_tables(self, routing_tables):
+        cn = MachineController("localhost")
+        cn.load_routing_table_entries = mock.Mock()
+
+        # Load the set of routing table entries
+        with cn(app_id=69):
+            cn.load_routing_tables(routing_tables)
+
+        # Check all the calls were made
+        cn.load_routing_table_entries.assert_has_calls(
+            [mock.call(entries, x=x, y=y, app_id=69)
+             for (x, y), entries in iteritems(routing_tables)]
+        )
+
     def test_get_p2p_routing_table(self):
         cn = MachineController("localhost")
 


### PR DESCRIPTION
To load multiple routing tables across a SpiNNaker machine.  The routing
table analogue of `load_application`.

Fixes #47