### PR TITLE
Remove constraint on data length.

### DIFF
--- a/rig/machine_control/packets.py
+++ b/rig/machine_control/packets.py
@@ -80,7 +80,7 @@ class SDPPacket(object):
     dest_y = RangedIntAttribute(0, 256)
     src_x = RangedIntAttribute(0, 256)
     src_y = RangedIntAttribute(0, 256)
-    data = ByteStringAttribute(max_length=272)
+    data = ByteStringAttribute()
 
     def __init__(self, reply_expected, tag, dest_port, dest_cpu, src_port,
                  src_cpu, dest_x, dest_y, src_x, src_y, data):

--- a/rig/machine_control/tests/test_packets.py
+++ b/rig/machine_control/tests/test_packets.py
@@ -178,11 +178,6 @@ class TestSDPPacket(object):
             # src_y is 8 bits
             SDPPacket(False, 255, 7, 17, 7, 17, 255, 255, 255, -1, b'')
 
-        with pytest.raises(ValueError):
-            # Data can only be 272 bytes long
-            SDPPacket(False, 255, 7, 17, 7, 17, 255, 255, 255, 255,
-                      273*b'\x00')
-
 
 class TestSCPPacket(object):
     """Test packets conforming to the SCP protocol."""
@@ -435,8 +430,3 @@ class TestSCPPacket(object):
         with pytest.raises(ValueError):  # arg3 is 32 bits
             SCPPacket(False, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                       0xFFFF, 0xFFFF, 0xFFFFFFFF, 0xFFFFFFFF, -1, b'')
-
-        with pytest.raises(ValueError):  # data is max 256 bytes
-            SCPPacket(False, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                      0xFFFF, 0xFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-                      257*b'\x00')


### PR DESCRIPTION
 - Allows data segments of SCP/SDP packets to be unbounded.

Fixes #56.