### PR TITLE
Buffered writes

### DIFF
--- a/docs/source/control_tutorials.rst
+++ b/docs/source/control_tutorials.rst
@@ -195,12 +195,35 @@ constrained to the allocated region. ::
     >>> block.read(13)
     b"Hello, world!"
 
-These blocks can also be sliced to allow a single allocation to be safely
-divided between different parts of the application::
+Writes can be optionally buffered before being transmitted to the SpiNNaker
+board.  This can be configured by using the `buffer_size` keyword argument::
+
+    >>> # Allocate 1024 bytes of SDRAM with tag '3' on chip (0, 0) with a
+    >>> # 256-byte write buffer
+    >>> block = mc.sdram_alloc_as_filelike(1024, 3, 0, 0, buffer_size=256)
+    >>> block.buffer_size
+    256
+
+If buffering is used then
+:py:meth:`~.rig.machine_control.machine_controller.MemoryIO.flush` must be
+called to force writes on a given file-like (and its siblings -- see below) to
+be completed::
+
+   >>> block.seek(0)
+   >>> block.write("Hello")
+   >>> block.flush()
+
+This is not necessary for unbuffered file-like objects (the default).
+
+File-like views of memory can also be sliced to allow a single allocation to be
+safely divided between different parts of the application::
 
     >>> hello = block[0:5]
     >>> hello.read()
     b"Hello"
+
+Slices of the same memory file-like are considered to be siblings and flushing
+one of them will result in flushing of the write buffer for all siblings.
 
 The :py:func:`~rig.machine_control.utils.sdram_alloc_for_vertices` utility
 function is provided to allocate multiple SDRAM blocks simultaneously.  This

--- a/rig/machine_control/machine_controller.py
+++ b/rig/machine_control/machine_controller.py
@@ -1,6 +1,7 @@
 """A high level interface for controlling a SpiNNaker system."""
 
 import collections
+import functools
 import os
 import six
 from six import iteritems
@@ -9,15 +10,15 @@ import struct
 import time
 import pkg_resources
 
-from . import struct_file
 from .consts import SCPCommands, NNCommands, NNConstants, AppFlags, LEDAction
-from . import boot, consts, regions
+from . import boot, consts, regions, struct_file
 from .scp_connection import SCPConnection
 
 from rig import routing_table
 from rig.machine import Cores, SDRAM, SRAM, Links, Machine
 
 from rig.utils.contexts import ContextMixin, Required
+from rig.utils.docstrings import add_signature_to_docstring
 
 
 class MachineController(ContextMixin):
@@ -573,9 +574,17 @@ class MachineController(ContextMixin):
 
     @ContextMixin.use_contextual_arguments()
     def sdram_alloc_as_filelike(self, size, tag=0, x=Required, y=Required,
-                                app_id=Required):
+                                app_id=Required, buffer_size=0):
         """Like :py:meth:`.sdram_alloc` but returns a file-like object which
         allows safe reading and writing to the block that is allocated.
+
+        Other Parameters
+        ----------------
+        buffer_size : int
+            The number of bytes to store in the write buffer for the file-like.
+            If this is set to anything but `0` (the default) then
+            :py:meth:`~.MemoryIO.flush` should be called to ensure that all
+            writes are completed.
 
         Returns
         -------
@@ -592,7 +601,8 @@ class MachineController(ContextMixin):
         # Perform the malloc
         start_address = self.sdram_alloc(size, tag, x, y, app_id)
 
-        return MemoryIO(self, x, y, start_address, start_address + size)
+        return MemoryIO(self, x, y, start_address, start_address + size,
+                        buffer_size=buffer_size)
 
     def _get_next_nn_id(self):
         """Get the next nearest neighbour ID."""
@@ -1378,6 +1388,18 @@ class SpiNNakerLoadingError(Exception):
             "Failed to load applications to cores {}".format(", ".join(cores)))
 
 
+def _if_not_closed(f):
+    """Run the method iff. the memory view hasn't been closed."""
+    @add_signature_to_docstring(f)
+    @functools.wraps(f)
+    def f_(self, *args, **kwargs):
+        if self.closed:
+            raise OSError
+        return f(self, *args, **kwargs)
+
+    return f_
+
+
 class MemoryIO(object):
     """A file-like view into a subspace of the memory-space of a chip.
 
@@ -1395,7 +1417,8 @@ class MemoryIO(object):
         b"Hello"
     """
 
-    def __init__(self, machine_controller, x, y, start_address, end_address):
+    def __init__(self, machine_controller, x, y, start_address, end_address,
+                 buffer_size=0, _write_buffer=None):
         """Create a file-like view onto a subset of the memory-space of a chip.
 
         Parameters
@@ -1411,14 +1434,25 @@ class MemoryIO(object):
             Starting address in memory.
         end_address : int
             End address in memory.
+        buffer_size : int
+            Number of bytes to store in the write buffer.
+        _write_buffer : :py:class:`._WriteBufferChild`
+            Internal use only, the write buffer to use to combine writes.
 
         If `start_address` is greater or equal to `end_address` then
         `end_address` is ignored and `start_address` is used instead.
         """
         # Store parameters
+        self.closed = False
         self._x = x
         self._y = y
         self._machine_controller = machine_controller
+
+        # Get, or create, a write buffer
+        if _write_buffer is None:
+            _write_buffer = _WriteBuffer(x, y, 0, machine_controller,
+                                         buffer_size)
+        self._write_buffer = _write_buffer
 
         # Store and clip the addresses
         self._start_address = start_address
@@ -1426,6 +1460,17 @@ class MemoryIO(object):
 
         # Current offset from start address
         self._offset = 0
+
+    @property
+    def buffer_size(self):
+        """Return the number of bytes in the write buffer."""
+        return self._write_buffer.buffer_size
+
+    def close(self):
+        """Flush and close the file-like."""
+        if not self.closed:
+            self.flush()
+            self.closed = True
 
     def __getitem__(self, sl):
         """Get a new file-like view of SDRAM covering the range indicated by
@@ -1470,7 +1515,8 @@ class MemoryIO(object):
             # Construct the new file-like
             return type(self)(
                 self._machine_controller, self._x, self._y,
-                start_address, end_address
+                start_address, end_address,
+                _write_buffer=self._write_buffer
             )
         else:
             raise ValueError("Can only make contiguous slices of MemoryIO")
@@ -1479,6 +1525,15 @@ class MemoryIO(object):
         """Return the number of bytes in the file-like view of SDRAM."""
         return self._end_address - self._start_address
 
+    def __enter__(self):
+        """Enter a new block which will call :py:meth:`~.close` when exited."""
+        return self
+
+    def __exit__(self, exception_type, exception_value, traceback):
+        """Exit a block and call :py:meth:`~.close`."""
+        self.close()
+
+    @_if_not_closed
     def read(self, n_bytes=-1):
         """Read a number of bytes from the memory.
 
@@ -1496,6 +1551,9 @@ class MemoryIO(object):
         :py:class:`bytes`
             Data read from SpiNNaker as a bytestring.
         """
+        # Flush this write buffer
+        self.flush()
+
         # If n_bytes is negative then calculate it as the number of bytes left
         if n_bytes < 0:
             n_bytes = self._end_address - self.address
@@ -1513,8 +1571,15 @@ class MemoryIO(object):
         self._offset += n_bytes
         return data
 
+    @_if_not_closed
     def write(self, bytes):
         """Write data to the memory.
+
+        .. warning::
+            If the buffer size is not zero then writes may be buffered (and
+            even overwritten) before being written to the machine.
+            :py:meth:`~.flush` must be called to ensure that all writes are
+            completed when required.
 
         .. note::
             Writes beyond the specified memory range will be truncated.
@@ -1538,11 +1603,20 @@ class MemoryIO(object):
             bytes = bytes[:n_bytes]
 
         # Perform the write and increment the offset
-        self._machine_controller.write(
-            self.address, bytes, self._x, self._y, 0)
+        self._write_buffer.add_new_write(self.address, bytes)
         self._offset += len(bytes)
         return len(bytes)
 
+    @_if_not_closed
+    def flush(self):
+        """Flush any buffered writes.
+
+        This must be called to ensure that all writes to SpiNNaker made using
+        this file-like object (and its siblings, if any) are completed.
+        """
+        self._write_buffer.flush()
+
+    @_if_not_closed
     def tell(self):
         """Get the current offset in the memory region.
 
@@ -1554,11 +1628,13 @@ class MemoryIO(object):
         return self._offset
 
     @property
+    @_if_not_closed
     def address(self):
         """Get the current hardware memory address (indexed from 0x00000000).
         """
         return self._offset + self._start_address
 
+    @_if_not_closed
     def seek(self, n_bytes, from_what=os.SEEK_SET):
         """Seek to a new position in the memory region.
 
@@ -1589,6 +1665,80 @@ class MemoryIO(object):
                 "from_what: can only take values 0 (from start), "
                 "1 (from current) or 2 (from end) not {}".format(from_what)
             )
+
+
+class _WriteBuffer(object):
+    """Write buffer used by :py:class:`.MemoryIO` to combine multiple writes
+    together.
+    """
+
+    def __init__(self, x, y, p, controller, buffer_size=0):
+        self.x = x
+        self.y = y
+        self.p = p
+        self.controller = controller
+
+        # A buffer of writes
+        self.buffer = bytearray(buffer_size)
+        self.start_address = None
+
+        self.current_end = 0
+        self.buffer_size = buffer_size
+
+    def add_new_write(self, start_address, data):
+        """Add a new write to the buffer."""
+        if len(data) > self.buffer_size:
+            # Perform the write if we couldn't buffer it at all
+            self.flush()  # Flush to ensure ordering is preserved
+            self.controller.write(start_address, data,
+                                  self.x, self.y, self.p)
+            return
+
+        if self.start_address is None:
+            # No value currently buffered, add this one
+            self.start_address = start_address
+
+        # If we can fit this write into the buffer then include it,
+        # otherwise we flush the current buffer and start again
+        start_offset = start_address - self.start_address
+        end_offset = start_offset + len(data)  # Byte AFTER the end of the data
+
+        if start_offset <= self.current_end and end_offset <= self.buffer_size:
+            # The write is entirely contained within the buffer and starts
+            # within the area of the buffer which already contains data, so we
+            # can just modify the buffer.
+            self.buffer[start_offset:end_offset] = data
+            self.current_end = max(end_offset, self.current_end)
+        else:
+            # The write either starts outside the used area of the buffer, or
+            # would overflow the buffer.
+            if start_offset < self.buffer_size:
+                # We would overflow the buffer, so store as much into the
+                # buffer as possible.
+                end = self.buffer_size - start_offset
+                self.buffer[start_offset:] = data[:end]
+                self.current_end = self.buffer_size
+
+                # Then prepare the next block of data for buffering
+                start_address += end
+                data = data[end:]
+
+            # Flush the buffer before storing the next write
+            self.flush()
+            self.add_new_write(start_address, data)
+
+    def flush(self):
+        """Write the current buffer out."""
+        if self.start_address is not None:
+            # Write out all the values from the buffer
+            self.controller.write(
+                self.start_address, self.buffer[:self.current_end],
+                self.x, self.y, self.p
+            )
+
+            # Reset the buffer
+            self.start_address = None
+            self.current_end = 0
 
 
 def unpack_routing_table_entry(packed):

--- a/tests/machine_control/test_machine_controller.py
+++ b/tests/machine_control/test_machine_controller.py
@@ -660,19 +660,21 @@ class TestMachineController(object):
         assert str((x, y)) in str(excinfo.value)
         assert str(size) in str(excinfo.value)
 
-    @pytest.mark.parametrize("x, y", [(0, 1), (3, 4)])
-    @pytest.mark.parametrize("app_id", [30, 33])
-    @pytest.mark.parametrize("size", [8, 200])
-    @pytest.mark.parametrize("tag", [0, 2])
-    @pytest.mark.parametrize("addr", [0x67000000, 0x61000000])
-    def test_sdram_alloc_as_filelike(self, app_id, size, tag, addr, x, y):
+    @pytest.mark.parametrize(
+        "x, y, app_id, tag, addr, size, buffer_size",
+        [(0, 1, 30, 8, 0x67800000, 100, 20),
+         (3, 4, 33, 2, 0x12134560, 300, 100)]
+    )
+    def test_sdram_alloc_as_filelike(self, app_id, size, tag, addr, x, y,
+                                     buffer_size):
         """Test allocing and getting a file-like object returned."""
         # Create the mock controller
         cn = MachineController("localhost")
         cn.sdram_alloc = mock.Mock(return_value=addr)
 
         # Try the allocation
-        fp = cn.sdram_alloc_as_filelike(size, tag, x, y, app_id=app_id)
+        fp = cn.sdram_alloc_as_filelike(size, tag, x, y, app_id=app_id,
+                                        buffer_size=buffer_size)
 
         # Check the fp has the expected start and end
         assert fp._start_address == addr
@@ -682,6 +684,9 @@ class TestMachineController(object):
         assert fp._machine_controller is cn
         assert fp._x == x
         assert fp._y == y
+
+        # Check the buffer size
+        assert fp.buffer_size == buffer_size
 
     @pytest.mark.parametrize("x, y, p", [(0, 1, 2), (2, 5, 6)])
     @pytest.mark.parametrize(
@@ -1576,22 +1581,26 @@ class TestMemoryIO(object):
 
     @pytest.mark.parametrize("x, y", [(4, 2), (255, 1)])
     @pytest.mark.parametrize("start_address", [0x60000004, 0x61000003])
-    @pytest.mark.parametrize("lengths", [[100, 200], [100], [300, 128, 32]])
+    @pytest.mark.parametrize("lengths", [[1, 2], [1], [3, 2, 4]])
     def test_write(self, mock_controller, x, y, start_address, lengths):
         sdram_file = MemoryIO(mock_controller, x, y,
                               start_address, start_address+500)
         assert sdram_file.tell() == 0
+        assert sdram_file.buffer_size == 0
 
         # Perform the reads, check that the address is progressed
         calls = []
         offset = 0
         for i, n_bytes in enumerate(lengths):
-            n_written = sdram_file.write(chr(i % 256) * n_bytes)
+            chars = bytes(bytearray([i] * n_bytes))
+            n_written = sdram_file.write(chars)
+
             assert n_written == n_bytes
             assert sdram_file.tell() == offset + n_bytes
             assert sdram_file.address == start_address + offset + n_bytes
+
             calls.append(mock.call(start_address + offset,
-                                   chr(i % 256) * n_bytes, x, y, 0))
+                                   chars, x, y, 0))
             offset = offset + n_bytes
 
         # Check the reads caused the appropriate calls to the machine
@@ -1605,7 +1614,38 @@ class TestMemoryIO(object):
         assert sdram_file.write(b"\x00\x00" * 12) == 10
 
         assert sdram_file.write(b"\x00") == 0
+        sdram_file.flush()
+
         assert mock_controller.write.call_count == 1
+
+    def test_close(self, mock_controller):
+        sdram_file = MemoryIO(mock_controller, 0, 0,
+                              start_address=0, end_address=10)
+
+        # Assert that after closing a file pointer it will not do anything
+        assert not sdram_file.closed
+        sdram_file.close()
+        assert sdram_file.closed
+        sdram_file.close()  # This shouldn't do anything
+
+        # Nothing else should work
+        with pytest.raises(OSError):
+            sdram_file.flush()
+
+        with pytest.raises(OSError):
+            sdram_file.tell()
+
+        with pytest.raises(OSError):
+            sdram_file.seek(0)
+
+        with pytest.raises(OSError):
+            sdram_file.read(1)
+
+        with pytest.raises(OSError):
+            sdram_file.write(b'\x00')
+
+        with pytest.raises(OSError):
+            sdram_file.address
 
     @pytest.mark.parametrize("start_address", [0x60000004, 0x61000003])
     @pytest.mark.parametrize("seeks", [(100, -3, 32, 5, -7)])
@@ -1742,6 +1782,128 @@ class TestMemoryIO(object):
         assert len(new_file) == 0
         assert new_file._start_address == 110
         assert new_file._end_address == 110
+
+    @pytest.mark.parametrize(
+        "get_node",
+        [lambda w, x, y, z: w,
+         lambda w, x, y, z: x,
+         lambda w, x, y, z: y,
+         lambda w, x, y, z: z,
+         ]
+    )
+    @pytest.mark.parametrize(
+        "flush_event",
+        [lambda filelike: filelike.flush(),
+         lambda filelike: filelike.read(1),
+         lambda filelike: filelike.close()]
+    )
+    def test_coalescing_writes(self, get_node, flush_event):
+        """Tests that writes from multiple slices of the same file-like view of
+        memory are buffered until some event occurs which flushes the buffer.
+        """
+        # Set up
+        cn = mock.Mock(spec_set=MachineController)
+        parent = MemoryIO(cn, 5, 6, 0, 8, buffer_size=8)
+        child_0 = parent[:4]
+        child_00 = child_0[2:]
+        child_1 = parent[4:]
+
+        # Writes to child 0 followed by writes to child 1 should NOT result in
+        # any writes
+        child_00.write(b'\x10\x20')
+        child_1.write(b'\x30\x40')
+        assert not cn.write.called  # No write should have occurred
+
+        # Performing the flush event on one of the children OR the parent
+        flush_event(get_node(parent, child_0, child_00, child_1))
+
+        # The write should have been performed
+        cn.write.assert_called_once_with(2, b'\x10\x20\x30\x40', 5, 6, 0)
+
+    def test_coalescing_writes_flushes_on_non_coalesced_write(self):
+        """Tests that writes from multiple slices of the same file-like view of
+        memory are buffered until a non-contiguous write occurs.
+        """
+        # Set up
+        cn = mock.Mock(spec_set=MachineController)
+        parent = MemoryIO(cn, 9, 2, 0, 8, buffer_size=8)
+
+        with parent:
+            child_0 = parent[:4]
+            child_1 = parent[4:]
+
+            child_0.write(b'\x12')  # Does not meet child 1
+            child_1.write(b'\x30\x40')
+
+        # The writes should have been performed
+        cn.write.assert_any_calls([
+            mock.call(0, b'\x12', 9, 2, 0),
+            mock.call(4, b'\x30\x40', 9, 2, 0),
+        ])
+
+    def test_buffer_overflows(self):
+        """Tests that writes from multiple slices of the same file-like view of
+        memory are buffered until a non-contiguous write occurs.
+        """
+        # Set up
+        cn = mock.Mock(spec_set=MachineController)
+        parent = MemoryIO(cn, 9, 2, 0, 8, buffer_size=3)
+
+        with parent:
+            child_0 = parent[:4]
+            child_1 = parent[4:]
+
+            child_0.seek(2)
+            child_0.write(b'AB')
+            child_1.write(b'CD')
+
+        # The writes should have been performed
+        cn.write.assert_has_calls([
+            mock.call(2, b'ABC', 9, 2, 0),
+            mock.call(5, b'D', 9, 2, 0),
+        ])
+
+    def test_completely_non_coalesced(self):
+        """Tests that writes from multiple slices of the same file-like view of
+        memory are buffered until a non-contiguous write occurs.
+        """
+        # Set up
+        cn = mock.Mock(spec_set=MachineController)
+        parent = MemoryIO(cn, 9, 2, 0, 8, buffer_size=2)
+
+        with parent:
+            child_0 = parent[:4]
+            child_1 = parent[4:]
+
+            child_0.write(b'AB')
+            child_1.write(b'CD')
+
+        # The writes should have been performed
+        cn.write.assert_has_calls([
+            mock.call(0, b'AB', 9, 2, 0),
+            mock.call(4, b'CD', 9, 2, 0),
+        ])
+
+    def test_coalescing_writes_overwrites(self):
+        """Test that multiple writes to the same area of memory are buffered
+        until flushed.
+        """
+        # Set up
+        cn = mock.Mock(spec_set=MachineController)
+        parent = MemoryIO(cn, 9, 2, 0, 8, buffer_size=8)
+
+        # None of these writes should flush the buffer
+        for start, data in [(0, b'\x44'*8), (2, b'\x22'), (7, b'\x00')]:
+            parent.seek(start)
+            assert not cn.write.called
+            parent.write(data)
+            assert not cn.write.called
+
+        # The write should have been performed
+        parent.flush()
+        cn.write.assert_called_once_with(
+            0, b'\x44\x44\x22\x44\x44\x44\x44\x00', 9, 2, 0
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
As suggested in #124.

Allows writes to be buffered.  A `flush` method and `with` manager are provided to ensure that writes are completed.

The following events flush write buffers:
 - `flush`
 - `seek`
 - `read`
 - A non-coalesced `write`

The following are equivalent:
```python
f.seek(0)
f.write(b"Hello, world")
f.flush()
```
```python
with f:
    f.seek(0)
    f.write(b"Hello, world")
```
 - [x] Stop seek from flushing
 - [x] Set buffer sizes
 - [x] Overwrite buffered values
 - [x] Writing when receiving values > buffer size
 - [x] `close`