### PR TITLE
Ensure Bitfield.__call__ uses `type`.

### DIFF
--- a/rig/bitfield.py
+++ b/rig/bitfield.py
@@ -221,7 +221,7 @@ class BitField(object):
             self.fields[identifier].max_value = max(
                 self.fields[identifier].max_value, value)
 
-        return BitField(self.length, self.fields, field_values)
+        return type(self)(self.length, self.fields, field_values)
 
     def __getattr__(self, identifier):
         """Get the value of a field.

--- a/rig/tests/test_bitfield.py
+++ b/rig/tests/test_bitfield.py
@@ -601,3 +601,17 @@ def test_repr():
     assert "'s1'" not in repr(ks_s0)
     assert "'s0'" not in repr(ks_s1)
     assert "'s1'" in repr(ks_s1)
+
+
+def test_subclass():
+    """It should be possible to inherit from BitField and still have __call__
+    work.
+    """
+    class MyBitField(BitField):
+        pass
+
+    x = MyBitField()
+    x.add_field("spam")
+
+    y = x(spam=0)
+    assert isinstance(y, MyBitField)


### PR DESCRIPTION
Allows subclassing of `BitField`, inasmuch as `__call__` creates a new instance of the same class rather than always calling `BitField`.

Previously:
```python
>>> class MyBitField(BitField):
...     pass
>>>
>>> x = MyBitField()
>>> x.add_field("spam")
>>> type(x(spam=3))
rig.bitfield.BitField
```

Whereas now:
```python
>>> type(x(spam=3))
__main__.MyBitField
```