### PR TITLE
Fix Links.from_vector when "spiralling" in 2x2

### DIFF
--- a/rig/machine.py
+++ b/rig/machine.py
@@ -112,6 +112,21 @@ _link_direction_lookup = {
 }
 _direction_link_lookup = {l: v for (v, l) in iteritems(_link_direction_lookup)}
 
+# Special case: Lets assume we've got a 2xN or Nx2 system (N >= 2) where we can
+# "spiral" around the Z axis to reach places which normally wouldn't be
+# accessible.
+#
+# (x+1, 0) <-> (x+0, 1)        (1, y+0) <-> (0, y+1)
+#           /                        |   |   |
+#     --+--/+---+--                  +---+---+
+#       | . |   |                    | . |   |/
+#     --+---+---+--                  /---+---/
+#       |   | . |                   /|   | . |
+#     --+---+/--+--                  +---+---+
+#           /                        |   |   |
+_link_direction_lookup[(+1, -1)] = Links.south_west
+_link_direction_lookup[(-1, +1)] = Links.north_east
+
 
 class Machine(object):
     """Defines the resources available in a SpiNNaker machine.

--- a/rig/tests/test_machine.py
+++ b/rig/tests/test_machine.py
@@ -134,7 +134,8 @@ class TestMachine(object):
 
 
 def test_links_from_vector():
-    # In all these tests we assume we're in a 4x8 system.
+    # In all but the last of the following tests we assume we're in a 4x8
+    # system.
 
     # Direct neighbours without wrapping
     assert Links.from_vector((+1, +0)) == Links.east
@@ -161,6 +162,10 @@ def test_links_from_vector():
 
     assert Links.from_vector((-3, -7)) == Links.north_east
     assert Links.from_vector((+3, +7)) == Links.south_west
+
+    # Special case: 2xN or Nx2 system (N >= 2) "spiraing" around the Z axis
+    assert Links.from_vector((1, -1)) == Links.south_west
+    assert Links.from_vector((-1, 1)) == Links.north_east
 
 
 def test_links_to_vector():


### PR DESCRIPTION
Handle the following special case which much trouble was made to handle in other
parts of the process but not here (because I'm stupid).

When we've got a 2xN or Nx2 system (N >= 2) we can "spiral" around the Z axis to
reach places which normally wouldn't be accessible. Below shows the two examples
where we can make a "diagonal hop" in the direction not usually allowed by
"spiralling around" on the Z axis.

    (x+1, 0) <-> (x+0, 1)        (1, y+0) <-> (0, y+1)
              /                        |   |   |
        --+--/+---+--                  +---+---+
          | . |   |                    | . |   |/
        --+---+---+--                  /---+---/
          |   | . |                   /|   | . |
        --+---+/--+--                  +---+---+
              /                        |   |   |