### PR TITLE
Run flake8 in pytest

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -69,6 +69,8 @@ bug in the test suite.
   does not indicate comprehensive tests.
 * [flake8](https://pypi.python.org/pypi/flake8) to enforce a [consistent code
   style](https://www.python.org/dev/peps/pep-0008/).
+* [pytest-flake8](https://pypi.python.org/pypi/pytest-flake8) to ensure code
+  style compliance when running tests.
 
 The test suite requires a number of additional Python packages to run which can
 be installed using::

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,5 @@
 [pytest]
-addopts = --doctest-modules --doctest-glob='*_doctest.rst'
+addopts = --doctest-modules --doctest-glob='*_doctest.rst' --flake8
+flake8-ignore =
+	*/__init__.py F401
+	docs/* ALL

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,6 @@
 pytest>=2.6
 pytest-cov
 flake8
+pytest-flake8
 mock
 toposort

--- a/rig/tests/conftest.py
+++ b/rig/tests/conftest.py
@@ -78,7 +78,11 @@ def pytest_runtest_setup(item):  # pragma: no cover
 
     for (mark, option, message) in [
             ("no_boot", "--no-boot", "don't (re)boot the SpiNNaker machine")]:
-        if getattr(item.obj, mark, None) and not item.config.getoption(option):
+        obj = getattr(item, "obj", None)
+        if obj is None:
+            continue
+
+        if getattr(obj, mark, None) and not item.config.getoption(option):
             pytest.skip(message)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, pep8
+envlist = py27, py33, py34
 
 [testenv]
 deps =
@@ -20,10 +20,3 @@ deps =
     -rrequirements.txt
     -rrequirements-2.7.txt
     -rrequirements-test.txt
-
-[testenv:pep8]
-deps = flake8
-commands = flake8 rig
-
-[flake8]
-exclude = __init__.py


### PR DESCRIPTION
 - Adds `pytest-flake8` as a dependency
 - Includes `--flake8` in pytest invocation
 - Ignores pep8 infractions in docs
 - Ignores `F401` in `__init__.py` files
 - Removes separate flake8 run from tox

Modifies `conftest.py` to avoid failing on the inserted Flake8 test item.