### PR TITLE
Clean up `sver`.

### DIFF
--- a/rig/machine_control/machine_controller.py
+++ b/rig/machine_control/machine_controller.py
@@ -199,6 +199,7 @@ class MachineController(ContextMixin):
         # Format the result
         # arg1 => p2p address, physical cpu, virtual cpu
         p2p = sver.arg1 >> 16
+        p2p_address = (p2p >> 8, p2p & 0x00ff)
         pcpu = (sver.arg1 >> 8) & 0xff
         vcpu = sver.arg1 & 0xff
 
@@ -206,8 +207,8 @@ class MachineController(ContextMixin):
         version = (sver.arg2 >> 16) / 100.
         buffer_size = (sver.arg2 & 0xffff)
 
-        return CoreInfo(p2p, pcpu, vcpu, version, buffer_size, sver.arg3,
-                        sver.data)
+        return CoreInfo(p2p_address, pcpu, vcpu, version, buffer_size,
+                        sver.arg3, sver.data)
 
     @ContextMixin.use_contextual_arguments
     def write(self, address, data, x=Required, y=Required, p=0):
@@ -996,13 +997,13 @@ class MachineController(ContextMixin):
 
 
 class CoreInfo(collections.namedtuple(
-    'CoreInfo', "p2p_address physical_cpu virt_cpu version buffer_size "
+    'CoreInfo', "position physical_cpu virt_cpu version buffer_size "
                 "build_date version_string")):
     """Information returned about a core by sver.
 
     Parameters
     ----------
-    p2p_address : (x, y)
+    position : (x, y)
         Logical location of the chip in the system.
     physical_cpu : int
         The physical ID of the core. (Not useful to most users).

--- a/rig/machine_control/tests/test_machine_controller.py
+++ b/rig/machine_control/tests/test_machine_controller.py
@@ -98,6 +98,7 @@ class TestMachineControllerLive(object):
                 assert sver.virt_cpu == 0
                 assert b"SpiNNaker" in bytes(sver.version_string)
                 assert sver.version >= 1.3
+                assert sver.position == (x, y)
 
     def test_write_and_read(self, controller):
         """Test write and read capabilities by writing a string to SDRAM and
@@ -349,7 +350,7 @@ class TestMachineController(object):
         sver = cn.get_software_version(0, 1, 2)
 
         # Assert that the response is correct
-        assert sver.p2p_address == (1 << 8) | 2
+        assert sver.position == (1, 2)
         assert sver.physical_cpu == 3
         assert sver.virt_cpu == 4
         assert sver.version == 2.56


### PR DESCRIPTION
Fixes #48.

Renames `CoreInfo.p2p_address` to `CoreInfo.position` and ensures that
it is a tuple `(x, y)`.