### PR TITLE
Clearer error message on SDRAM allocation failure

### DIFF
--- a/rig/machine_control/machine_controller.py
+++ b/rig/machine_control/machine_controller.py
@@ -639,7 +639,7 @@ class MachineController(ContextMixin):
         rv = self._send_scp(x, y, 0, SCPCommands.alloc_free, arg1, size, tag)
         if rv.arg1 == 0:
             # Allocation failed
-            raise SpiNNakerMemoryError(size, x, y)
+            raise SpiNNakerMemoryError(size, x, y, tag)
         return rv.arg1
 
     @ContextMixin.use_contextual_arguments()
@@ -1421,13 +1421,20 @@ class SpiNNakerMemoryError(Exception):
     """Raised when it is not possible to allocate memory on a SpiNNaker
     chip.
     """
-    def __init__(self, size, x, y):
+    def __init__(self, size, x, y, tag=0):
         self.size = size
         self.chip = (x, y)
+        self.tag = tag
 
     def __str__(self):
-        return ("Failed to allocate {} bytes of SDRAM on chip ({}, {})".
-                format(self.size, self.chip[0], self.chip[1]))
+        if self.tag == 0:
+            return ("Failed to allocate {} bytes of SDRAM on chip ({}, {}). "
+                    "Insufficient memory available.".
+                    format(self.size, self.chip[0], self.chip[1]))
+        else:
+            return ("Failed to allocate {} bytes of SDRAM on chip ({}, {}). "
+                    "Insufficient memory available or tag {} already in use.".
+                    format(self.size, self.chip[0], self.chip[1], self.tag))
 
 
 class SpiNNakerRouterError(Exception):

--- a/tests/machine_control/test_machine_controller.py
+++ b/tests/machine_control/test_machine_controller.py
@@ -659,8 +659,8 @@ class TestMachineController(object):
                                              size, tag)
 
     @pytest.mark.parametrize("x, y", [(1, 3), (5, 6)])
-    @pytest.mark.parametrize("size", [8, 200])
-    def test_sdram_alloc_fail(self, x, y, size):
+    @pytest.mark.parametrize("size, tag", [(8, 0), (200, 2)])
+    def test_sdram_alloc_fail(self, x, y, size, tag):
         """Test that sdram_alloc raises an exception when ALLOC fails."""
         # Create the mock controller
         cn = MachineController("localhost")
@@ -669,10 +669,16 @@ class TestMachineController(object):
                                               0x80, 0, 0, None, None, b"")
 
         with pytest.raises(SpiNNakerMemoryError) as excinfo:
-            cn.sdram_alloc(size, x=x, y=y, app_id=30)
+            cn.sdram_alloc(size, tag=tag, x=x, y=y, app_id=30)
 
         assert str((x, y)) in str(excinfo.value)
         assert str(size) in str(excinfo.value)
+
+        if tag == 0:
+            assert "tag" not in str(excinfo.value)
+        else:
+            assert "tag" in str(excinfo.value)
+            assert str(tag) in str(excinfo.value)
 
     @pytest.mark.parametrize(
         "x, y, app_id, tag, addr, size, buffer_size",


### PR DESCRIPTION
The error message returned when allocating SDRAM fails isn't clear that
the cause can be either that there is insufficient memory OR that the
tag assigned to the allocation is already in use.

This is now changed so that when insufficient memory is definitely the
cause (only when tag == 0) the tag is not mentioned, but that the tag is
mentioned when it may be the problem.