### PR TITLE
Add `update_current_context` to `ContextMixin`

### DIFF
--- a/docs/source/control.rst
+++ b/docs/source/control.rst
@@ -186,6 +186,12 @@ reduce the repetition, Python's ``with`` statement can be used::
     ...     block_addr = mc.sdram_alloc(1024, 3)
     ...     mc.write(block_addr, b"Hello, world!")
 
+Alternatively, the current context can be modified by calling
+:py:meth:`~.MachineController.update_current_context`::
+
+    >>> # Following this call all commands will use app_id=56
+    >>> mc.update_current_context(app_id=56)
+
 
 :py:class:`.BMPController` Tutorial
 -----------------------------------

--- a/rig/utils/contexts.py
+++ b/rig/utils/contexts.py
@@ -67,6 +67,10 @@ class ContextMixin(object):
         """Create a new context with the given keyword arguments."""
         return Context(kwargs, self.__context_stack)
 
+    def update_current_context(self, **context_args):
+        """Update the current context to contain new arguments."""
+        self.__context_stack[-1].update(context_args)
+
     def get_context_arguments(self):
         """Return a dictionary containing the current context arguments."""
         cargs = {}
@@ -161,8 +165,12 @@ class Context(object):
             Context stack to which this context will append itself when
             entered.
         """
-        self.context_arguments = context_arguments
+        self.context_arguments = dict(context_arguments)
         self.stack = stack
+
+    def update(self, updates):
+        """Update the arguments contained within this context."""
+        self.context_arguments.update(updates)
 
     def __enter__(self):
         # Add this context object to the stack


### PR DESCRIPTION
 - `update_current_context` allows changing of a context without
   entering a `with` block.
 - Corrects `Context.__init__` to copy the dictionary it is passed, not
   doing so caused some bugs when introducing `update_current_context`.

Expected use case:
```python
cn = MachineController(...)
cn.update_current_context(async=True)  # Retains the app_id from the default context.
```

This allows the final example in my comment on #73.