### PR TITLE
SCP Performance Improvements

### DIFF
--- a/rig/machine_control/consts.py
+++ b/rig/machine_control/consts.py
@@ -304,3 +304,12 @@ class BMPInfoType(enum.IntEnum):
     can_status = 2  # Status of all CAN devices on the bus
     adc = 3  # ADC (e.g. voltage + temperature)
     ip_addr = 4  # IP Address
+
+
+# Dictionary of (address % 4, n_bytes % 4) to data type
+address_length_dtype = {
+    (i, j): (DataType.word if (i == j == 0) else
+             (DataType.short if (i % 2 == j % 2 == 0) else
+              DataType.byte))
+    for i in range(4) for j in range(4)
+}

--- a/rig/machine_control/packets.py
+++ b/rig/machine_control/packets.py
@@ -1,90 +1,19 @@
 """Representations of SDP and SCP Packets."""
-import six
 import struct
-from weakref import WeakKeyDictionary
 
 # SDP header flags
 FLAG_REPLY = 0x87
 FLAG_NO_REPLY = 0x07
 
 
-class RangedIntAttribute(object):
-    """Descriptor that ensures values fit within a range of values."""
-    def __init__(self, minimum, maximum, min_inclusive=True,
-                 max_inclusive=False, allow_none=False, accept=list()):
-        """Create a new ranged descriptor with specified minimum and maximum
-        values.
-        """
-        if not min_inclusive:
-            minimum += 1  # Convert from [x, y) to (x, y)
-        if max_inclusive:
-            maximum += 1  # Convert from [x, y) to [x, y]
-
-        if not minimum <= maximum:
-            raise ValueError('min should be smaller than max')
-
-        self.accept = accept[:]
-        self.default = minimum
-        self.min = minimum
-        self.max = maximum
-        self.data = WeakKeyDictionary()
-        self.allow_none = allow_none
-
-    def __get__(self, instance, owner):
-        # Get the value, or the default
-        return self.data.get(instance, self.default)
-
-    def __set__(self, instance, value):
-        if value is not None:
-            # Check that min <= value < max
-            if not isinstance(value, six.integer_types):
-                raise TypeError("Value should be an integer: {!s}"
-                                .format(value))
-            if not self.min <= value < self.max and value not in self.accept:
-                raise ValueError("Value outside range {}: [{} to {})"
-                                 .format(value, self.min, self.max))
-            self.data[instance] = value
-        else:
-            if self.allow_none:
-                self.data[instance] = None
-            else:
-                raise ValueError("Value may not be None")
-
-
-class ByteStringAttribute(object):
-    """Descriptor that ensures values are bytestrings of the correct length."""
-    def __init__(self, default=b'', max_length=None):
-        self.max_length = max_length
-        self.default = default
-        self.data = WeakKeyDictionary()
-
-    def __get__(self, instance, owner):
-        return self.data.get(instance, self.default)
-
-    def __set__(self, instance, value):
-        if self.max_length is not None and len(value) > self.max_length:
-            raise ValueError(
-                "Byte string is too long: should be less than {} bytes"
-                .format(self.max_length)
-            )
-        self.data[instance] = value
-
-
 class SDPPacket(object):
     """An SDP Packet"""
-    tag = RangedIntAttribute(0, 256)
-    dest_port = RangedIntAttribute(0, 8)
-    dest_cpu = RangedIntAttribute(0, 18, accept=[31])  # For IPtags
-    src_port = RangedIntAttribute(0, 8)
-    src_cpu = RangedIntAttribute(0, 18, accept=[31])
-    dest_x = RangedIntAttribute(0, 256)
-    dest_y = RangedIntAttribute(0, 256)
-    src_x = RangedIntAttribute(0, 256)
-    src_y = RangedIntAttribute(0, 256)
-    data = ByteStringAttribute()
+    __slots__ = ["reply_expected", "tag", "dest_port", "dest_cpu", "src_port",
+                 "src_cpu", "dest_x", "dest_y", "src_x", "src_y", "data"]
 
-    def __init__(self, reply_expected, tag, dest_port, dest_cpu, src_port,
-                 src_cpu, dest_x, dest_y, src_x, src_y, data):
+    def __init__(self, reply_expected=False, tag=None,
+                 dest_port=None, dest_cpu=None, src_port=None, src_cpu=None,
+                 dest_x=None, dest_y=None, src_x=None, src_y=None, data=b''):
         """Create a new SDPPacket.
 
         Parameters
@@ -108,33 +37,6 @@ class SDPPacket(object):
         self.data = data
 
     @classmethod
-    def unpack_packet(cls, bytestring):
-        """Unpack the SDP header from a bytestring."""
-        # Extract the header and the data from the packet
-        header = bytestring[0:8]  # First 8 bytes
-        data = bytestring[8:]  # Everything else
-
-        # Unpack the header
-        (flags, tag, dest_cpu_port, src_cpu_port, dest_p2p,
-         src_p2p) = struct.unpack('<4B2H', header)
-
-        dest_x = (dest_p2p & 0xff00) >> 8
-        dest_y = (dest_p2p & 0x00ff)
-        src_x = (src_p2p & 0xff00) >> 8
-        src_y = (src_p2p & 0x00ff)
-
-        # Neaten up the combined VCPU and port fields
-        dest_cpu, dest_port = cls.unpack_dest_cpu_port(dest_cpu_port)
-        src_cpu, src_port = cls.unpack_dest_cpu_port(src_cpu_port)
-
-        # Create a dictionary representing the packet.
-        return dict(
-            reply_expected=flags == FLAG_REPLY, tag=tag, dest_port=dest_port,
-            dest_cpu=dest_cpu, src_port=src_port, src_cpu=src_cpu,
-            dest_x=dest_x, dest_y=dest_y, src_x=src_x, src_y=src_y, data=data
-        )
-
-    @classmethod
     def from_bytestring(cls, bytestring):
         """Create a new SDPPacket from a bytestring.
 
@@ -143,23 +45,9 @@ class SDPPacket(object):
         SDPPacket
             An SDPPacket containing the data from the bytestring.
         """
-        return cls(**cls.unpack_packet(bytestring))
-
-    @staticmethod
-    def pack_dest_cpu_port(port, cpu):
-        return ((port & 0x07) << 5) | (cpu & 0x1f)
-
-    @staticmethod
-    def unpack_dest_cpu_port(portcpu):
-        return portcpu & 0x1f, ((portcpu >> 5) & 0x07)
-
-    @property
-    def packed_dest_cpu_port(self):
-        return self.pack_dest_cpu_port(self.dest_port, self.dest_cpu)
-
-    @property
-    def packed_src_cpu_port(self):
-        return self.pack_dest_cpu_port(self.src_port, self.src_cpu)
+        packet = cls()
+        _unpack_sdp_into_packet(packet, bytestring)
+        return packet
 
     @property
     def packed_data(self):
@@ -169,14 +57,16 @@ class SDPPacket(object):
     def bytestring(self):
         """Convert the packet into a bytestring."""
         # Convert x and y to p2p addresses
-        dest_p2p = (self.dest_x << 8) | self.dest_y
-        src_p2p = (self.src_x << 8) | self.src_y
+        packed_dest_cpu_port = (((self.dest_port & 0x7) << 5) |
+                                (self.dest_cpu & 0x1f))
+        packed_src_cpu_port = (((self.src_port & 0x7) << 5) |
+                               (self.src_cpu & 0x1f))
 
         # Construct the header
         header = struct.pack(
-            '<4B2H', FLAG_REPLY if self.reply_expected else FLAG_NO_REPLY,
-            self.tag, self.packed_dest_cpu_port, self.packed_src_cpu_port,
-            dest_p2p, src_p2p
+            '<2x8B', FLAG_REPLY if self.reply_expected else FLAG_NO_REPLY,
+            self.tag, packed_dest_cpu_port, packed_src_cpu_port,
+            self.dest_y, self.dest_x, self.src_y, self.src_x
         )
 
         # Return the header and the packed data
@@ -185,19 +75,12 @@ class SDPPacket(object):
 
 class SCPPacket(SDPPacket):
     """An SCP Packet"""
-    cmd_rc = RangedIntAttribute(0, 0xFFFF, max_inclusive=True)
-    seq = RangedIntAttribute(0, 0xFFFF, max_inclusive=True)
-    arg1 = RangedIntAttribute(0, 0xFFFFFFFF, max_inclusive=True,
-                              allow_none=True)
-    arg2 = RangedIntAttribute(0, 0xFFFFFFFF, max_inclusive=True,
-                              allow_none=True)
-    arg3 = RangedIntAttribute(0, 0xFFFFFFFF, max_inclusive=True,
-                              allow_none=True)
-    data = ByteStringAttribute(max_length=256)
+    __slots__ = ["cmd_rc", "seq", "arg1", "arg2", "arg3"]
 
-    def __init__(self, reply_expected, tag, dest_port, dest_cpu, src_port,
-                 src_cpu, dest_x, dest_y, src_x, src_y, cmd_rc, seq, arg1,
-                 arg2, arg3, data):
+    def __init__(self, reply_expected=False, tag=None,
+                 dest_port=None, dest_cpu=None, src_port=None, src_cpu=None,
+                 dest_x=None, dest_y=None, src_x=None, src_y=None, cmd_rc=None,
+                 seq=None, arg1=None, arg2=None, arg3=None, data=b''):
         super(SCPPacket, self).__init__(
             reply_expected, tag, dest_port, dest_cpu, src_port,
             src_cpu, dest_x, dest_y, src_x, src_y, data)
@@ -220,43 +103,71 @@ class SCPPacket(SDPPacket):
         n_args : int
             The number of arguments to unpack from the SCP data.
         """
-        sdp_data = cls.unpack_packet(scp_packet)
-        sdp_data.update(cls.unpack_scp_header(sdp_data["data"], n_args))
-        return cls(**sdp_data)
+        packet = cls()  # Empty packet
+        _unpack_sdp_into_packet(packet, scp_packet)
 
-    @classmethod
-    def unpack_scp_header(cls, data, n_args=3):
-        """Unpack the SCP header from a bytestring."""
         # Unpack the SCP header from the data
-        (cmd_rc, seq) = struct.unpack('<2H', data[0:4])
-        data = data[4:]
+        data = packet.data[4:]
+        packet.cmd_rc, packet.seq = struct.unpack_from('<2H', packet.data)
 
         # Unpack as much of the data as is present
-        arg1 = arg2 = arg3 = None
-        if n_args >= 1 and len(data) >= 4:
-            arg1 = struct.unpack('<I', data[0:4])[0]
-            data = data[4:]
-        if n_args >= 2 and len(data) >= 4:
-            arg2 = struct.unpack('<I', data[0:4])[0]
-            data = data[4:]
-        if n_args >= 3 and len(data) >= 4:
-            arg3 = struct.unpack('<I', data[0:4])[0]
-            data = data[4:]
+        data_len = len(data)
+        offset = 0
+        if n_args >= 1 and data_len >= 4:
+            packet.arg1, = struct.unpack_from('<I', data, offset)
+            offset += 4
 
-        # Return the SCP header
-        scp_header = {
-            'cmd_rc': cmd_rc, 'seq': seq, 'arg1': arg1, 'arg2': arg2, 'arg3':
-            arg3, 'data': data}
-        return scp_header
+            if n_args >= 2 and data_len >= 8:
+                packet.arg2, = struct.unpack_from('<I', data, offset)
+                offset += 4
+
+                if n_args >= 3 and data_len >= 12:
+                    packet.arg3, = struct.unpack_from('<I', data, offset)
+                    offset += 4
+
+        packet.data = data[offset:]
+
+        return packet
 
     @property
     def packed_data(self):
         """Pack the data for the SCP packet."""
+        # Pack the header
         scp_header = struct.pack("<2H", self.cmd_rc, self.seq)
 
-        for arg in (self.arg1, self.arg2, self.arg3):
-            if arg is not None:
-                scp_header += struct.pack('<I', arg)
+        # Potential loop intentionally unrolled
+        if self.arg1 is not None:
+            scp_header += struct.pack('<I', self.arg1)
+        if self.arg2 is not None:
+            scp_header += struct.pack('<I', self.arg2)
+        if self.arg3 is not None:
+            scp_header += struct.pack('<I', self.arg3)
 
         # Return the SCP header and the rest of the data
         return scp_header + self.data
+
+
+def _unpack_sdp_into_packet(packet, bytestring):
+    """Unpack the SDP header from a bytestring into a packet.
+
+    Parameters
+    ----------
+    packet : :py:class:`.SDPPacket`
+        Packet into which to store the unpacked header.
+    bytestring : bytes
+        Bytes from which to unpack the header data.
+    """
+    # Extract the header and the data from the packet
+    packet.data = bytestring[10:]  # Everything but the header
+
+    # Unpack the header
+    (flags, packet.tag, dest_cpu_port, src_cpu_port,
+     packet.dest_y, packet.dest_x,
+     packet.src_y, packet.src_x) = struct.unpack_from('<2x8B', bytestring)
+    packet.reply_expected = flags == FLAG_REPLY
+
+    # Neaten up the combined VCPU and port fields
+    packet.dest_cpu = dest_cpu_port & 0x1f
+    packet.dest_port = (dest_cpu_port >> 5)  # & 0x07
+    packet.src_cpu = src_cpu_port & 0x1f
+    packet.src_port = (src_cpu_port >> 5)  # & 0x07

--- a/rig/machine_control/scp_connection.py
+++ b/rig/machine_control/scp_connection.py
@@ -101,7 +101,7 @@ class SCPConnection(object):
         n_tries = 0
         while n_tries < self.n_tries:
             # Transit the packet
-            self.sock.send(b'\x00\x00' + packet.bytestring)
+            self.sock.send(packet.bytestring)
             n_tries += 1
 
             try:
@@ -114,8 +114,7 @@ class SCPConnection(object):
             # Convert the possible returned packet into an SCP packet. If
             # the sequence number matches the expected sequence number then
             # the acknowledgement has been received.
-            scp = packets.SCPPacket.from_bytestring(ack[2:],
-                                                    n_args=expected_args)
+            scp = packets.SCPPacket.from_bytestring(ack, n_args=expected_args)
 
             # Check that the CMD_RC isn't an error
             if scp.cmd_rc in self.error_codes:
@@ -137,6 +136,102 @@ class SCPConnection(object):
             "Exceeded {} tries when trying to transmit packet.".format(
                 self.n_tries)
         )
+
+    def read(self, buffer_size, x, y, p, address, length_bytes):
+        """Read a bytestring from an address in memory.
+
+        ..note::
+            This method is included here to maintain API compatibility with an
+            `alternative implementation of SCP
+            <https://github.com/project-rig/rig-scp>`_.
+
+        Parameters
+        ----------
+        buffer_size : int
+            Number of bytes held in an SCP buffer by SARK, determines how many
+            bytes will be expected in a socket and how many bytes of data will
+            be read back in each packet.
+        x : int
+        y : int
+        p : int
+        address : int
+            The address at which to start reading the data.
+        length_bytes : int
+            The number of bytes to read from memory. Large reads are
+            transparently broken into multiple SCP read commands.
+
+        Returns
+        -------
+        :py:class:`bytes`
+            The data is read back from memory as a bytestring.
+        """
+        # Prepare the buffer to receive the incoming data
+        data = bytearray(length_bytes)
+
+        # Request data until all data has been received
+        offset = 0
+        while length_bytes > 0:
+            # Get the next block of data
+            block_size = min((length_bytes, buffer_size))
+            read_address = address + offset
+            dtype = consts.address_length_dtype[(read_address % 4,
+                                                 block_size % 4)]
+
+            # Send the SCP packet to request the data
+            block_data = self.send_scp(
+                buffer_size, x, y, p, consts.SCPCommands.read,
+                read_address, block_size, dtype, expected_args=0
+            )
+
+            # Save the data to the buffer, update the number of bytes remaining
+            # and the offset
+            data[offset:offset + block_size] = block_data.data
+            offset += block_size
+            length_bytes -= block_size
+
+        return bytes(data)
+
+    def write(self, buffer_size, x, y, p, address, data):
+        """Write a bytestring to an address in memory.
+
+        ..note::
+            This method is included here to maintain API compatibility with an
+            `alternative implementation of SCP
+            <https://github.com/project-rig/rig-scp>`_.
+
+        Parameters
+        ----------
+        buffer_size : int
+            Number of bytes held in an SCP buffer by SARK, determines how many
+            bytes will be expected in a socket and how many bytes will be
+            written in each packet.
+        x : int
+        y : int
+        p : int
+        address : int
+            The address at which to start writing the data. Addresses are given
+            within the address space of a SpiNNaker core. See the SpiNNaker
+            datasheet for more information.
+        data : :py:class:`bytes`
+            Data to write into memory. Writes are automatically broken into a
+            sequence of SCP write commands.
+        """
+        # While there is still data perform a write: get the block to write
+        # this time around, determine the data type, perform the write and
+        # increment the address
+        end = len(data)
+        pos = 0
+        while pos < end:
+            block = data[pos:pos + buffer_size]
+            block_size = len(block)
+
+            dtype = consts.address_length_dtype[(address % 4, block_size % 4)]
+
+            self.send_scp(buffer_size, x, y, p, consts.SCPCommands.write,
+                          address, block_size, dtype, block)
+
+            address += block_size
+            pos += block_size
 
 
 class SCPError(IOError):

--- a/rig/machine_control/tests/test_packets.py
+++ b/rig/machine_control/tests/test_packets.py
@@ -1,97 +1,4 @@
-import pytest
 from ..packets import SDPPacket, SCPPacket
-from .. import packets
-
-
-class TestRangedIntAttribute(object):
-    def test_min_exclusive(self):
-        # Test values are correctly checked in the min value is excluded from
-        # the valid range.
-        class X(object):
-            y = packets.RangedIntAttribute(0, 10, min_inclusive=False)
-
-        x = X()
-        with pytest.raises(ValueError):
-            x.y = 0
-
-        x.y = 1
-
-    def test_max_inclusive(self):
-        # Test values are correctly checked in the max value is included in the
-        # valid range.
-        class X(object):
-            y = packets.RangedIntAttribute(0, 10, max_inclusive=True)
-
-        x = X()
-        x.y = 10
-
-    def test_min_max_fail(self):
-        # Test that a value error is raised on instantiation if the min/max
-        # values are wrong.
-        with pytest.raises(ValueError):
-            class X(object):
-                y = packets.RangedIntAttribute(100, 0)
-
-    def test_type_fail(self):
-        class X(object):
-            y = packets.RangedIntAttribute(0, 100)
-
-        x = X()
-        with pytest.raises(TypeError):
-            x.y = "Oops!"
-
-    def test_allow_none(self):
-        class X(object):
-            y = packets.RangedIntAttribute(0, 10, allow_none=False)
-
-        x = X()
-        with pytest.raises(ValueError):
-            x.y = None
-
-        class Y(object):
-            y = packets.RangedIntAttribute(0, 10, allow_none=True)
-
-        y = Y()
-        y.y = None
-
-
-class TestByteStringAttribute(object):
-    def test_unlimited_length(self):
-        class X(object):
-            y = packets.ByteStringAttribute(default=b"default")
-
-        x = X()
-
-        assert x.y == b"default"
-
-        x.y = b""
-        assert x.y == b""
-
-        x.y = b"hello"
-        assert x.y == b"hello"
-
-        x.y = b"01234567"
-        assert x.y == b"01234567"
-
-    def test_max_length(self):
-        class X(object):
-            y = packets.ByteStringAttribute(max_length=8)
-
-        x = X()
-
-        assert x.y == b""
-
-        x.y = b""
-        assert x.y == b""
-
-        x.y = b"hello"
-        assert x.y == b"hello"
-
-        x.y = b"01234567"
-        assert x.y == b"01234567"
-
-        with pytest.raises(ValueError):
-            x.y = b"012345678"
 
 
 class TestSDPPacket(object):
@@ -110,7 +17,7 @@ class TestSDPPacket(object):
         #     src_x: 0x0F
         #     src_y: 0xF0
         #     data: 0xDEADBEEF
-        packet = b'\x87\xf0\xef\xee\x5a\xa5\xf0\x0f\xDE\xAD\xBE\xEF'
+        packet = b'\x00\x00\x87\xf0\xef\xee\x5a\xa5\xf0\x0f\xDE\xAD\xBE\xEF'
         sdp_packet = SDPPacket.from_bytestring(packet)
 
         assert isinstance(sdp_packet, SDPPacket)
@@ -134,88 +41,11 @@ class TestSDPPacket(object):
         """Test creating a new SDPPacket from a bytestring."""
         # Create bytestring representing a packet with:
         #     flags: 0x07
-        packet = b'\x07\xf0\xef\xee\xa5\x5a\x0f\xf0\xDE\xAD\xBE\xEF'
+        packet = b'\x00\x00\x07\xf0\xef\xee\xa5\x5a\x0f\xf0\xDE\xAD\xBE\xEF'
         sdp_packet = SDPPacket.from_bytestring(packet)
 
         assert isinstance(sdp_packet, SDPPacket)
         assert not sdp_packet.reply_expected
-
-    def test_values(self):
-        """Check that errors are raised when values are out of range."""
-        with pytest.raises(TypeError):  # Ints should be ints
-            SDPPacket(False, 3.0, 0, 0, 0, 0, 0, 0, 0, 0, b'')
-
-        with pytest.raises(ValueError):
-            # IPTag is 8 bits
-            SDPPacket(False, 300, 0, 0, 0, 0, 0, 0, 0, 0, b'')
-
-        with pytest.raises(ValueError):
-            # IPTag is 8 bits
-            SDPPacket(False, -1, 0, 0, 0, 0, 0, 0, 0, 0, b'')
-
-        with pytest.raises(ValueError):
-            # dest_port is 3 bits
-            SDPPacket(False, 255, 8, 0, 0, 0, 0, 0, 0, 0, b'')
-
-        with pytest.raises(ValueError):
-            # dest_port is 3 bits
-            SDPPacket(False, 255, -1, 0, 0, 0, 0, 0, 0, 0, b'')
-
-        with pytest.raises(ValueError):
-            # dest_cpu is 5 bits but should range 0..17
-            SDPPacket(False, 255, 7, 18, 0, 0, 0, 0, 0, 0, b'')
-
-        with pytest.raises(ValueError):
-            # dest_cpu is 5 bits but should range 0..17
-            SDPPacket(False, 255, 7, -1, 0, 0, 0, 0, 0, 0, b'')
-
-        with pytest.raises(ValueError):
-            # src_port is 3 bits
-            SDPPacket(False, 255, 7, 17, 8, 0, 0, 0, 0, 0, b'')
-
-        with pytest.raises(ValueError):
-            # src_port is 3 bits
-            SDPPacket(False, 255, 7, 17, -1, 0, 0, 0, 0, 0, b'')
-
-        with pytest.raises(ValueError):
-            # src_cpu is 5 bits but should range 0..17
-            SDPPacket(False, 255, 7, 17, 7, 18, 0, 0, 0, 0, b'')
-
-        with pytest.raises(ValueError):
-            # src_cpu is 5 bits but should range 0..17
-            SDPPacket(False, 255, 7, 17, 7, -1, 0, 0, 0, 0, b'')
-
-        with pytest.raises(ValueError):
-            # dest_x is 8 bits
-            SDPPacket(False, 255, 7, 17, 7, 17, 256, 0, 0, 0, b'')
-
-        with pytest.raises(ValueError):
-            # dest_x is 8 bits
-            SDPPacket(False, 255, 7, 17, 7, 17, -1, 0, 0, 0, b'')
-
-        with pytest.raises(ValueError):
-            # dest_y is 8 bits
-            SDPPacket(False, 255, 7, 17, 7, 17, 255, 256, 0, 0, b'')
-
-        with pytest.raises(ValueError):
-            # dest_y is 8 bits
-            SDPPacket(False, 255, 7, 17, 7, 17, 255, -1, 0, 0, b'')
-
-        with pytest.raises(ValueError):
-            # src_x is 8 bits
-            SDPPacket(False, 255, 7, 17, 7, 17, 255, 255, 256, 0, b'')
-
-        with pytest.raises(ValueError):
-            # src_x is 8 bits
-            SDPPacket(False, 255, 7, 17, 7, 17, 255, 255, -1, 0, b'')
-
-        with pytest.raises(ValueError):
-            # src_y is 8 bits
-            SDPPacket(False, 255, 7, 17, 7, 17, 255, 255, 255, 256, b'')
-
-        with pytest.raises(ValueError):
-            # src_y is 8 bits
-            SDPPacket(False, 255, 7, 17, 7, 17, 255, 255, 255, -1, b'')
 
 
 class TestSCPPacket(object):
@@ -237,7 +67,7 @@ class TestSCPPacket(object):
         #     src_y: 0xF0
         #     cmd_rc: 0xDEAD
         #     seq: 0xBEEF
-        packet = b'\x87\xf0\xef\xee\x5a\xa5\xf0\x0f\xAD\xDE\xEF\xBE'
+        packet = b'\x00\x00\x87\xf0\xef\xee\x5a\xa5\xf0\x0f\xAD\xDE\xEF\xBE'
         scp_packet = SCPPacket.from_bytestring(packet)
 
         assert isinstance(scp_packet, SCPPacket)
@@ -281,7 +111,8 @@ class TestSCPPacket(object):
         #     arg2: 0xCAFECAFE
         #     arg3: 0x5A5A7B7B
         #     data: 0xFEEDDEAF01
-        packet = b'\x87\xf0\xef\xee\x5a\xa5\xf0\x0f\xAD\xDE\xEF\xBE' + \
+        packet = b'\x00\x00' + \
+                 b'\x87\xf0\xef\xee\x5a\xa5\xf0\x0f\xAD\xDE\xEF\xBE' + \
                  b'\xB7\xB7\xA5\xA5\xFE\xCA\xFE\xCA\x7B\x7B\x5A\x5A' + \
                  b'\xFE\xED\xDE\xAF\x01'
         scp_packet = SCPPacket.from_bytestring(packet)
@@ -324,7 +155,8 @@ class TestSCPPacket(object):
         #     cmd_rc: 0xDEAD
         #     seq: 0xBEEF
         #     data: 0xA5A5B7B7CAFECAFE5A5A7B7BFEEDDEAF01
-        packet = b'\x87\xf0\xef\xee\xa5\x5a\x0f\xf0\xAD\xDE\xEF\xBE' + \
+        packet = b'\x00\x00' + \
+                 b'\x87\xf0\xef\xee\xa5\x5a\x0f\xf0\xAD\xDE\xEF\xBE' + \
                  b'\xB7\xB7\xA5\xA5\xFE\xCA\xFE\xCA\x7B\x7B\x5A\x5A' + \
                  b'\xFE\xED\xDE\xAF\x01'
         scp_packet = SCPPacket.from_bytestring(packet, n_args=0)
@@ -344,7 +176,7 @@ class TestSCPPacket(object):
 
     def test_from_bytestring_0_args_short(self):
         """Test creating a new SCPPacket from a bytestring."""
-        packet = b'\x87\xf0\xef\xee\xa5\x5a\x0f\xf0\xAD\xDE\xEF\xBE'
+        packet = b'\x00\x00\x87\xf0\xef\xee\xa5\x5a\x0f\xf0\xAD\xDE\xEF\xBE'
         scp_packet = SCPPacket.from_bytestring(packet)
 
         assert scp_packet.arg1 is None
@@ -360,7 +192,8 @@ class TestSCPPacket(object):
         """Test creating a new SCPPacket from a bytestring."""
         #     arg1: 0xA5A5B7B7
         #     data: 0xCAFECAFE5A5A7B7BFEEDDEAF01
-        packet = b'\x87\xf0\xef\xee\xa5\x5a\x0f\xf0\xAD\xDE\xEF\xBE' + \
+        packet = b'\x00\x00' + \
+                 b'\x87\xf0\xef\xee\xa5\x5a\x0f\xf0\xAD\xDE\xEF\xBE' + \
                  b'\xB7\xB7\xA5\xA5\xFE\xCA\xFE\xCA\x7B\x7B\x5A\x5A' + \
                  b'\xFE\xED\xDE\xAF\x01'
         scp_packet = SCPPacket.from_bytestring(packet, n_args=1)
@@ -379,7 +212,8 @@ class TestSCPPacket(object):
     def test_from_bytestring_1_args_short(self):
         """Test creating a new SCPPacket from a bytestring."""
         #     arg1: 0xA5A5B7B7
-        packet = b'\x87\xf0\xef\xee\xa5\x5a\x0f\xf0\xAD\xDE\xEF\xBE' + \
+        packet = b'\x00\x00' + \
+                 b'\x87\xf0\xef\xee\xa5\x5a\x0f\xf0\xAD\xDE\xEF\xBE' + \
                  b'\xB7\xB7\xA5\xA5'
         scp_packet = SCPPacket.from_bytestring(packet)
 
@@ -397,7 +231,8 @@ class TestSCPPacket(object):
         #     arg1: 0xA5A5B7B7
         #     arg2: 0xCAFECAFE
         #     data: 0x5A5A7B7BFEEDDEAF01
-        packet = b'\x87\xf0\xef\xee\xa5\x5a\x0f\xf0\xAD\xDE\xEF\xBE' + \
+        packet = b'\x00\x00' + \
+                 b'\x87\xf0\xef\xee\xa5\x5a\x0f\xf0\xAD\xDE\xEF\xBE' + \
                  b'\xB7\xB7\xA5\xA5\xFE\xCA\xFE\xCA\x7B\x7B\x5A\x5A' + \
                  b'\xFE\xED\xDE\xAF\x01'
         scp_packet = SCPPacket.from_bytestring(packet, n_args=2)
@@ -415,7 +250,8 @@ class TestSCPPacket(object):
         """Test creating a new SCPPacket from a bytestring."""
         #     arg1: 0xA5A5B7B7
         #     arg2: 0xCAFECAFE
-        packet = b'\x87\xf0\xef\xee\xa5\x5a\x0f\xf0\xAD\xDE\xEF\xBE' + \
+        packet = b'\x00\x00' + \
+                 b'\x87\xf0\xef\xee\xa5\x5a\x0f\xf0\xAD\xDE\xEF\xBE' + \
                  b'\xB7\xB7\xA5\xA5\xFE\xCA\xFE\xCA'
         scp_packet = SCPPacket.from_bytestring(packet)
 
@@ -427,45 +263,3 @@ class TestSCPPacket(object):
         # Check that the bytestring this packet creates is the same as the one
         # we specified before.
         assert scp_packet.bytestring == packet
-
-    def test_values(self):
-        """Check that SCP packets respect data values."""
-        with pytest.raises(ValueError):  # cmd_rc is 16 bits
-            SCPPacket(False, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                      1 << 16, 0, 0, 0, 0, b'')
-
-        with pytest.raises(ValueError):  # cmd_rc is 16 bits
-            SCPPacket(False, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                      -1, 0, 0, 0, 0, b'')
-
-        with pytest.raises(ValueError):  # seq is 16 bits
-            SCPPacket(False, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                      0xFFFF, 1 << 16, 0, 0, 0, b'')
-
-        with pytest.raises(ValueError):  # seq is 16 bits
-            SCPPacket(False, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                      0xFFFF, -1, 0, 0, 0, b'')
-
-        with pytest.raises(ValueError):  # arg1 is 32 bits
-            SCPPacket(False, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                      0xFFFF, 0xFFFF, 1 << 32, 0, 0, b'')
-
-        with pytest.raises(ValueError):  # arg1 is 32 bits
-            SCPPacket(False, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                      0xFFFF, 0xFFFF, -1, 0, 0, b'')
-
-        with pytest.raises(ValueError):  # arg2 is 32 bits
-            SCPPacket(False, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                      0xFFFF, 0xFFFF, 0xFFFFFFFF, 1 << 32, 0, b'')
-
-        with pytest.raises(ValueError):  # arg2 is 32 bits
-            SCPPacket(False, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                      0xFFFF, 0xFFFF, 0xFFFFFFFF, -1, 0, b'')
-
-        with pytest.raises(ValueError):  # arg3 is 32 bits
-            SCPPacket(False, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                      0xFFFF, 0xFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 1 << 32, b'')
-
-        with pytest.raises(ValueError):  # arg3 is 32 bits
-            SCPPacket(False, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                      0xFFFF, 0xFFFF, 0xFFFFFFFF, 0xFFFFFFFF, -1, b'')


### PR DESCRIPTION
 - Pushes `read` and `write` functionality down to the level of the `SCPController` (8116dcd)
 - Removes the value and type checking from SCP and SDP packets (fa05d4e)
 - Slightly neatens SDP internals (1d14607)

Reading and writing 10MB data to chip (0, 0) on a SpiNN3 board I have at home gives:

Commit | Write speed / Mbs<sup>-1</sup> | Read speed / Mbs<sup>-1</sup>
------ | ------------------------------ | -----------------------------
Master | 5.41 | 5.01
After 8116dcd | 5.80 | 5.30
After 8116dcd and fa05d4e | 8.70 | 7.80
After all | 8.90 | 8.00

~~Obviously the results are a little rough, but being faster than @mossblaser's profiling of ybug is pleasing :)~~ Comparable to ybug in the same tests, which is probably a good place to be.

@mossblaser - If you wanted to be nerd-sniped then introducing trollius back into the equation might be interesting.

 - [x] Move the packing bytes into the SDP header struct packing
 - [x] Investigate improving the efficiency of packing SDP packets (particularly fewer string add operations and more memoryview/bytearray writes).