### PR TITLE
Improve `MemoryIO`

### DIFF
--- a/docs/source/control.rst
+++ b/docs/source/control.rst
@@ -168,7 +168,7 @@ into applications and also ensures reads and writes are constrained only to the
 allocated region. For example::
 
     >>> # Allocate 1024 bytes of SDRAM with tag '3' on chip (0, 0)
-    >>> block = mc.sdram_alloc_as_io(1024, 3, 0, 0)
+    >>> block = mc.sdram_alloc_as_filelike(1024, 3, 0, 0)
     >>> block.write(b"Hello, world!")
     >>> block.seek(-13)
     >>> block.read(13)

--- a/rig/machine_control/machine_controller.py
+++ b/rig/machine_control/machine_controller.py
@@ -1448,7 +1448,7 @@ class MemoryIO(object):
                 "1 (from current) or 2 (from end) not {}".format(from_what)
             )
 
-    def alloc_next_as_io(self, n_bytes):
+    def create_view(self, n_bytes):
         """Get a new :py:class:`.MemoryIO` starting from the current address
         and extending for the given number of bytes.
 
@@ -1463,7 +1463,7 @@ class MemoryIO(object):
             >>> # Get a new file-like for 100 bytes of this 1kB starting 100
             >>> # bytes in.
             >>> mem.seek(100)
-            >>> smaller_mem = mem.alloc_next_as_io(100)
+            >>> smaller_mem = mem.create_view(100)
             >>> mem.tell()
             200
 

--- a/rig/machine_control/tests/test_machine_controller.py
+++ b/rig/machine_control/tests/test_machine_controller.py
@@ -1620,15 +1620,15 @@ class TestMemoryIO(object):
          (1, 3, 0x60000000, 0x60000008, 0x4, 0x4),
          ]
     )
-    def test_alloc_next_as_io(self, x, y, mock_controller, start_address,
-                              end_address, offset, grab):
+    def test_create_view(self, x, y, mock_controller, start_address,
+                         end_address, offset, grab):
         # Create the SDRAM file and seek to the offset
         sdram_file = MemoryIO(mock_controller, x, y, start_address,
                               end_address)
         sdram_file.seek(offset)
 
         # Grab next bytes as a new MemoryIO
-        region = sdram_file.alloc_next_as_io(grab)
+        region = sdram_file.create_view(grab)
 
         # Check that we have a new MemoryIO with appropriate parameters and
         # that the original MemoryIO has seeked to the end of the new MemoryIO.
@@ -1645,9 +1645,9 @@ class TestMemoryIO(object):
         [(1, 3, 0x60000000, 0x60000008, 0x4, 0x5),
          ]
     )
-    def test_alloc_next_as_io_fails(self, x, y, mock_controller, start_address,
-                                    end_address, offset, grab):
-        """Check that alloc_next_as_io raises an error if we try to grab too
+    def test_create_view_fails(self, x, y, mock_controller, start_address,
+                               end_address, offset, grab):
+        """Check that create_view raises an error if we try to grab too
         much memory.
         """
         # Create the SDRAM file and seek to the offset
@@ -1657,7 +1657,7 @@ class TestMemoryIO(object):
 
         # Grab next bytes as a new MemoryIO should fail
         with pytest.raises(SpiNNakerMemoryError) as excinfo:
-            sdram_file.alloc_next_as_io(grab)
+            sdram_file.create_view(grab)
         assert str(grab) in str(excinfo.value)
 
 

--- a/rig/machine_control/tests/test_machine_controller.py
+++ b/rig/machine_control/tests/test_machine_controller.py
@@ -818,7 +818,7 @@ class TestMachineController(object):
         "field, data, converted",
         [("app_name", b"rig_test\x00\x00\x00\x00\x00\x00\x00\x00", "rig_test"),
          ("cpu_flags", b"\x08", 8)]
-     )
+    )
     def test_read_vcpu_struct(self, x, y, p, vcpu_base, field, data,
                               converted):
         struct_data = pkg_resources.resource_string("rig", "boot/sark.struct")

--- a/rig/machine_control/tests/test_regions.py
+++ b/rig/machine_control/tests/test_regions.py
@@ -104,7 +104,7 @@ class TestRegionTree(object):
                 assert sr.add_coordinate(i, j) == (i == 3 and j == 3)
 
         # This should propagate up
-        assert pr.add_coordinate(3, 3) == False
+        assert pr.add_coordinate(3, 3) is False
         assert pr.locally_selected == {0}
 
         # We should be able to get a minimised regions out of this tree

--- a/rig/place_and_route/route/tests/test_ner.py
+++ b/rig/place_and_route/route/tests/test_ner.py
@@ -269,10 +269,10 @@ def test_copy_and_disconnect_tree():
             # Ensure that any children missing are exactly those which are
             # disconnected or on dead chips
             assert (  # pragma: no branch
-                    old_children.difference(new_children) ==
-                    set(c for c in old_children
-                        if c not in machine or
-                        not links_between(chip, c, machine)))
+                old_children.difference(new_children) ==
+                set(c for c in old_children
+                    if c not in machine or
+                    not links_between(chip, c, machine)))
 
 
 def test_a_star():
@@ -396,8 +396,8 @@ def test_avoid_dead_links_no_change():
 
             # Children should be the same
             assert (  # pragma: no branch
-                    set(n.chip for n in new_node.children) ==
-                    set(n.chip for n in old_node.children))
+                set(n.chip for n in new_node.children) ==
+                set(n.chip for n in old_node.children))
 
 
 def test_avoid_dead_links_change():
@@ -464,8 +464,8 @@ def test_avoid_dead_links_change():
 
         # Check all non-dead nodes still exist
         assert (  # pragma: no branch
-                set(n.chip for n in old_root if n.chip in machine).issubset(
-                    set(n.chip for n in new_root)))
+            set(n.chip for n in old_root if n.chip in machine).issubset(
+                set(n.chip for n in new_root)))
 
         # Check for cycles
         visited = set()


### PR DESCRIPTION
 - Improves the `seek` docstring to mention `os.SEEK_CUR` and friends.
 - If `read` is called with no (or negative) argument then it is interpreted as being a read until the end of the memory region.
 - Implements the suggestions from #68 
 - flake8