### PR TITLE
Include buffer_size in sdram_alloc_for_vertices

### DIFF
--- a/rig/machine_control/utils.py
+++ b/rig/machine_control/utils.py
@@ -3,7 +3,7 @@ from ..machine import Cores, SDRAM
 
 
 def sdram_alloc_for_vertices(controller, placements, allocations,
-                             core_as_tag=True,
+                             core_as_tag=True, buffer_size=0,
                              sdram_resource=SDRAM, cores_resource=Cores):
     """Allocate and return a file-like view of a region of SDRAM for each
     vertex which uses SDRAM as a resource.
@@ -46,6 +46,9 @@ def sdram_alloc_for_vertices(controller, placements, allocations,
     core_as_tag : bool
         Use the index of the first allocated core as the tag for the region of
         memory, otherwise 0 will be used.
+    buffer_size : int
+        Size of write buffer (in bytes) to allocate to _each_ file-like object
+        created by this method.
     sdram_resource : resource (default :py:class:`~rig.machine.SDRAM`)
         Key used to indicate SDRAM usage in the resources dictionary.
     cores_resource : resource (default :py:class:`~rig.machine.Cores`)
@@ -82,6 +85,7 @@ def sdram_alloc_for_vertices(controller, placements, allocations,
 
             # Get the memory
             vertex_memory[vertex] = controller.sdram_alloc_as_filelike(
-                size, tag, x=x, y=y)
+                size, tag, x=x, y=y, buffer_size=buffer_size
+            )
 
     return vertex_memory

--- a/tests/machine_control/test_machine_control_utils.py
+++ b/tests/machine_control/test_machine_control_utils.py
@@ -8,7 +8,8 @@ from rig.machine import Cores, SDRAM
 
 
 @pytest.mark.parametrize("core_as_tag", [True, False])
-def test_sdram_alloc_for_vertices(core_as_tag):
+@pytest.mark.parametrize("buffer_size", [None, 400])
+def test_sdram_alloc_for_vertices(core_as_tag, buffer_size):
     """Test allocing and getting a map of vertices to file-like objects
     when multiple blocks of memory are requested.
     """
@@ -42,8 +43,12 @@ def test_sdram_alloc_for_vertices(core_as_tag):
 
     # Perform the SDRAM allocation
     with cn(app_id=33):
+        kwargs = dict(core_as_tag=core_as_tag)
+        if buffer_size is not None:
+            kwargs["buffer_size"] = buffer_size
+
         allocs = sdram_alloc_for_vertices(cn, placements, allocations,
-                                          core_as_tag=core_as_tag)
+                                          **kwargs)
 
     # Ensure the correct calls were made to sdram_alloc
     cn.sdram_alloc.assert_has_calls([
@@ -61,6 +66,7 @@ def test_sdram_alloc_for_vertices(core_as_tag):
     if core_as_tag:
         assert allocs[vertices[0]]._start_address == 0x67800000
         assert allocs[vertices[0]]._end_address == 0x67800000 + 400
+    assert allocs[vertices[0]].buffer_size == 0 or buffer_size
 
     assert isinstance(allocs[vertices[1]], MemoryIO)
     assert allocs[vertices[1]]._x == 0
@@ -69,6 +75,7 @@ def test_sdram_alloc_for_vertices(core_as_tag):
     if core_as_tag:
         assert allocs[vertices[1]]._start_address == 0x60000000
         assert allocs[vertices[1]]._end_address == 0x60000000 + 200
+    assert allocs[vertices[1]].buffer_size == 0 or buffer_size
 
     assert isinstance(allocs[vertices[2]], MemoryIO)
     assert allocs[vertices[2]]._x == 1
@@ -77,3 +84,4 @@ def test_sdram_alloc_for_vertices(core_as_tag):
     if core_as_tag:
         assert allocs[vertices[2]]._start_address == 0x67800000
         assert allocs[vertices[2]]._end_address == 0x67800000 + 100
+    assert allocs[vertices[2]].buffer_size == 0 or buffer_size


### PR DESCRIPTION
Includes the `buffer_size` keyword argument in the utils method `sdram_alloc_for_vertices`.

Fixes #133.