### PR TITLE
`alloc_as_filelike` for vertices

### DIFF
--- a/docs/source/control.rst
+++ b/docs/source/control.rst
@@ -163,7 +163,8 @@ to and from memory in SpiNNaker::
     >>> mc.read(block_addr, 13)
     b"Hello, world!"
 
-Rig also provides a file-like I/O wrapper which may prove easier to integrate
+Rig also provides a file-like I/O wrapper
+(:py:class:`~rig.machine_control.MemoryIO`) which may prove easier to integrate
 into applications and also ensures reads and writes are constrained only to the
 allocated region. For example::
 
@@ -173,6 +174,21 @@ allocated region. For example::
     >>> block.seek(0)
     >>> block.read(13)
     b"Hello, world!"
+
+The :py:func:`~rig.machine_control.utils.sdram_alloc_for_vertices` utility
+function is provided to allocate multiple SDRAM blocks simultaneously.  This
+will be especially useful if you're using Rig's :doc:`place and route
+tools<place_and_route>`, since the utility accepts the place-and-route tools'
+output format. For example::
+
+    >>> placements, allocations, application_map, routing_tables = \
+    ...     rig.place_and_route.wrapper(...)
+    >>> from rig.machine_control.utils import sdram_alloc_for_vertices
+    >>> vertex_memory = sdram_alloc_for_vertices(mc, placements, allocations)
+    
+    >>> # The returned dictionary maps from vertex to file-like wrappers
+    >>> vertex_memory[vertex].write(b"Hello, world!")
+
 
 Context Managers
 ^^^^^^^^^^^^^^^^

--- a/docs/source/control_api.rst
+++ b/docs/source/control_api.rst
@@ -16,6 +16,9 @@ SpiNNaker Control API
     :members: CoreInfo, ProcessorStatus, IPTag, MemoryIO
     :special-members:
 
+.. automodule:: rig.machine_control.utils
+    :members: sdram_alloc_for_vertices
+
 BMP Control API
 ---------------
 

--- a/rig/machine_control/tests/test_machine_control_utils.py
+++ b/rig/machine_control/tests/test_machine_control_utils.py
@@ -1,0 +1,79 @@
+import mock
+import pytest
+
+from rig.machine_control import MachineController
+from rig.machine_control.machine_controller import MemoryIO
+from rig.machine_control.utils import sdram_alloc_for_vertices
+from rig.machine import Cores, SDRAM
+
+
+@pytest.mark.parametrize("core_as_tag", [True, False])
+def test_sdram_alloc_for_vertices(core_as_tag):
+    """Test allocing and getting a map of vertices to file-like objects
+    when multiple blocks of memory are requested.
+    """
+    # Create 3 vertices and make them require some amounts of SDRAM
+    vertices = [mock.Mock(name="vertex") for _ in range(4)]
+    placements = {vertices[0]: (0, 0),
+                  vertices[1]: (0, 0),
+                  vertices[2]: (1, 1),
+                  vertices[3]: (1, 1),
+                  }
+    allocations = {vertices[0]: {Cores: slice(1, 2), SDRAM: slice(0, 400)},
+                   vertices[1]: {Cores: slice(2, 3), SDRAM: slice(400, 600)},
+                   vertices[2]: {Cores: slice(1, 2), SDRAM: slice(124, 224)},
+                   vertices[3]: {Cores: slice(2, 3)},
+                   }
+
+    # Create the controller
+    cn = MachineController("localhost")
+
+    def sdram_alloc(size, tag, x, y, app_id):
+        return {
+            (0, 0, 1): 0x67800000,
+            (0, 0, 2): 0x60000000,
+            (1, 1, 1): 0x67800000,
+        }[(x, y, tag)]
+
+    if core_as_tag:
+        cn.sdram_alloc = mock.Mock(wraps=sdram_alloc)
+    else:
+        cn.sdram_alloc = mock.Mock(return_value=0x60080000)
+
+    # Perform the SDRAM allocation
+    with cn(app_id=33):
+        allocs = sdram_alloc_for_vertices(cn, placements, allocations,
+                                          core_as_tag=core_as_tag)
+
+    # Ensure the correct calls were made to sdram_alloc
+    cn.sdram_alloc.assert_has_calls([
+        mock.call(400, 1 if core_as_tag else 0, 0, 0, 33),
+        mock.call(200, 2 if core_as_tag else 0, 0, 0, 33),
+        mock.call(100, 1 if core_as_tag else 0, 1, 1, 33),
+    ], any_order=True)
+
+    # Ensure that every vertex has a memory file-like
+    assert len(allocs) == 3
+    assert isinstance(allocs[vertices[0]], MemoryIO)
+    assert allocs[vertices[0]]._x == 0
+    assert allocs[vertices[0]]._y == 0
+    assert allocs[vertices[0]]._machine_controller is cn
+    if core_as_tag:
+        assert allocs[vertices[0]]._start_address == 0x67800000
+        assert allocs[vertices[0]]._end_address == 0x67800000 + 400
+
+    assert isinstance(allocs[vertices[1]], MemoryIO)
+    assert allocs[vertices[1]]._x == 0
+    assert allocs[vertices[1]]._y == 0
+    assert allocs[vertices[1]]._machine_controller is cn
+    if core_as_tag:
+        assert allocs[vertices[1]]._start_address == 0x60000000
+        assert allocs[vertices[1]]._end_address == 0x60000000 + 200
+
+    assert isinstance(allocs[vertices[2]], MemoryIO)
+    assert allocs[vertices[2]]._x == 1
+    assert allocs[vertices[2]]._y == 1
+    assert allocs[vertices[2]]._machine_controller is cn
+    if core_as_tag:
+        assert allocs[vertices[2]]._start_address == 0x67800000
+        assert allocs[vertices[2]]._end_address == 0x67800000 + 100

--- a/rig/machine_control/tests/test_machine_controller.py
+++ b/rig/machine_control/tests/test_machine_controller.py
@@ -772,14 +772,11 @@ class TestMachineController(object):
     @pytest.mark.parametrize("size", [8, 200])
     @pytest.mark.parametrize("tag", [0, 2])
     @pytest.mark.parametrize("addr", [0x67000000, 0x61000000])
-    def test_sdram_alloc_and_open(self, app_id, size, tag, addr, x, y):
+    def test_sdram_alloc_as_filelike(self, app_id, size, tag, addr, x, y):
         """Test allocing and getting a file-like object returned."""
         # Create the mock controller
         cn = MachineController("localhost")
-
-        cn._send_scp = mock.Mock()
-        cn._send_scp.return_value = SCPPacket(False, 1, 0, 0, 0, 0, 0, 0, 0, 0,
-                                              0x80, 0, addr, None, None, b"")
+        cn.sdram_alloc = mock.Mock(return_value=addr)
 
         # Try the allocation
         fp = cn.sdram_alloc_as_filelike(size, tag, x, y, app_id=app_id)

--- a/rig/machine_control/utils.py
+++ b/rig/machine_control/utils.py
@@ -1,0 +1,87 @@
+import six
+from ..machine import Cores, SDRAM
+
+
+def sdram_alloc_for_vertices(controller, placements, allocations,
+                             core_as_tag=True,
+                             sdram_resource=SDRAM, cores_resource=Cores):
+    """Allocate and return a file-like view of a region of SDRAM for each
+    vertex which uses SDRAM as a resource.
+
+    The tag assigned to each region of assigned SDRAM is the index of the
+    first core that each vertex is assigned.  For example::
+
+        placements = {vertex: (0, 5)}
+        allocations = {vertex: {Cores: slice(3, 6),
+                                SDRAM: slice(204, 304)}}
+        sdram_allocations = sdram_alloc_for_vertices(
+            controller, placements, allocations
+        )
+
+    Will allocate a 100-byte block of SDRAM for the vertex which is
+    allocated cores 3-5 on chip (0, 5).  The region of SDRAM will be tagged
+    `3` (because this is the index of the first core).
+
+    Parameters
+    ----------
+    controller : :py:class:`rig.machine_control.MachineController`
+        Controller to use to allocate the SDRAM.
+    placements : {vertex: (x, y), ...}
+        Mapping of vertices to the chips they have been placed on.  Same as
+        produced by placers.
+    allocations : {vertex: {resource: allocation, ...}, ...}
+        Mapping of vertices to the resources they have been allocated.
+
+        A block of memory of the size specified by the `sdram_resource`
+        (default: :py:class:`~rig.machine.SDRAM`) resource will be allocated
+        for each vertex. Note that location of the supplied allocation is *not*
+        used.
+
+        When `core_as_tag=True`, the tag allocated will be the ID of the first
+        core used by the vertex (indicated by the `cores_resource`, default
+        :py:class:`~rig.machine.Cores`), otherwise the tag will be set to 0.
+
+    Other Parameters
+    ----------------
+    core_as_tag : bool
+        Use the index of the first allocated core as the tag for the region of
+        memory, otherwise 0 will be used.
+    sdram_resource : resource (default :py:class:`~rig.machine.SDRAM`)
+        Key used to indicate SDRAM usage in the resources dictionary.
+    cores_resource : resource (default :py:class:`~rig.machine.Cores`)
+        Key used to indicate cores which have been allocated in the
+        allocations dictionary.
+
+    Returns
+    -------
+    {vertex: :py:class:`.MemoryIO`, ...}
+        A file-like object for each vertex which can be used to read and write
+        to the region of SDRAM allocated to the vertex.
+
+    Raises
+    ------
+    SpiNNakerMemoryError
+        If the memory cannot be allocated, or a tag is already taken or
+        invalid.
+    """
+    # For each vertex we perform an SDRAM alloc to get a file-like for
+    # the vertex.
+    vertex_memory = dict()
+    for vertex, allocs in six.iteritems(allocations):
+        if sdram_resource in allocs:
+            sdram_slice = allocs[sdram_resource]
+            assert sdram_slice.step is None
+
+            size = sdram_slice.stop - sdram_slice.start
+            x, y = placements[vertex]
+
+            if core_as_tag:
+                tag = allocs[cores_resource].start
+            else:
+                tag = 0
+
+            # Get the memory
+            vertex_memory[vertex] = controller.sdram_alloc_as_filelike(
+                size, tag, x=x, y=y)
+
+    return vertex_memory


### PR DESCRIPTION
Allow allocation of SDRAM for a number of vertices.  `sdram_alloc_as_filelike` now accepts resources, placements and allocations and will perform SDRAM allocation for vertices given this information.  A dictionary mapping vertices to SDRAM file-like objects will be returned.

The older calling convention is still provided.