### PR TITLE
Fix #51 and #52

### DIFF
--- a/rig/machine_control/machine_controller.py
+++ b/rig/machine_control/machine_controller.py
@@ -517,8 +517,8 @@ class MachineController(ContextMixin):
         """
         assert 0 <= tag < 256
 
-        # Construct arg1 (op_code << 8) | app_id
-        arg1 = consts.AllocOperations.alloc_sdram << 8 | app_id
+        # Construct arg1 (app_id << 8) | op code
+        arg1 = app_id << 8 | consts.AllocOperations.alloc_sdram
 
         # Send the packet and retrieve the address
         rv = self._send_scp(x, y, 0, SCPCommands.alloc_free, arg1, size, tag)

--- a/rig/machine_control/machine_controller.py
+++ b/rig/machine_control/machine_controller.py
@@ -1221,7 +1221,7 @@ class MemoryIO(object):
 
         # Perform the read and increment the offset
         data = self._machine_controller.read(
-            self._x, self._y, 0, self.address, n_bytes)
+            self.address, n_bytes, self._x, self._y, 0)
         self._offset += n_bytes
         return data
 
@@ -1251,7 +1251,7 @@ class MemoryIO(object):
 
         # Perform the write and increment the offset
         self._machine_controller.write(
-            self._x, self._y, 0, self.address, bytes)
+            self.address, bytes, self._x, self._y, 0)
         self._offset += len(bytes)
         return len(bytes)
 

--- a/rig/machine_control/tests/test_machine_controller.py
+++ b/rig/machine_control/tests/test_machine_controller.py
@@ -654,7 +654,7 @@ class TestMachineController(object):
 
         Outgoing:
             cmd_rc : 28
-            arg1 : op code (0) << 8 | app_id
+            arg1 : app_id << 8 | op code (0)
             arg2 : size (bytes)
             arg3 : tag
         """
@@ -672,7 +672,8 @@ class TestMachineController(object):
         assert address == addr
 
         # Check the packet was sent as expected
-        cn._send_scp.assert_called_once_with(1, 2, 0, 28, app_id, size, tag)
+        cn._send_scp.assert_called_once_with(1, 2, 0, 28, app_id << 8,
+                                             size, tag)
 
     @pytest.mark.parametrize("x, y", [(1, 3), (5, 6)])
     @pytest.mark.parametrize("size", [8, 200])


### PR DESCRIPTION
Fixes #51 and #52.

Adds new tests to ensure that `sdram_malloc_as_io` (and hence `sdram_malloc`) and `MemoryIO.write`, `MemoryIO.seek` and `MemoryIO.read` work against a real machine.