### PR TITLE
Add BitField.get_tags (Implements #85)

### DIFF
--- a/docs/source/bitfield_doctest.rst
+++ b/docs/source/bitfield_doctest.rst
@@ -396,8 +396,8 @@ those fields are present.
 You can list the set of tags associated with a particular field using
 :py:meth:`.get_tags` like so:
 
-    >>> b.get_tags("device_id")
-    {'routing'}
+    >>> b.get_tags("device_id") == {'routing'}
+    True
 
 Allowing 3rd party expansion of bit fields
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/bitfield_doctest.rst
+++ b/docs/source/bitfield_doctest.rst
@@ -393,6 +393,12 @@ further up the hierarchy have specific values. In other words: when checking tha
 a given set of tagged fields have a certain value, we must equally check that
 those fields are present.
 
+You can list the set of tags associated with a particular field using
+:py:meth:`.get_tags` like so:
+
+    >>> b.get_tags("device_id")
+    {'routing'}
+
 Allowing 3rd party expansion of bit fields
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/rig/bitfield.py
+++ b/rig/bitfield.py
@@ -341,6 +341,20 @@ class BitField(object):
 
         return mask
 
+    def get_tags(self, field):
+        """Get the set of tags for a given field.
+
+        Parameters
+        ----------
+        field : str
+            The field whose tag should be read.
+        
+        Returns
+        -------
+        set([tag, ...])
+        """
+        return self.fields[field].tags.copy()
+
     def assign_fields(self):
         """Assign a position & length to any fields which do not have one.
 

--- a/rig/bitfield.py
+++ b/rig/bitfield.py
@@ -348,7 +348,7 @@ class BitField(object):
         ----------
         field : str
             The field whose tag should be read.
-        
+
         Returns
         -------
         set([tag, ...])

--- a/rig/tests/test_bitfield.py
+++ b/rig/tests/test_bitfield.py
@@ -174,6 +174,12 @@ def test_bitfield_tags():
     ks.add_field("d", length=1, start_at=3, tags=["D"])
     ks.add_field("e", length=1, start_at=4, tags=["E", "E_"])
 
+    assert ks.get_tags("a") == set()
+    assert ks.get_tags("b") == set(["B"])
+    assert ks.get_tags("c") == set(["C", "C_"])
+    assert ks.get_tags("d") == set(["D"])
+    assert ks.get_tags("e") == set(["E", "E_"])
+
     ks_def = ks(a=1, b=1, c=1, d=1, e=1)
     assert ks_def.get_mask() == 0x1F
     assert ks_def.get_mask("B") == 0x02
@@ -203,6 +209,9 @@ def test_bitfield_tags():
     ks_a1.add_field("a1", length=1, start_at=5, tags="A1")
 
     # Test that tags are applied heirachically to parents
+    assert ks.get_tags("a") == set(["A0", "A1"])
+    assert ks.get_tags("a0") == set(["A0"])
+    assert ks.get_tags("a1") == set(["A1"])
     assert ks.get_mask("A0") == 0x01
     assert ks.get_mask("A1") == 0x01
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py27, py33, py34, pep8
 deps =
     -rrequirements.txt
     -rrequirements-test.txt
-commands = py.test rig {posargs}
+commands = py.test rig docs/ {posargs}
 
 [testenv:py27]
 deps =


### PR DESCRIPTION
As requested in #85 by @mundya, allows getting the set of tags a field has:

    >>> from rig.bitfield import BitField
    >>> bf = BitField(32)
    >>> bf.add_field("test", tags="TestTag")
    >>> bf(test=0).add_field("test0", tags="Test0Tag")
    >>> bf(test=1).add_field("test1", tags="Test1Tag")

    >>> bf.get_tags("test")
    {"TestTag", "Test0Tag", "Test1Tag"}

    >>> bf.get_tags("test0")
    {"Test0Tag"}