### PR TITLE
Correct core mask in application loading

### DIFF
--- a/rig/machine_control/machine_controller.py
+++ b/rig/machine_control/machine_controller.py
@@ -715,7 +715,7 @@ class MachineController(ContextMixin):
     def _send_ffe(self, pid, app_id, app_flags, cores, fr):
         """Send a flood-fill end packet."""
         arg1 = (NNCommands.flood_fill_end << 24) | pid
-        arg2 = (app_id << 24) | (app_flags << 18) | (cores & 0x3fff)
+        arg2 = (app_id << 24) | (app_flags << 18) | (cores & 0x3ffff)
         self._send_scp(0, 0, 0, SCPCommands.nearest_neighbour_packet,
                        arg1, arg2, fr)
 

--- a/tests/machine_control/test_machine_controller.py
+++ b/tests/machine_control/test_machine_controller.py
@@ -944,7 +944,8 @@ class TestMachineController(object):
 
     @pytest.mark.parametrize(
         "app_id, wait, cores",
-        [(31, False, [1, 2, 3]), (12, True, [5])]
+        [(31, False, [1, 2, 3]), (12, True, [5]),
+         (66, False, list(range(1, 18)))]
     )
     @pytest.mark.parametrize("present_map", [False, True])
     def test_flood_fill_aplx_single_aplx(self, cn, aplx_file, app_id, wait,
@@ -1030,7 +1031,6 @@ class TestMachineController(object):
             cn._send_scp.call_args_list[-1][0]
         assert x_ == x and y_ == y and p_ == p
         assert cmd == SCPCommands.nearest_neighbour_packet
-        print(hex(NNCommands.flood_fill_end << 24))
         assert arg1 & 0xff000000 == NNCommands.flood_fill_end << 24
         assert arg2 & 0xff000000 == app_id << 24
         assert arg2 & 0x0003ffff == coremask


### PR DESCRIPTION
Applications previously couldn't be loaded onto cores 14..17 because the core mask was masked with 4 fewer bits than it needed.

Fixes #144.

@neworderofjamie can you check this seems sane please?  I think Jonathan is on holiday.