### PR TITLE
Add namespace support to Bitfields

### DIFF
--- a/rig/bitfield.py
+++ b/rig/bitfield.py
@@ -1,12 +1,14 @@
 """A system for defining and representing bit fields.
 
-A common use-ase for this module is defining SpiNNaker routing keys based on
+A common use-case for this module is defining SpiNNaker routing keys based on
 hierarchical bit-fields.
 
 See the :py:class:`.BitField` class.
 """
 
-from collections import namedtuple, OrderedDict
+from six import iteritems
+
+from collections import OrderedDict
 
 from math import log
 
@@ -60,21 +62,16 @@ class BitField(object):
         ----------
         length : int
             The total number of bits in the bit field.
-        _fields : dict
-            For internal use only. The shared, global field dictionary.
+        _fields : :py:class:`._Tree`
+            For internal use only. The shared, global field tree.
         _field_values : dict
             For internal use only. Mapping of field-identifier to value.
         """
         self.length = length
 
-        # An OrderedDict if field definitions (globally shared by all
-        # derivatives of the same BitField) which maps human-friendly
-        # field-identifiers (e.g.  strings) to corresponding BitField._Field
-        # instances. An OrderedDict preserves insertion ordering which is used
-        # to automatic field positioning more predictable and also ensures the
-        # fields are stored under the partial ordering of their hierarchy (a
-        # property used by this code).
-        self.fields = _fields if _fields is not None else OrderedDict()
+        # Fields are kept in a tree structure where child fields only exist
+        # when their parents have a particular value.
+        self.fields = _fields if _fields is not None else type(self)._Tree()
 
         if _field_values is not None:
             self.field_values = _field_values
@@ -92,8 +89,33 @@ class BitField(object):
         ----------
         identifier : str
             A identifier for the field. Must be a valid python identifier.
-            Field names must be unique and users are encouraged to sensibly
-            name-space fields in the `prefix_` style to avoid collisions.
+            Field names must be unique within the scope in which they exist and
+            are only valid within that scope. For example::
+
+                >>> bf = BitField(32)
+                >>> bf.add_field("a")
+
+                >>> # Can add multiple fields with the same name if they exist
+                >>> # in different scopes
+                >>> bf0 = bf(a=0)
+                >>> bf0.add_field("b", length=4)
+                >>> bf1 = bf(a=1)
+                >>> bf1.add_field("b", length=8)
+
+                >>> # Can't add multiple fields with the same name which exist
+                >>> # within the same or nested scopes.
+                >>> bf.add_field("a")
+                Traceback (most recent call last):
+                ValueError: Field with identifier 'a' already exists
+                >>> bf.add_field("b")
+                Traceback (most recent call last):
+                ValueError: Field with identifier 'b' already exists
+
+            Here *three* fields are defined, one called "a" and the other two
+            called "b". The two fields called "b" are completely unrelated
+            (they may differ in size, position and associated set of tags) and
+            are distinguished by the fact that one exists when a=0 and the
+            other when a=1.
         length : int or None
             The number of bits in the field. If None the field will be
             automatically assigned a length long enough for the largest value
@@ -115,14 +137,8 @@ class BitField(object):
             If any the field overlaps with another one or does not fit within
             the bit field. Note that fields with unspecified lengths and
             positions do not undergo such checks until their length and
-            position become known.
+            position become known when :py:meth:`.assign_fields` is called.
         """
-        # Check for duplicate names
-        if identifier in self.fields:
-            raise ValueError(
-                "Field with identifier '{}' already exists.".format(
-                    identifier))
-
         # Check for zero-length fields
         if length is not None and length <= 0:
             raise ValueError("Fields must be at least one bit in length.")
@@ -138,7 +154,8 @@ class BitField(object):
         # Check for fields which occupy the same bits
         if start_at is not None:
             end_at = start_at + (length or 1)
-            for other_identifier, other_field in self._potential_fields():
+            for other_identifier, other_field in \
+                    self.fields.potential_fields(self.field_values):
                 if other_field.start_at is not None:
                     other_start_at = other_field.start_at
                     other_end_at = other_start_at + (other_field.length or 1)
@@ -160,17 +177,16 @@ class BitField(object):
         else:
             tags = set(tags)
 
-        # Add tags to all parents of this field
-        parent_identifiers = list(self.field_values.keys())
-        while parent_identifiers:
-            parent_identifier = parent_identifiers.pop(0)
-            parent = self.fields[parent_identifier]
-            parent.tags.update(tags)
-            parent_identifiers.extend(parent.conditions.keys())
+        # Add the field (checking that the identifier is unique in the process)
+        field = BitField._Field(length, start_at, tags)
+        self.fields.add_field(field, identifier, self.field_values)
 
-        # Add the field
-        self.fields[identifier] = BitField._Field(
-            length, start_at, tags, dict(self.field_values))
+        # Add tags to all parents of this field
+        for parent_identifier in self.fields.get_field_requirements(
+                identifier, self.field_values):
+            parent = self.fields.get_field(parent_identifier,
+                                           self.field_values)
+            parent.tags.update(tags)
 
     def __call__(self, **field_values):
         """Return a new BitField instance with fields assigned values as
@@ -187,41 +203,38 @@ class BitField(object):
         ValueError
             If any field has already been assigned a value or the value is too
             large for the field.
-        AttributeError
-            If a field is specified which is not present.
+        UnavailableFieldError
+            If a field is specified which does not exist or is not available.
         """
-        # Ensure fields exist
-        for identifier in field_values.keys():
-            if identifier not in self.fields:
-                raise ValueError("Field '{}' not defined.".format(identifier))
-
         # Make sure no values are changed
         for identifier, value in self.field_values.items():
             if identifier in field_values:
                 raise ValueError(
                     "Field '{}' already has value.".format(identifier))
 
+        # Work out what the new set of defined values looks like
         field_values.update(self.field_values)
 
-        # Ensure no fields are specified which are not enabled
-        for identifier in field_values:
-            self._assert_field_available(identifier, field_values)
-
-        # Ensure values are within range
         for identifier, value in field_values.items():
-            field_length = self.fields[identifier].length
+            # All fields specified must exist
+            field = self.fields.get_field(identifier, field_values)
+
+            # All field values must be within range
             if value < 0:
                 raise ValueError("Fields must be positive.")
-            elif field_length is not None and value >= (1 << field_length):
+            elif field.length is not None and value >= (1 << field.length):
                 raise ValueError(
                     "Value {} too large for {}-bit field '{}'.".format(
-                        value, field_length, identifier))
+                        value, field.length, identifier))
+
+        # Everything looks good!
 
         # Update maximum observed values
         for identifier, value in field_values.items():
-            self.fields[identifier].max_value = max(
-                self.fields[identifier].max_value, value)
+            field = self.fields.get_field(identifier, field_values)
+            field.max_value = max(field.max_value, value)
 
+        # Finally, create a new BitField with the specified values
         return type(self)(self.length, self.fields, field_values)
 
     def __getattr__(self, identifier):
@@ -235,16 +248,18 @@ class BitField(object):
 
         Raises
         ------
-        AttributeError
+        UnavailableFieldError
             If the field requested does not exist or is not available given
             current field values.
         """
-        self._assert_field_available(identifier)
+        # Ensure that the field exists/is available
+        self.fields.get_field(identifier, self.field_values)
+
         return self.field_values.get(identifier, None)
 
     def get_value(self, tag=None, field=None):
         """Generate an integer whose bits are set according to the values of
-        fields in this bit field. All bits not in a field are set to zero.
+        fields in this bit field. All other bits are set to zero.
 
         Parameters
         ----------
@@ -258,36 +273,30 @@ class BitField(object):
         Raises
         ------
         ValueError
-            If a field whose length or position has not been defined. (i.e.
-            `assign_fields()` has not been called when a field's
-            length/position has not been fixed.
+            If a field's value, length or position has not been defined. (e.g.
+            :py:meth:`.assign_fields` has not been called).
+        UnknownTagError
+            If the tag specified using the `tag` argument does not exist.
+        UnavailableFieldError
+            If the field specified using the `field` argument does not exist or
+            is not available.
         """
         assert not (tag is not None and field is not None), \
             "Cannot filter by tag and field simultaneously."
 
-        # Build a filtered list of fields to be used in the value
-        if field is not None:
-            self._assert_field_available(field)
-            selected_field_idents = [field]
-        elif tag is not None:
-            self._assert_tag_exists(tag)
-            selected_field_idents = [i for (i, f) in self._enabled_fields()
-                                     if tag in f.tags]
-        else:
-            selected_field_idents = [i for (i, f) in self._enabled_fields()]
+        selected_fields = self._select_by_field_or_tag(tag, field)
 
-        # Check all selected fields are defined
-        missing_fields_idents = \
-            set(selected_field_idents) - set(self.field_values.keys())
+        # Check all selected fields have values defined
+        missing_fields_idents = set(selected_fields) - set(self.field_values)
         if missing_fields_idents:
             raise ValueError(
                 "Cannot generate value with undefined fields {}.".format(
-                    ", ".join(missing_fields_idents)))
+                    ", ".join("'{}'".format(f)
+                              for f in missing_fields_idents)))
 
         # Build the value
         value = 0
-        for identifier in selected_field_idents:
-            field = self.fields[identifier]
+        for identifier, field in iteritems(selected_fields):
             if field.length is None or field.start_at is None:
                 raise ValueError(
                     "Field '{}' does not have a fixed size/position.".format(
@@ -312,30 +321,24 @@ class BitField(object):
         Raises
         ------
         ValueError
-            If a field whose length or position has not been defined. (i.e.
-            `assign_fields()` has not been called when a field's size/position
-            has not been fixed.
+            If a field's length or position has not been defined. (e.g.
+            :py:meth:`.assign_fields` has not been called).
+        UnknownTagError
+            If the tag specified using the `tag` argument does not exist.
+        UnavailableFieldError
+            If the field specified using the `field` argument does not exist or
+            is not available.
         """
         if tag is not None and field is not None:
             raise TypeError("get_mask() takes exactly one keyword argument, "
                             "either 'field' or 'tag' (both given)")
 
-        # Build a filtered list of fields to be used in the mask
-        if field is not None:
-            self._assert_field_available(field)
-            selected_field_idents = [field]
-        elif tag is not None:
-            self._assert_tag_exists(tag)
-            selected_field_idents = [i for (i, f) in self._enabled_fields()
-                                     if tag in f.tags]
-        else:
-            selected_field_idents = [i for (i, f) in self._enabled_fields()]
+        selected_fields = self._select_by_field_or_tag(tag, field)
 
         # Build the mask (and throw an exception if we encounter a field
         # without a fixed size/length.
         mask = 0
-        for identifier in selected_field_idents:
-            field = self.fields[identifier]
+        for identifier, field in iteritems(selected_fields):
             if field.length is None or field.start_at is None:
                 raise ValueError(
                     "Field '{}' does not have a fixed size/position.".format(
@@ -344,8 +347,58 @@ class BitField(object):
 
         return mask
 
+    def _select_by_field_or_tag(self, tag=None, field=None):
+        """For internal use only. Returns an OrderedDict of {identifier: field}
+        representing fields which match the supplied field/tag.
+
+        Parameters
+        ----------
+        tag : str
+            Optionally specifies that the mask should only include fields with
+            the specified tag.
+        field : str
+            Optionally specifies that the mask should only include the
+            specified field.
+
+        Raises
+        ------
+        UnknownTagError
+            If the tag specified using the `tag` argument does not exist.
+        UnavailableFieldError
+            If the field specified using the `field` argument does not exist or
+            is not available.
+        """
+        # Get the set of fields whose values will be included in the value
+        if field is not None:
+            # Select just the specified field (checking the field exists)
+            field_obj = self.fields.get_field(field, self.field_values)
+            selected_fields = OrderedDict([(field, field_obj)])
+        elif tag is not None:
+            # Select just fields with the specified tag
+            selected_fields = OrderedDict(
+                (i, f)
+                for (i, f) in self.fields.enabled_fields(self.field_values)
+                if tag in f.tags)
+            # Fail if no fields match the supplied tag. Because tags are
+            # applied to parent fields in the hierarchy, it is guaranteed that
+            # if a tag exists, at least one top-level (i.e. always present)
+            # field will have the tag.
+            if not selected_fields:
+                raise UnknownTagError(tag)
+        else:
+            # No specific field/tag supplied, select all enabled fields.
+            selected_fields = OrderedDict(
+                (i, f)
+                for (i, f) in self.fields.enabled_fields(self.field_values))
+
+        return selected_fields
+
     def get_tags(self, field):
         """Get the set of tags for a given field.
+
+        .. note::
+            The named field must be accessible given the current set of values
+            defined.
 
         Parameters
         ----------
@@ -355,8 +408,13 @@ class BitField(object):
         Returns
         -------
         set([tag, ...])
+
+        Raises
+        ------
+        UnavailableFieldError
+            If the field does not exist or is not available.
         """
-        return self.fields[field].tags.copy()
+        return self.fields.get_field(field, self.field_values).tags.copy()
 
     def assign_fields(self):
         """Assign a position & length to any fields which do not have one.
@@ -368,67 +426,43 @@ class BitField(object):
         # (otherwise fields of children won't be allowed to overlap). Here we
         # do a breadth-first iteration over the hierarchy to fix fields with
         # given starting positions; then we do depth-first to fix other fields.
-        #
-        # The breadth-first ensures that children's fixed position fields must
-        # fit around the fixed position fields of their parents.  The depth
-        # first search for variable position fields ensures that parents don't
-        # allocate fields in positions which would collide with fixed and
-        # variable position fields their children have already allocated.
 
-        class Node(namedtuple("Node", "bitfield children")):
-            """Node used in depth-first search of bitfields."""
-            def recurse_assign_unfixed_fields(self, assigned_bits=0,
-                                              excluded_fields=set()):
-                # Call this for the children first
-                excludes = set(i for (i, f) in self.bitfield._enabled_fields())
-                new_assigned_bits = assigned_bits
-                for child in self.children:
-                    # Children can assign bits independently
-                    new_assigned_bits |= child.recurse_assign_unfixed_fields(
-                        assigned_bits, excludes)
+        # Assign all fields with a fixed starting position in breadth first,
+        # top-down order. The breadth-first ensures that children's fixed
+        # position fields must fit around the fixed position fields of their
+        # parents.
+        queue = [(self.fields, {})]
+        while queue:
+            node, field_values = queue.pop(0)
 
-                # Now assign locally
-                assigned_bits =\
-                    self.bitfield._assign_enabled_fields_without_fixed_start(
-                        new_assigned_bits, excluded_fields
-                    )
+            # Assign all fields at this level whose position is fixed
+            self._assign_fields(node.fields, field_values,
+                                assign_positions=False)
 
-                return assigned_bits
+            # Breadth-first search through children
+            for requirements, child in iteritems(node.children):
+                requirements = dict(requirements)
+                requirements.update(field_values)
+                queue.append((child, requirements))
 
-        root = Node(BitField(self.length, self.fields), list())
-        unsearched_hierarchy = [root]
+        # Assign all fields with movable starting positions in leaf-first,
+        # depth-first order.  The depth first ordering for variable position
+        # fields ensures that parents don't allocate fields in positions which
+        # would collide with fixed and variable position fields their children
+        # have already allocated.
 
-        # Build a tree of Node describing the bitfield hierarchy and assign all
-        # fields with a fixed starting position.
-        while unsearched_hierarchy:
-            parent = unsearched_hierarchy.pop(0)
-            ks = parent.bitfield
+        def recurse_assign_fields(node=self.fields, field_values={}):
+            # Assign fields of child nodes first (allowing them to allocate
+            # bits independently)
+            for requirements, child in iteritems(node.children):
+                child_field_values = dict(requirements)
+                child_field_values.update(field_values)
+                recurse_assign_fields(child, child_field_values)
 
-            # Assign all fields with a fixed starting position
-            ks._assign_enabled_fields_with_fixed_start()
-
-            # Look for potential children in the hierarchy
-            for identifier, field in ks._potential_fields():
-                enabled_field_idents = set(i for (i, f) in
-                                           ks._enabled_fields())
-                set_fields = {}
-
-                for cond_ident, cond_value in field.conditions.items():
-                    # Fail if not a child
-                    if cond_ident not in enabled_field_idents:
-                        set_fields = {}
-                        break
-                    # Accumulate fields which must be set
-                    if getattr(ks, cond_ident) is None:
-                        set_fields[cond_ident] = cond_value
-
-                if set_fields:
-                    child = Node(ks(**set_fields), list())
-                    parent.children.append(child)
-                    unsearched_hierarchy.append(child)
-
-        # Assign all fields with variables starting positions
-        root.recurse_assign_unfixed_fields()
+            # Finally, assign all remaining fields at this level in the tree
+            self._assign_fields(node.fields, field_values,
+                                assign_positions=True)
+        recurse_assign_fields()
 
     def __eq__(self, other):
         """Test that this :py:class:`.BitField` is equivalent to another.
@@ -447,10 +481,12 @@ class BitField(object):
         current value.
         """
         enabled_field_idents = [
-            i for (i, f) in self._enabled_fields()]
+            i for (i, f) in self.fields.enabled_fields(self.field_values)]
 
-        return "<{}-bit BitField {}>".format(
+        return "<{}-bit {}{}{}>".format(
             self.length,
+            type(self).__name__,
+            " " if enabled_field_idents else "",
             ", ".join("'{}':{}".format(identifier,
                                        self.field_values.get(identifier, "?"))
                       for identifier in enabled_field_idents))
@@ -474,12 +510,6 @@ class BitField(object):
                 into an unused area of the bit field.
             tags : set
                 A (possibly empty) set of tags used to classify the field.
-            conditions : dict
-                Specifies conditions when this field is valid. If empty, this
-                field is always defined. Otherwise, keys in the dictionary
-                specify field-identifers and values specify the desired value.
-                All listed fields must match the specified values for the
-                condition to be met.
             max_value : int
                 The largest value ever assigned to this field (used for
                 automatically determining field sizes.
@@ -487,156 +517,374 @@ class BitField(object):
             self.length = length
             self.start_at = start_at
             self.tags = tags or set()
-            self.conditions = conditions or dict()
             self.max_value = max_value
 
-    def _assert_field_available(self, identifier, field_values=None):
-        """Raise a human-readable :py:exc:`ValueError` if the specified field
-        does not exist or is not enabled by the current field values.
+    class _Tree(object):
+        """A tree representing a hierarchy of fields."""
 
-        Parameters
-        ----------
-        identifier : str
-            The field to check for availability.
-        field_values : dict or None
-            The values currently assigned to fields.
-        """
-        if field_values is None:
-            field_values = self.field_values
+        def __init__(self, fields=None, children=None):
+            """Create a node in the tree of fields.
 
-        if identifier not in self.fields:
-            raise AttributeError(
-                "Field '{}' does not exist.".format(identifier))
-        elif identifier not in (i for (i, f) in
-                                self._enabled_fields(field_values)):
-            # Accumulate the complete list of conditions which must be true for
-            # the given field to exist
-            unmet_conditions = []
-            unchecked_fields = [identifier]
-            while unchecked_fields:
-                field = self.fields[unchecked_fields.pop(0)]
-                for cond_identifier, cond_value in field.conditions.items():
-                    actual_value = field_values.get(cond_identifier, None)
-                    if actual_value != cond_value:
-                        unmet_conditions.append((cond_identifier, cond_value))
-                        unchecked_fields.append(cond_identifier)
+            Parameters
+            ----------
+            fields : OrderedDict or None
+                A mapping from field identifier to :py:class:`._Field` for
+                fields which exist at this point in the hierarchy.
+            children : OrderedDict or None
+                A mapping from a non-empty tuples ((identifier, value), ...) to
+                [_Tree, ...] defining set of field values which must be defined
+                for the specified children to become available.
+            """
+            self.fields = fields or OrderedDict()
+            self.children = children or OrderedDict()
 
-            raise AttributeError("Field '{}' requires that {}.".format(
-                identifier,
-                ", ".join("'{}' == {}".format(cond_ident, cond_val)
-                          for cond_ident, cond_val in unmet_conditions)))
+        def add_field(self, field, identifier, field_values):
+            """Add a new _Field to the tree.
 
-    def _assert_tag_exists(self, tag):
-        """Raise a human-readable :py:exc:`ValueError` if the supplied tag is
-        not used by any enabled field.
-        """
+            Parameters
+            ----------
+            field : :py:class:`._Field`
+                The field to be added
+            identifier : str
+                A identifier for the field. Must be unique within the scope in
+                which it exists.
+            field_values : {identifier: int, ...}
+                The field values which must be set for this field to exist. All
+                identifiers must correspond to actual field values.
 
-        for identifier, field in self._enabled_fields():
-            if tag in field.tags:
-                return
-        raise ValueError("Tag '{}' does not exist.".format(tag))
+            Raises
+            ------
+            ValueError
+                If the identifier is not unique within the scope supplied.
+            """
+            # Check the identifier is not already in use
+            if identifier in (i for (i, f) in
+                              self.potential_fields(field_values)):
+                raise ValueError("Field with identifier '{}' already "
+                                 "exists".format(identifier))
 
-    def _enabled_fields(self, field_values=None):
-        """Generator of (identifier, field) tuples which iterates over the
-        fields which can be set based on the currently specified field values.
-
-        Parameters
-        ----------
-        field_values : dict or None
-            Dictionary of field identifier to value mappings to use in the
-            test. If None, uses `self.field_values`.
-        """
-        if field_values is None:
-            field_values = self.field_values
-
-        for identifier, field in self.fields.items():
-            if not field.conditions or \
-               all(field_values.get(cond_field, None) == cond_value
-                   for cond_field, cond_value
-                   in field.conditions.items()):
-                yield (identifier, field)
-
-    def _potential_fields(self):
-        """Generator of (identifier, field) tuples iterating over every field
-        which could potentially be defined given the currently specified field
-        values.
-        """
-        # Fields are blocked when their conditions can't be met. This only
-        # occurs if a condition field's value can't be as the condition
-        # requires. This can occur either because the user has already assigned
-        # a value which doesn't mean the condition or the conditional field
-        # itself has been blocked (and thus can't ever be set to meet the
-        # condition). Since fields are partially ordered by hierarchy, we can
-        # simply build up a set of blocked fields as we go and be guaranteed
-        # to have already seen any field which appears in a condition.
-        blocked = set()
-        for identifier, field in self.fields.items():
-            if not field.conditions \
-               or all(cond_field not in blocked and
-                      self.field_values.get(cond_field, cond_value) ==
-                      cond_value
-                      for cond_field, cond_value
-                      in field.conditions.items()):
-                yield (identifier, field)
+            if not field_values:
+                # If no field_values need be specified, add the field at this
+                # point in the hierarchy
+                self.fields[identifier] = field
             else:
-                blocked.add(identifier)
+                # The field depends on some fields being defined with a
+                # particular value; descend the hierarchy.
 
-    def _assign_enabled_fields_with_fixed_start(self):
-        """For internal use only. Assign a length to any enabled fields which
-        do not have one but do have a fixed position.
-        """
-        assigned_bits = 0
-        unassigned_fields = list()
-        for identifier, field in self._enabled_fields():
-            if field.length is not None and field.start_at is not None:
-                assigned_bits |= ((1 << field.length) - 1) << field.start_at
-            elif field.start_at is not None:
-                unassigned_fields.append((identifier, field))
+                # Get the child node which has the specified set of values and
+                # add the field to that. (Note that requirement order mimics
+                # the order of field definition.)
+                meetable_requirements = tuple(
+                    (i, field_values[i]) for (i, f) in iteritems(self.fields)
+                    if i in field_values
+                )
+                child = self.children.setdefault(meetable_requirements,
+                                                 BitField._Tree())
+                child.add_field(field, identifier,
+                                {i: v for (i, v) in iteritems(field_values)
+                                 if i not in dict(meetable_requirements)})
 
-        for identifier, field in unassigned_fields:
-            assigned_bits = self._assign_enabled_field(
-                assigned_bits, identifier, field)
+        def get_field(self, identifier, field_values):
+            """Get the _Field object associated with a given identifier when the
+            given set of field values are present.
 
-    def _assign_enabled_fields_without_fixed_start(self, assigned_bits,
-                                                   exclude_fields=set()):
-        """For internal use only. Assign a length and position to any enabled
-        fields which do not have a fixed position.
+            Parameters
+            ----------
+            identifier : str
+            field_values : {identifier: int, ...}
+
+            Returns
+            -------
+            :py:class:`._Field`
+
+            Raises
+            ------
+            UnavailableFieldError
+                If a field with the specified identifier is not present or is
+                not accessible with the supplied set of values.
+            """
+            if identifier in self.fields:
+                return self.fields[identifier]
+            else:
+                for requirements, child in self._enabled_children(
+                        field_values):
+                    try:
+                        return child.get_field(identifier, field_values)
+                    except UnavailableFieldError:
+                        # Try the next child...
+                        pass
+
+            raise UnavailableFieldError(self, identifier, field_values)
+
+        def get_field_requirements(self, identifier, field_values):
+            """Get minimum subset of field_values which must be set for the
+            given (already enabled) identifier to be enabled.
+
+            Parameters
+            ----------
+            identifier : str
+            field_values : {identifier: int, ...}
+
+            Returns
+            -------
+            {identifier: int, ...}
+
+            Raises
+            ------
+            UnavailableFieldError
+                If a field with the specified identifier is not present or is
+                not accessible with the supplied set of values.
+            """
+            if identifier in self.fields:
+                # The field is part of this node and so no values need be set
+                return OrderedDict()
+            else:
+                for child_requirements, child in self._enabled_children(
+                        field_values):
+                    try:
+                        sub_requirements = child.get_field_requirements(
+                            identifier, field_values)
+                        requirements = OrderedDict(child_requirements)
+                        requirements.update(sub_requirements)
+                        return requirements
+                    except UnavailableFieldError:
+                        # Try the next child...
+                        pass
+
+            raise UnavailableFieldError(self, identifier, field_values)
+
+        def get_field_candidates(self, identifier, field_values):
+            """Get the possible sets of additional field values which could be
+            set to enable an identifier with the specified name.
+
+            Useful for generating helpful error messages.
+
+            Parameters
+            ----------
+            identifier : str
+            field_values : {identifier: int, ...}
+
+            Returns
+            -------
+            [{identifier: value, ...}, ...]
+                With a minimal set of additional field values which must be set
+                to access a field with the supplied identifier. Empty list if
+                a field with the identifier is not reachable given the current
+                values (or if it doesn't exist at all).
+            """
+            candidates = []
+
+            if identifier in self.fields:
+                # No additional requirements!
+                candidates.append({})
+            else:
+                # Look in any children for matching fields, adding any
+                # additional requirements introduced as we go.
+                for requirements, child in self._potential_children(
+                        field_values):
+                    for candidate in child.get_field_candidates(identifier,
+                                                                field_values):
+                        # Gather any additional requirements
+                        for i, v in requirements:
+                            if field_values.get(i, None) != v:
+                                candidate[i] = v
+                        candidates.append(candidate)
+
+            return candidates
+
+        def get_field_human_readable(self, identifier, field_values):
+            """Get a human-readable representation of a field's fully-specified
+            name.
+
+            This representation includes any qualifying field values which must
+            be set. The format looks like this::
+
+                >>> t = BitField._Tree()
+                >>> t.add_field(object(), "a", {})
+                >>> t.add_field(object(), "b", {})
+                >>> t.add_field(object(), "c", {"a": 0})
+
+                >>> # Just reports the name of fields which don't have any
+                >>> # field value requirements.
+                >>> t.get_field_human_readable("a", {})
+                "'a'"
+                >>> t.get_field_human_readable("a", {"a": 0, "b": 1})
+                "'a'"
+
+                >>> # Prints field value requirements when present
+                >>> t.get_field_human_readable("c", {"a": 0})
+                "'c' ('a':0)"
+                >>> t.get_field_human_readable("c", {"a": 0, "b": 1})
+                "'c' ('a':0)"
+            """
+            requirements = self.get_field_requirements(identifier,
+                                                       field_values)
+            if requirements:
+                return "'{}' ({})".format(
+                    identifier,
+                    ", ".join("'{}':{}".format(i, v)
+                              for (i, v) in iteritems(requirements))
+                )
+            else:
+                return "'{}'".format(identifier)
+
+        def _enabled_children(self, field_values):
+            """Iterate over (frozenset((identifier, int), ...), child) tuples
+            which are accessible with the specified field values set.
+
+            Iteration proceeds in a depth-first fashion with the ordering of
+            each level of the hierarchy matching insertion order.
+
+            Parameters
+            ----------
+            field_values : {identifier: int, ...}
+
+            Generates
+            ---------
+            (((identifier, int), ...), :py:class:`_Tree`)
+            """
+            for requirements, child in iteritems(self.children):
+                # Skip children with unfulfilled requirements
+                conflict = False
+                for ident, value in requirements:
+                    if ident not in field_values or \
+                            value != field_values[ident]:
+                        conflict = True
+                        break
+                if not conflict:
+                    yield (requirements, child)
+
+        def enabled_fields(self, field_values):
+            """Iterate over all accessible (identifier, field) pairs.
+
+            This iterator excludes fields which need additional or different
+            field values setting. Iteration proceeds in a depth-first fashion
+            with the ordering of each level of the hierarchy matching insertion
+            order.
+            """
+            for identifier, field in iteritems(self.fields):
+                yield (identifier, field)
+
+            for requirements, child in self._enabled_children(field_values):
+                for identifier, field in child.enabled_fields(field_values):
+                    yield (identifier, field)
+
+        def _potential_children(self, field_values):
+            """Iterate over (frozenset((identifier, int), ...), child) tuples
+            which don't have field value requirements which conflict with those
+            given.
+
+            This iterator includes children which require additional field
+            values to be set but excludes children which require field values
+            which don't match those supplied. Iteration proceeds in a
+            depth-first fashion with the ordering of each level of the
+            hierarchy matching insertion order.
+
+            Parameters
+            ----------
+            field_values : {identifier: int, ...}
+
+            Generates
+            ---------
+            (((identifier, int), ...), :py:class:`_Tree`)
+            """
+            for requirements, child in iteritems(self.children):
+                # Skip children with conflicting requirements
+                conflict = False
+                for ident, value in requirements:
+                    if ident in field_values and value != field_values[ident]:
+                        conflict = True
+                        break
+                if not conflict:
+                    yield (requirements, child)
+
+        def potential_fields(self, field_values):
+            """Iterate over all potentially accessible (identifier, field)
+            pairs.
+
+            This iterator includes fields which may not yet be accessible (but
+            which could be with additional field values set) but not fields
+            which require a different set of field_values set. Iteration
+            proceeds in a depth-first fashion with the ordering of each level
+            of the hierarchy matching insertion order.
+            """
+            for identifier, field in iteritems(self.fields):
+                yield (identifier, field)
+
+            for requirements, child in self._potential_children(field_values):
+                for identifier, field in child.potential_fields(field_values):
+                    yield (identifier, field)
+
+    def _assign_fields(self, identifiers, field_values,
+                       assign_positions, assigned_bits=0):
+        """For internal use only.  Assign lengths & positions to a subset of all
+        potential fields with the supplied field_values.
+
+        This method will check for any assigned bits of all potential fields
+        but will only assign those fields whose identifiers are provided.
 
         Parameters
         ----------
-        exclude_fields : {identifier, ...}
-            Exclude fields which will be assigned later, for example those
-            which will be assigned by bitfields higher up the hierarchy.
+        identifiers : iterable of identifiers
+            The identifiers of the fields to assign
+        field_values : {identifier: value, ...}
+            The values held by various fields (used to access the correct
+            identifiers)
+        assign_positions : bool
+            If False, will only assign fields whose length is unknown (leaving
+            those with undefined positions as they are). If True, will assign
+            positions and lengths as required.
+        assigned_bits : int
+            A bit mask of bits which are already allocated. (Note that this
+            will automatically be extended with any already-assigned potential
+            fields' bits.
 
         Returns
         -------
         int
-            Mask of which bits have been assigned to fields.
+            Mask of which bits which are assigned to fields after fields have
+            been assigned.
         """
-        unassigned_fields = list()
-        for identifier, field in self._enabled_fields():
-            if field.length is None or field.start_at is None:
-                if identifier not in exclude_fields:
-                    unassigned_fields.append((identifier, field))
-            else:
-                assigned_bits |= ((1 << field.length) - 1) << field.start_at
+        # Calculate a mask of already allocated fields' bits
+        for i, f in self.fields.potential_fields(field_values):
+            if f.length is not None and f.start_at is not None:
+                assigned_bits |= ((1 << f.length) - 1) << f.start_at
 
-        for identifier, field in unassigned_fields:
-            assert identifier not in exclude_fields
-            assigned_bits |= self._assign_enabled_field(
-                assigned_bits, identifier, field)
+        # Allocate all specified fields
+        for identifier in identifiers:
+            field = self.fields.get_field(identifier, field_values)
+            if field.length is not None and field.start_at is not None:
+                # Already allocated, do nothing!
+                pass
+            elif assign_positions or field.start_at is not None:
+                assigned_bits |= self._assign_field(assigned_bits,
+                                                    identifier,
+                                                    field_values)
 
         return assigned_bits
 
-    def _assign_enabled_field(self, assigned_bits, identifier, field):
+    def _assign_field(self, assigned_bits, identifier, field_values):
         """For internal use only.  Assign a length and position to a field
         which may have either one of these values missing.
+
+        Parameters
+        ----------
+        assigned_bits : int
+            A bit mask of bits already in use by other fields
+        identifier : str
+            The identifier of the field to assign
+        field_values : {identifier: value, ...}
+            The values held by various fields (used to access the correct
+            identifier)
 
         Returns
         -------
         int
-            Mask of which bits have been assigned to fields.
+            Mask of which bits which are assigned to fields after this field
+            has been assigned.
         """
+        field = self.fields.get_field(identifier, field_values)
+
         length = field.length
         if length is None:
             # Assign lengths based on values
@@ -660,9 +908,13 @@ class BitField(object):
 
             if assigned_bits & field_bits:
                 raise ValueError(
-                    "{}-bit field '{}' with fixed position does not fit in "
-                    "bit field.".format(
-                        field.length, identifier)
+                    "{}-bit field {} with fixed position does not fit in "
+                    "{}.".format(
+                        field.length,
+                        self.fields.get_field_human_readable(identifier,
+                                                             field_values),
+                        type(self).__name__
+                    )
                 )
 
             # Mark these bits as assigned
@@ -674,8 +926,66 @@ class BitField(object):
             field.start_at = start_at
         else:
             raise ValueError(
-                "{}-bit field '{}' does not fit in bit field.".format(
-                    field.length, identifier)
+                "{}-bit field {} does not fit in {}.".format(
+                    field.length,
+                    self.fields.get_field_human_readable(identifier,
+                                                         field_values),
+                    type(self).__name__
+                )
             )
 
         return assigned_bits
+
+
+class UnknownTagError(LookupError):
+    """Exception thrown when a tag is specified which does not exist."""
+
+    def __init__(self, tag):
+        """Simply enclose the tag in quotes."""
+        super(UnknownTagError, self).__init__("'{}'".format(tag))
+
+
+class UnavailableFieldError(LookupError):
+    """Exception thrown when a field is requested from a BitField which is not
+    does not exist or is unavailable (i.e. not in scope)."""
+
+    def __init__(self, tree, identifier, field_values):
+        """Create a human-readable error explaining that a field with the
+        supplied identifier was not found."""
+        # Find all possible instances of the supplied identifier (even those
+        # which are blocked)
+        candidates = tree.get_field_candidates(identifier, {})
+
+        # Sanity check: the identifier shouldn't be available
+        assert {} not in candidates
+
+        # Split candidates into two groups: those which can be reached
+        # without changing a field value...
+        possible = [candidate for candidate in candidates
+                    if not set(candidate).intersection(set(field_values))]
+        # ...and those where an existing field value must be changed
+        impossible = [candidate for candidate in candidates
+                      if set(candidate).intersection(set(field_values))]
+
+        if not candidates:
+            # The supplied field either never existed or requires
+            # contradictory field values.
+            super(UnavailableFieldError, self).__init__(
+                "Field '{}' does not exist.".format(identifier))
+        elif possible:
+            super(UnavailableFieldError, self).__init__(
+                "Field '{}' is not available unless {}.".format(
+                    identifier,
+                    " OR ".join(
+                        ", ".join("'{}':{}".format(i, v)
+                                  for (i, v) in iteritems(candidate))
+                        for candidate in possible)))
+        else:  # impossible != []
+            super(UnavailableFieldError, self).__init__(
+                "Field '{}' is not available when {}.".format(
+                    identifier,
+                    " OR ".join(
+                        ", ".join("'{}':{}".format(i, v)
+                                  for (i, v) in iteritems(candidate)
+                                  if i in field_values)
+                        for candidate in impossible)))

--- a/rig/bitfield.py
+++ b/rig/bitfield.py
@@ -178,7 +178,7 @@ class BitField(object):
             tags = set(tags)
 
         # Add the field (checking that the identifier is unique in the process)
-        field = BitField._Field(length, start_at, tags)
+        field = type(self)._Field(length, start_at, tags)
         self.fields.add_field(field, identifier, self.field_values)
 
         # Add tags to all parents of this field
@@ -579,7 +579,7 @@ class BitField(object):
                     if i in field_values
                 )
                 child = self.children.setdefault(meetable_requirements,
-                                                 BitField._Tree())
+                                                 type(self)())
                 child.add_field(field, identifier,
                                 {i: v for (i, v) in iteritems(field_values)
                                  if i not in dict(meetable_requirements)})

--- a/rig/bitfield.py
+++ b/rig/bitfield.py
@@ -216,7 +216,7 @@ class BitField(object):
         field_values.update(self.field_values)
 
         for identifier, value in field_values.items():
-            # All fields specified must exist
+            # All fields specified must exist (and be enabled)
             field = self.fields.get_field(identifier, field_values)
 
             # All field values must be within range
@@ -831,13 +831,13 @@ class BitField(object):
             The values held by various fields (used to access the correct
             identifiers)
         assign_positions : bool
-            If False, will only assign fields whose length is unknown (leaving
-            those with undefined positions as they are). If True, will assign
-            positions and lengths as required.
+            If False, will only assign lengths to fields whose positions are
+            already known. Otherwise lengths and positions will be assigned to
+            all fields as necessary.
         assigned_bits : int
             A bit mask of bits which are already allocated. (Note that this
             will automatically be extended with any already-assigned potential
-            fields' bits.
+            fields' bits.)
 
         Returns
         -------


### PR DESCRIPTION
As proposed in #94, allows multiple fields in a BitField to share the same name
so long as they are mutually exclusive.

This commit fundamentally changes the underlying datastructure in the BitField
class from a somewhat ad-hoc dictionary-with-dependency-list form into a true
tree format. This change alone is a "good thing" (TM) and has also simplified
implementation in some places.

Breaking changes
------------------------

* Exception types changed in some cases
* `get_tags` now only works when a field is enabled