### PR TITLE
Remove Numpy as a requirement

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,3 +3,4 @@ pytest-cov
 flake8
 mock
 toposort
+numpy>=1.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-numpy>1.6
 six
 sentinel

--- a/rig/type_casts.py
+++ b/rig/type_casts.py
@@ -1,6 +1,9 @@
 """Fixed point conversion utilities.
 """
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    np = None  # No Numpy support
 
 
 def float_to_fix(signed, n_bits, n_frac):
@@ -154,95 +157,6 @@ def fix_to_float(signed, n_bits, n_frac):
     return kbits
 
 
-class NumpyFloatToFixConverter(object):
-    """A callable which converts Numpy arrays of floats to fixed point arrays.
-
-    General usage is to create a new converter and then call this on arrays of
-    values.  The `dtype` of the returned array is determined from the
-    parameters passed.  For example::
-
-        >>> f = NumpyFloatToFixConverter(signed=True, n_bits=8, n_frac=4)
-
-    Will convert floating point values to 8-bit signed representations with 4
-    fractional bits.  Consequently the returned `dtype` will be `int8`::
-
-        >>> import numpy as np
-        >>> vals = np.array([0.0, 0.25, 0.5, -0.5, -0.25])
-        >>> f(vals)
-        array([ 0,  4,  8, -8, -4], dtype=int8)
-
-    The conversion is saturating::
-
-        >>> f(np.array([15.0, 16.0, -16.0, -17.0]))
-        array([ 127,  127, -128, -128], dtype=int8)
-
-    The byte representation can be expected to match that for using
-    `float_to_fix`::
-
-        >>> d = f(np.array([-16.0]))
-
-        >>> import struct
-        >>> g = float_to_fix(True, 8, 4)
-        >>> val = g(-16.0)
-        >>> struct.pack('B', val) == bytes(d.data)
-        True
-
-    An exception is raised if the number of bits specified cannot be
-    represented using a whole `dtype`::
-
-        >>> NumpyFloatToFixConverter(True, 12, 0)
-        Traceback (most recent call last):
-        ValueError: n_bits: 12: Must be 8, 16, 32 or 64.
-    """
-    dtypes = {
-        (False, 8): np.uint8,
-        (True, 8): np.int8,
-        (False, 16): np.uint16,
-        (True, 16): np.int16,
-        (False, 32): np.uint32,
-        (True, 32): np.int32,
-        (False, 64): np.uint64,
-        (True, 64): np.int64,
-    }
-
-    def __init__(self, signed, n_bits, n_frac):
-        """Create a new converter from floats into ints.
-
-        Parameters
-        ----------
-        signed : bool
-            Indicates that the converted values are to be signed or otherwise.
-        n_bits : int
-            The number of bits each value will use overall (must be 8, 16, 32,
-            or 64).
-        n_frac : int
-            The number of fractional bits.
-        """
-        self.min_value, self.max_value = validate_fp_params(
-            signed, n_bits, n_frac)
-
-        # Check the number of bits is sane
-        if n_bits not in [8, 16, 32, 64]:
-            raise ValueError(
-                "n_bits: {}: Must be 8, 16, 32 or 64.".format(n_bits))
-
-        # Store the settings
-        self.bytes_per_element = n_bits / 8
-        self.dtype = self.dtypes[(signed, n_bits)]
-        self.n_frac = n_frac
-
-    def __call__(self, values):
-        """Convert the given NumPy array of values into fixed point format."""
-        # Saturate the values
-        vals = np.clip(values, self.min_value, self.max_value)
-
-        # Scale and cast to appropriate int types
-        vals *= 2.0 ** self.n_frac
-        vals = np.round(vals)
-
-        return self.dtype(vals)
-
-
 def validate_fp_params(signed, n_bits, n_frac):
     # Check the number of bits is sane
     if n_bits < 1:
@@ -264,3 +178,97 @@ def validate_fp_params(signed, n_bits, n_frac):
     max_v = ((1 << n_int) - 1) / float(1 << n_frac)
 
     return min_v, max_v
+
+
+if np is not None:
+    class NumpyFloatToFixConverter(object):
+        """A callable which converts Numpy arrays of floats to fixed point
+        arrays.
+
+        General usage is to create a new converter and then call this on arrays
+        of values.  The `dtype` of the returned array is determined from the
+        parameters passed.  For example::
+
+            >>> f = NumpyFloatToFixConverter(signed=True, n_bits=8, n_frac=4)
+
+        Will convert floating point values to 8-bit signed representations with
+        4 fractional bits.  Consequently the returned `dtype` will be `int8`::
+
+            >>> import numpy as np
+            >>> vals = np.array([0.0, 0.25, 0.5, -0.5, -0.25])
+            >>> f(vals)
+            array([ 0,  4,  8, -8, -4], dtype=int8)
+
+        The conversion is saturating::
+
+            >>> f(np.array([15.0, 16.0, -16.0, -17.0]))
+            array([ 127,  127, -128, -128], dtype=int8)
+
+        The byte representation can be expected to match that for using
+        `float_to_fix`::
+
+            >>> d = f(np.array([-16.0]))
+
+            >>> import struct
+            >>> g = float_to_fix(True, 8, 4)
+            >>> val = g(-16.0)
+            >>> struct.pack('B', val) == bytes(d.data)
+            True
+
+        An exception is raised if the number of bits specified cannot be
+        represented using a whole `dtype`::
+
+            >>> NumpyFloatToFixConverter(True, 12, 0)
+            Traceback (most recent call last):
+            ValueError: n_bits: 12: Must be 8, 16, 32 or 64.
+        """
+        dtypes = {
+            (False, 8): np.uint8,
+            (True, 8): np.int8,
+            (False, 16): np.uint16,
+            (True, 16): np.int16,
+            (False, 32): np.uint32,
+            (True, 32): np.int32,
+            (False, 64): np.uint64,
+            (True, 64): np.int64,
+        }
+
+        def __init__(self, signed, n_bits, n_frac):
+            """Create a new converter from floats into ints.
+
+            Parameters
+            ----------
+            signed : bool
+                Indicates that the converted values are to be signed or
+                otherwise.
+            n_bits : int
+                The number of bits each value will use overall (must be 8, 16,
+                32, or 64).
+            n_frac : int
+                The number of fractional bits.
+            """
+            self.min_value, self.max_value = validate_fp_params(
+                signed, n_bits, n_frac)
+
+            # Check the number of bits is sane
+            if n_bits not in [8, 16, 32, 64]:
+                raise ValueError(
+                    "n_bits: {}: Must be 8, 16, 32 or 64.".format(n_bits))
+
+            # Store the settings
+            self.bytes_per_element = n_bits / 8
+            self.dtype = self.dtypes[(signed, n_bits)]
+            self.n_frac = n_frac
+
+        def __call__(self, values):
+            """Convert the given NumPy array of values into fixed point
+            format.
+            """
+            # Saturate the values
+            vals = np.clip(values, self.min_value, self.max_value)
+
+            # Scale and cast to appropriate int types
+            vals *= 2.0 ** self.n_frac
+            vals = np.round(vals)
+
+            return self.dtype(vals)

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,9 @@ setup(
     license="GPLv2",
 
     # Requirements
-    install_requires=["numpy>1.6", "six", "enum34", "sentinel"],
+    install_requires=["six", "enum34", "sentinel"],
     tests_require=["pytest>=2.6", "pytest-cov", "mock", "toposort"],
+    extra_require={"numpy": ["numpy>=1.6"]},
 
     # Scripts
     entry_points={


### PR DESCRIPTION
I'm not sure how we want to test this - we could create a new Tox environment that doesn't install Numpy and check that the method isn't available...?