### PR TITLE
Add type cast documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
-# Allow the docs to be built by ReadTheDocs without building numpy.
+# Allow the docs to be built by ReadTheDocs without building numpy (and other
+# expensive to install modules). This is achieved by swapping out missing
+# modules for mocks.
 import sys
 from mock import Mock as MagicMock
 
@@ -10,7 +12,11 @@ class Mock(MagicMock):
             return Mock()
 
 MOCK_MODULES = ['pygtk', 'gtk', 'gobject', 'argparse', 'numpy', 'pandas']
-sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
+for mod_name in MOCK_MODULES:
+    try:
+        __import__(mod_name)
+    except ImportError:
+        sys.modules.update({mod_name: Mock()})
 
 AUTHORS = u'Project Rig'
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -48,6 +48,15 @@ Execution control
         control
         control_api
 
+Utilities
+---------
+
+.. toctree::
+        :maxdepth: 2
+
+        type_casts
+
+
 Indices and tables
 ==================
 

--- a/docs/source/type_casts.rst
+++ b/docs/source/type_casts.rst
@@ -1,0 +1,5 @@
+Type casts
+==========
+
+.. automodule:: rig.type_casts
+    :members:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --doctest-glob='*_doctest.rst'
+addopts = --doctest-modules --doctest-glob='*_doctest.rst'

--- a/rig/tests/test_type_casts.py
+++ b/rig/tests/test_type_casts.py
@@ -88,9 +88,9 @@ class TestFixToFloat(object):
     @pytest.mark.parametrize(
         "bits, signed, n_bits, n_frac, value",
         [(0xff, False, 8, 0, 255.0),
-         (0xff, True, 8, 0, -127.0),
+         (0x81, True, 8, 0, -127.0),
          (0xff, False, 8, 1, 127.5),
-         (0xff, True, 8, 1, -63.5),
+         (0xf8, True, 8, 4, -0.5)
          ])
     def test_fix_to_float(self, bits, signed, n_bits, n_frac, value):
         assert value == fix_to_float(signed, n_bits, n_frac)(bits)

--- a/rig/type_casts.py
+++ b/rig/type_casts.py
@@ -7,11 +7,58 @@ def float_to_fix(signed, n_bits, n_frac):
     """Return a function to convert a floating point value to a fixed point
     value.
 
+    For example, a function to convert a float to a signed fractional
+    representation with 8 bits overall and 4 fractional bits (S3.4) can be
+    constructed and used with::
+
+        >>> s34 = float_to_fix(signed=True, n_bits=8, n_frac=4)
+        >>> hex(s34(0.5))
+        '0x8'
+
+    The fixed point conversion is saturating::
+
+        >>> q34 = float_to_fix(False, 8, 4)  # Unsigned 4.4
+        >>> hex(q34(-0.5))
+        '0x0'
+
+        >>> hex(q34(15.0))
+        '0xf0'
+
+        >>> hex(q34(16.0))
+        '0xff'
+
     Parameters
     ----------
     signed : bool
+        Whether the values that are to be converted should be signed, or
+        clipped at zero.
+
+            >>> hex(float_to_fix(True, 8, 4)(-0.5))  # Signed
+            '0xf8'
+            >>> hex(float_to_fix(False, 8, 4)(-0.5))  # Unsigned
+            '0x0'
+
+        .. note::
+            Regardless of the value of the `signed` parameter the returned
+            value is always an unsigned integer suitable for packing with the
+            struct packing chars `B`, `H`, `I` etc.
+
     n_bits : int
+        Total number of bits in the fixed-point representation (including sign
+        bit and fractional bits).
     n_frac : int
+        Number of fractional bits in the fixed-point representation.
+
+    Raises
+    ------
+    ValueError
+        If the number of bits specified is not possible.  For example,
+        requiring more fractional bits than there are bits overall will result
+        in a `ValueError`::
+
+            >>> fix_to_float(False, 8, 9)
+            Traceback (most recent call last):
+            ValueError: n_frac: 9: Must be less than 8 (and positive).
     """
     mask = int(2**n_bits - 1)
     min_v, max_v = validate_fp_params(signed, n_bits, n_frac)
@@ -42,11 +89,50 @@ def fix_to_float(signed, n_bits, n_frac):
     """Return a function to convert a fixed point value to a floating point
     value.
 
+    For example, a function to convert from signed fractional representations
+    with 8 bits overall and 4 fractional representations (S3.4) can be
+    constructed and used with::
+
+        >>> f = fix_to_float(True, 8, 4)
+        >>> f(0x08)
+        0.5
+
+        >>> f(0xf8)
+        -0.5
+
+        >>> f(0x88)
+        -7.5
+
     Parameters
     ----------
     signed : bool
+        Determines whether input values should be treated as signed or
+        otherwise, e.g.::
+
+            >>> fix_to_float(True, 8, 4)(0xfc)
+            -0.25
+
+            >>> fix_to_float(False, 8, 4)(0xf8)
+            15.5
+
+        The value accepted by the returned function should always be an
+        unsigned integer.
     n_bits : int
+        Total number of bits in the fixed-point representation (including sign
+        bit and fractional bits).
     n_frac : int
+        Number of fractional bits in the fixed-point representation.
+
+    Raises
+    ------
+    ValueError
+        If the number of bits specified is not possible.  For example,
+        requiring more fractional bits than there are bits overall will result
+        in a `ValueError`::
+
+            >>> fix_to_float(False, 8, 9)
+            Traceback (most recent call last):
+            ValueError: n_frac: 9: Must be less than 8 (and positive).
     """
     validate_fp_params(signed, n_bits, n_frac)
 
@@ -60,16 +146,53 @@ def fix_to_float(signed, n_bits, n_frac):
         """
         if signed and value & (1 << (n_bits - 1)):
             # If signed and negative
-            return -(value & (2**(n_bits - 1) - 1)) / (2.0**n_frac)
-        else:
-            # Unsigned or signed and positive
-            return float(value) / (2.0**n_frac)
+            value -= (1 << n_bits)
+
+        # Unsigned or signed and positive
+        return float(value) / (2.0**n_frac)
 
     return kbits
 
 
 class NumpyFloatToFixConverter(object):
     """A callable which converts Numpy arrays of floats to fixed point arrays.
+
+    General usage is to create a new converter and then call this on arrays of
+    values.  The `dtype` of the returned array is determined from the
+    parameters passed.  For example::
+
+        >>> f = NumpyFloatToFixConverter(signed=True, n_bits=8, n_frac=4)
+
+    Will convert floating point values to 8-bit signed representations with 4
+    fractional bits.  Consequently the returned `dtype` will be `int8`::
+
+        >>> import numpy as np
+        >>> vals = np.array([0.0, 0.25, 0.5, -0.5, -0.25])
+        >>> f(vals)
+        array([ 0,  4,  8, -8, -4], dtype=int8)
+
+    The conversion is saturating::
+
+        >>> f(np.array([15.0, 16.0, -16.0, -17.0]))
+        array([ 127,  127, -128, -128], dtype=int8)
+
+    The byte representation can be expected to match that for using
+    `float_to_fix`::
+
+        >>> d = f(np.array([-16.0]))
+
+        >>> import struct
+        >>> g = float_to_fix(True, 8, 4)
+        >>> val = g(-16.0)
+        >>> struct.pack('B', val) == bytes(d.data)
+        True
+
+    An exception is raised if the number of bits specified cannot be
+    represented using a whole `dtype`::
+
+        >>> NumpyFloatToFixConverter(True, 12, 0)
+        Traceback (most recent call last):
+        ValueError: n_bits: 12: Must be 8, 16, 32 or 64.
     """
     dtypes = {
         (False, 8): np.uint8,

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,9 @@ envlist = py27, py33, py34, pep8
 deps =
     -rrequirements.txt
     -rrequirements-test.txt
-commands = py.test rig docs/ {posargs}
+commands =
+	py.test rig {posargs}
+	py.test docs/
 
 [testenv:py27]
 deps =


### PR DESCRIPTION
 - Fixes #87 
 - Also fixes an embarrassing bug in fix->float conversions.
 - Modifies the `tox.ini` to run doctests and unit tests separately.
 - Modifies `pytest.ini` to run doctests in docstrings wherever possible.