### PR TITLE
Remove Python 3.3 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: python
 python:
         - 2.7
-        - 3.3
         - 3.4
 install:
         - python setup.py install

--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ Python Version Support
 Rig is tested against the following versions of Python:
 
 * 2.7
-* 3.3
 * 3.4
 
 Other versions may or may not work.

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
 
         "Topic :: Software Development :: Libraries",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, pep8
+envlist = py27, py34, pep8
 
 [testenv]
 deps =


### PR DESCRIPTION
As proposed in #76, official support (and thus test infrastructure) for Python
3.3 has been dropped.