### PR TITLE
Hit 100% Statement & Branch Test Coverage

### DIFF
--- a/rig/bitfield.py
+++ b/rig/bitfield.py
@@ -497,20 +497,11 @@ class BitField(object):
                    in field.conditions.items()):
                 yield (identifier, field)
 
-    def _potential_fields(self, field_values=None):
+    def _potential_fields(self):
         """Generator of (identifier, field) tuples iterating over every field
         which could potentially be defined given the currently specified field
         values.
-
-        Parameters
-        ----------
-        field_values : dict or None
-            Dictionary of field identifier to value mappings to use in the
-            test. If *None*, uses `self.field_values`.
         """
-        if field_values is None:
-            field_values = self.field_values
-
         # Fields are blocked when their conditions can't be met. This only
         # occurs if a condition field's value can't be as the condition
         # requires. This can occur either because the user has already assigned
@@ -523,7 +514,8 @@ class BitField(object):
         for identifier, field in self.fields.items():
             if not field.conditions \
                or all(cond_field not in blocked and
-                      field_values.get(cond_field, cond_value) == cond_value
+                      self.field_values.get(cond_field, cond_value) ==
+                      cond_value
                       for cond_field, cond_value
                       in field.conditions.items()):
                 yield (identifier, field)

--- a/rig/machine_control/boot.py
+++ b/rig/machine_control/boot.py
@@ -50,7 +50,7 @@ spin5_boot_options = {
 
 def boot(hostname, width, height, boot_port=consts.BOOT_PORT,
          cpu_frequency=200, hardware_version=0,
-         led_config=0x00000001, boot_data=None, struct_data=None,
+         led_config=0x00000001, boot_data=None, structs=None,
          boot_delay=0.05, post_boot_delay=5.0):
     """Boot a SpiNNaker machine of the given size.
 
@@ -78,9 +78,9 @@ def boot(hostname, width, height, boot_port=consts.BOOT_PORT,
         thus the default value of 0x00000001 is safe.
     boot_data : bytes or None
         Data to boot the machine with
-    struct_data : bytes or None
-        Data to interpret as a representation of the memory layout of data
-        within the boot data.
+    structs : dict or None
+        The structs to use to supply boot parameters to the machine or None to
+        use the default struct.
     boot_delay : float
         Number of seconds to pause between sending boot data packets.
     post_boot_delay : float
@@ -103,17 +103,16 @@ def boot(hostname, width, height, boot_port=consts.BOOT_PORT,
     {struct_name: :py:class:`~rig.machine_control.struct_file.Struct`}
         Layout of structs in memory.
     """
-    # Get the boot and struct data if not specified.
-    if struct_data is None:
-        struct_data = pkg_resources.resource_string("rig",
-                                                    "boot/sark.struct")
-
-    if boot_data is None:
+    # Get the boot data if not specified.
+    if boot_data is None:  # pragma: no branch
         boot_data = pkg_resources.resource_string("rig", "boot/scamp.boot")
 
     # Read the struct file and modify the "sv" struct to contain the
     # configuration values and write this into the boot data.
-    structs = struct_file.read_struct_file(struct_data)
+    if structs is None:  # pragma: no branch
+        struct_data = pkg_resources.resource_string("rig",
+                                                    "boot/sark.struct")
+        structs = struct_file.read_struct_file(struct_data)
     sv = structs[b"sv"]
     sv.update_default_values(p2p_dims=(width << 8) | height,
                              hw_ver=hardware_version,

--- a/rig/machine_control/tests/test_packets.py
+++ b/rig/machine_control/tests/test_packets.py
@@ -55,6 +55,45 @@ class TestRangedIntAttribute(object):
         y.y = None
 
 
+class TestByteStringAttribute(object):
+    def test_unlimited_length(self):
+        class X(object):
+            y = packets.ByteStringAttribute(default=b"default")
+
+        x = X()
+
+        assert x.y == b"default"
+
+        x.y = b""
+        assert x.y == b""
+
+        x.y = b"hello"
+        assert x.y == b"hello"
+
+        x.y = b"01234567"
+        assert x.y == b"01234567"
+
+    def test_max_length(self):
+        class X(object):
+            y = packets.ByteStringAttribute(max_length=8)
+
+        x = X()
+
+        assert x.y == b""
+
+        x.y = b""
+        assert x.y == b""
+
+        x.y = b"hello"
+        assert x.y == b"hello"
+
+        x.y = b"01234567"
+        assert x.y == b"01234567"
+
+        with pytest.raises(ValueError):
+            x.y = b"012345678"
+
+
 class TestSDPPacket(object):
     """Test SDPPacket representations."""
     def test_from_bytestring_to_bytestring(self):

--- a/rig/place_and_route/place/tests/test_generic.py
+++ b/rig/place_and_route/place/tests/test_generic.py
@@ -96,7 +96,7 @@ def test_trivial(algorithm, kwargs):
     # resources.
     machine = Machine(1, 1, chip_resources={Cores: 8})
     vertices = [object() for _ in range(8)]
-    assert algorithm({v: {Cores: 1} for v in vertices},
+    assert algorithm({v: {Cores: 1} for v in vertices},  # pragma: no branch
                      [], machine, [], **kwargs) \
         == {v: (0, 0) for v in vertices}
 
@@ -105,7 +105,7 @@ def test_trivial(algorithm, kwargs):
     machine = Machine(1, 1, chip_resources={Cores: 8})
     vertices = [object() for _ in range(8)]
     nets = [Net(vertices[0], vertices[1:])]
-    assert algorithm({v: {Cores: 1} for v in vertices},
+    assert algorithm({v: {Cores: 1} for v in vertices},  # pragma: no branch
                      nets, machine, [], **kwargs) \
         == {v: (0, 0) for v in vertices}
 

--- a/rig/place_and_route/route/ner.py
+++ b/rig/place_and_route/route/ner.py
@@ -344,7 +344,7 @@ def avoid_dead_links(root, machine, wrap_around=False):
                 new_node = lookup[(x, y)]
 
                 # Disconnect node from parent
-                for node in lookup[child]:
+                for node in lookup[child]:  # pragma: no branch
                     if new_node in node.children:
                         node.children.remove(new_node)
                         break

--- a/rig/place_and_route/route/tests/test_generic.py
+++ b/rig/place_and_route/route/tests/test_generic.py
@@ -72,8 +72,9 @@ def assert_equivilent(route, net, placements, allocation, constraints=[]):
     assert placements[net.source] == route.chip
 
     # Net should visit all locations where a net's sink exists
-    assert set(n.chip for n in route if isinstance(n, RoutingTree)).issuperset(
-        set(placements[v] for v in net.sinks))
+    assert (  # pragma: no branch
+        set(n.chip for n in route if isinstance(n, RoutingTree)).issuperset(
+            set(placements[v] for v in net.sinks)))
 
     # Enumerate the locations and types of all terminations of the tree.
     endpoints = set()
@@ -87,7 +88,8 @@ def assert_equivilent(route, net, placements, allocation, constraints=[]):
     # Enumerate all vertices which are constrained to a certain route
     endpoint_constraints = {}
     for constraint in constraints:
-        if isinstance(constraint, RouteEndpointConstraint):
+        if isinstance(constraint,  # pragma: no branch
+                      RouteEndpointConstraint):
             endpoint_constraints[constraint.vertex] = constraint.route
 
     # Ensure all vertices in the net have a corresponding endpoint

--- a/rig/place_and_route/route/tests/test_ner.py
+++ b/rig/place_and_route/route/tests/test_ner.py
@@ -222,8 +222,8 @@ def test_copy_and_disconnect_tree():
         assert old_chips.issuperset(new_chips)
 
         # Check the locations missing are exactly those on dead cores
-        assert old_chips.difference(new_chips) \
-            == set(c for c in old_chips if c not in machine)
+        assert (old_chips.difference(new_chips) ==  # pragma: no branch
+                set(c for c in old_chips if c not in machine))
 
         # Check that the set of broken links is as expected
         assert new_broken_links == expected_broken_links
@@ -268,10 +268,11 @@ def test_copy_and_disconnect_tree():
 
             # Ensure that any children missing are exactly those which are
             # disconnected or on dead chips
-            assert old_children.difference(new_children) \
-                == set(c for c in old_children
-                       if c not in machine or
-                       not links_between(chip, c, machine))
+            assert (  # pragma: no branch
+                    old_children.difference(new_children) ==
+                    set(c for c in old_children
+                        if c not in machine or
+                        not links_between(chip, c, machine)))
 
 
 def test_a_star():
@@ -394,8 +395,9 @@ def test_avoid_dead_links_no_change():
             assert new_node.chip == old_node.chip
 
             # Children should be the same
-            assert set(n.chip for n in new_node.children) \
-                == set(n.chip for n in old_node.children)
+            assert (  # pragma: no branch
+                    set(n.chip for n in new_node.children) ==
+                    set(n.chip for n in old_node.children))
 
 
 def test_avoid_dead_links_change():
@@ -431,6 +433,22 @@ def test_avoid_dead_links_change():
     t = RoutingTree((0, 0), set([t0]))
     test_cases.append(t)
 
+    # A subtree which blocks A* from reaching the start without crossing itself
+    # but which doesn't directly encircle the top of the blockage.
+    t55 = RoutingTree((2, 5), set([]))
+    t54 = RoutingTree((3, 5), set([t55]))
+    t53 = RoutingTree((4, 5), set([t54]))
+    t52 = RoutingTree((5, 2), set([]))
+    t51 = RoutingTree((5, 3), set([t52]))
+    t50 = RoutingTree((5, 4), set([t51]))
+    t4 = RoutingTree((5, 5), set([t50, t53]))
+    t3 = RoutingTree((4, 4), set([t4]))
+    t2 = RoutingTree((3, 3), set([t3]))
+    t1 = RoutingTree((2, 2), set([t2]))
+    t0 = RoutingTree((1, 1), set([t1]))
+    t = RoutingTree((0, 0), set([t0]))
+    test_cases.append(t)
+
     # For each test case just ensure the new tree is a tree and visits all
     # non-dead nodes from the testcase. No checks made for
     # minimality/efficiency etc.
@@ -445,8 +463,9 @@ def test_avoid_dead_links_change():
             assert new_lookup[node.chip] is node
 
         # Check all non-dead nodes still exist
-        assert set(n.chip for n in old_root if n.chip in machine).issubset(
-            set(n.chip for n in new_root))
+        assert (  # pragma: no branch
+                set(n.chip for n in old_root if n.chip in machine).issubset(
+                    set(n.chip for n in new_root)))
 
         # Check for cycles
         visited = set()

--- a/rig/place_and_route/route/tests/test_util.py
+++ b/rig/place_and_route/route/tests/test_util.py
@@ -102,7 +102,7 @@ def test_longest_dimension_first():
     generated_x_first = False
     generated_y_first = False
     generated_z_first = False
-    for _ in range(1000):
+    for _ in range(1000):  # pragma: no branch
         first_move = list(longest_dimension_first((1, 1, 1)))[0]
         if first_move == (1, 0):
             generated_x_first = True
@@ -172,8 +172,8 @@ def test_links_between():
 
     # If some links are down, these should be omitted
     machine = Machine(1, 1, dead_links=set([(0, 0, Links.north)]))
-    assert links_between((0, 0), (0, 0), machine) \
-        == set(l for l in Links if l != Links.north)
+    assert (links_between((0, 0), (0, 0), machine) ==  # pragma: no branch
+            set(l for l in Links if l != Links.north))
 
     # Should work the same in large system
     machine = Machine(10, 10, dead_links=set([(4, 4, Links.north)]))

--- a/rig/place_and_route/route/util.py
+++ b/rig/place_and_route/route/util.py
@@ -50,7 +50,7 @@ def longest_dimension_first(vector, start=(0, 0), width=None, height=None):
                 x += sign
             elif dimension == 1:
                 y += sign
-            elif dimension == 2:
+            elif dimension == 2:  # pragma: no branch
                 x -= sign
                 y -= sign
 

--- a/rig/regions/tests/test_keyspace_region.py
+++ b/rig/regions/tests/test_keyspace_region.py
@@ -42,6 +42,13 @@ class TestKeyspacesRegion(object):
                             prepend_num_keyspaces=True)
         assert r.sizeof(slice(None)) == 4
 
+    def test_sizeof_partitioned(self):
+        r = KeyspacesRegion([BitField(32)]*4, fields=[mock.Mock()],
+                            partitioned_by_atom=True,
+                            prepend_num_keyspaces=False)
+        assert r.sizeof(slice(1, 2)) == 4
+        assert r.sizeof(slice(2, 4)) == 8
+
     def test_write_subregion_calls_fields(self):
         """Check that writing a subregion to file calls the field functions
         with each key and that any extra arguments are passed along.

--- a/rig/tests/test_bitfield.py
+++ b/rig/tests/test_bitfield.py
@@ -223,14 +223,16 @@ def test_bitfield_hierachy():
 
     # Add different fields dependent on the split-bit. This checks that
     # creating fields in different branches of the heirachy doesn't result in
-    # clashes.
+    # clashes.  Additionally creates multiple levels of heirarchy.
     ks_s0 = ks(split=0)
     ks_s0.add_field("s0_btm", length=3, start_at=0)
     ks_s0.add_field("s0_top", length=3, start_at=3)
 
     ks_s1 = ks(split=1)
-    ks_s1.add_field("s1_btm", length=3, start_at=0)
-    ks_s1.add_field("s1_top", length=3, start_at=3)
+    ks_s1.add_field("s1_btm", length=2, start_at=0)
+    ks_s1.add_field("s1_top", length=2, start_at=2)
+    ks_s1s = ks_s1(s1_btm=0, s1_top=0)
+    ks_s1s.add_field("split2", length=2, start_at=4)
 
     # Shouldn't be able to access child-fields of split before it is defined
     with pytest.raises(AttributeError):
@@ -241,6 +243,8 @@ def test_bitfield_hierachy():
         ks.s1_top
     with pytest.raises(AttributeError):
         ks.s1_btm
+    with pytest.raises(AttributeError):
+        ks.split2
 
     # Should be able to define a new key from scratch
     ks_s0_defined = ks(always=1, split=0, s0_btm=3, s0_top=5)
@@ -260,6 +264,8 @@ def test_bitfield_hierachy():
         ks_s0_defined.s1_btm
     with pytest.raises(AttributeError):
         ks_s0_defined.s1_top
+    with pytest.raises(AttributeError):
+        ks_s0_defined.split2
 
     # Shouldn't have to define all top-level fields in order to get at split
     # fields
@@ -274,6 +280,18 @@ def test_bitfield_hierachy():
         ks_s1_selected.s0_btm
     with pytest.raises(AttributeError):
         ks_s1_selected.s0_top
+
+    # Accessing fields in a split lower in the hierarchy should still fail
+    with pytest.raises(AttributeError):
+        ks_s1_selected.split2
+
+    # Should be able to access the second-level of split
+    ks_s1s_selected = ks(always=1, split=1, s1_btm=0, s1_top=0, split2=3)
+    assert ks_s1s_selected.always == 1
+    assert ks_s1s_selected.split == 1
+    assert ks_s1s_selected.s1_btm == 0
+    assert ks_s1s_selected.s1_top == 0
+    assert ks_s1s_selected.split2 == 3
 
     # Should not be able to set child fields before parent field is set
     with pytest.raises(AttributeError):

--- a/rig/tests/test_geometry.py
+++ b/rig/tests/test_geometry.py
@@ -284,7 +284,7 @@ def test_shortest_torus_path():
             # them given a large number of tests. Note that the chances of this
             # test failing for a working implementation should be incredibly
             # low.
-            for _ in range(1000):
+            for _ in range(1000):  # pragma: no branch
                 path = shortest_torus_path(start, end, width, height)
                 assert path in minimiseds, \
                     (start, end, width, height, minimiseds)
@@ -297,7 +297,7 @@ def test_shortest_torus_path():
             assert unseen_minimiseds == set(), \
                 (start, end, width, height, minimiseds)
 
-            for _ in range(1000):
+            for _ in range(1000):  # pragma: no branch
                 path = shortest_torus_path(end, start, width, height)
                 assert path in neg_minimiseds, \
                     (end, start, width, height, neg_minimiseds)

--- a/rig/tests/test_type_casts.py
+++ b/rig/tests/test_type_casts.py
@@ -167,7 +167,7 @@ class TestNumpyFloatToFixConverter(object):
         # Check the values are correct
         ftf = float_to_fix(True, n_bits, n_frac)
         assert vals.dtype == dtype
-        assert (
+        assert (  # pragma: no branch
             bytes(vals.data) ==
             struct.pack("{}{}".format(len(values), c),
                         *[ftf(v) for v in values])
@@ -190,7 +190,7 @@ class TestNumpyFloatToFixConverter(object):
 
         # Check the values are correct
         ftf = float_to_fix(signed, n_bits, n_frac)
-        assert (
+        assert (  # pragma: no branch
             bytes(vals.data) ==
             struct.pack("{}{}".format(len(values), c),
                         *[ftf(v) for v in values])


### PR DESCRIPTION
* A few additional tests have been added to test run various corner cases.
* Note in one case I've pragma'd out some lines in boot: there is no meaningful
  way to test the boot method with non-default arguments, I've pragma
  no-branch'd the handler conditions for these.
* This commit also removes the odd piece of dead-code in internal methods.
* Struct field reads have their endianness explicitly stated.
* The boot method now accepts structs rather than the raw struct data
  since this seemed like a sensible thing to do.

The large number of `pragma: no branch`es in test code asserts is due to a bug in pytest/pytest-cov. When pytest assertion rewriting is used the coverage checker frustratingly will sometimes shout about branch coverage on these assertions. Even better, since the rewriter's internal behaviour is not documented you can't simply tell pytest-cov to ignore asserts (since there won't be any asserts once the rewriting is complete!). Grrr!