### PR TITLE
Fix documentation re `seek`.

### DIFF
--- a/docs/source/control.rst
+++ b/docs/source/control.rst
@@ -170,7 +170,7 @@ allocated region. For example::
     >>> # Allocate 1024 bytes of SDRAM with tag '3' on chip (0, 0)
     >>> block = mc.sdram_alloc_as_filelike(1024, 3, 0, 0)
     >>> block.write(b"Hello, world!")
-    >>> block.seek(-13)
+    >>> block.seek(0)
     >>> block.read(13)
     b"Hello, world!"
 


### PR DESCRIPTION
The documentation for `seek` in `control.rst` was out of date.  I have
updated it to use our corrected `seek` implementation (i.e., relative to
start of file by default).