### PR TITLE
Simulated annealing based placement

### DIFF
--- a/docs/source/place_and_route/placement_algorithms.rst
+++ b/docs/source/place_and_route/placement_algorithms.rst
@@ -1,4 +1,6 @@
 Placement algorithms
 --------------------
 
+.. autofunction:: rig.place_and_route.place.sa.place
+
 .. autofunction:: rig.place_and_route.place.hilbert.place

--- a/rig/machine.py
+++ b/rig/machine.py
@@ -100,6 +100,12 @@ class Links(IntEnum):
     def to_vector(self):
         """Given a link direction, return the equivalent vector."""
         return _direction_link_lookup[self]
+    
+    
+    @property
+    def opposite(self):
+        """Get the opposite link to the one given."""
+        return Links((self + 3) % 6)
 
 
 _link_direction_lookup = {

--- a/rig/machine.py
+++ b/rig/machine.py
@@ -203,6 +203,18 @@ class Machine(object):
             self.chip_resources, self.chip_resource_exceptions,
             self.dead_chips, self.dead_links)
 
+    def __eq__(self, other):
+        """Test whether this Machine describes the same machine as another."""
+        return (self.width == other.width and
+                self.height == other.height and
+                self.chip_resources == other.chip_resources and
+                all(self[chip] == other[chip]
+                    for chip in self.chip_resource_exceptions) and
+                all(self[chip] == other[chip]
+                    for chip in other.chip_resource_exceptions) and
+                self.dead_chips == other.dead_chips and
+                self.dead_links == other.dead_links)
+
     def __contains__(self, chip_or_link):
         """Test if a given chip or link is present and alive.
 

--- a/rig/machine.py
+++ b/rig/machine.py
@@ -100,8 +100,7 @@ class Links(IntEnum):
     def to_vector(self):
         """Given a link direction, return the equivalent vector."""
         return _direction_link_lookup[self]
-    
-    
+
     @property
     def opposite(self):
         """Get the opposite link to the one given."""

--- a/rig/netlist.py
+++ b/rig/netlist.py
@@ -41,3 +41,9 @@ class Net(object):
     def __contains__(self, vertex):
         """Test if a supplied vertex is a source or sink of this net."""
         return vertex == self.source or vertex in self.sinks
+    
+    def __iter__(self):
+        """Iterate over all vertices in the net, starting with the source."""
+        yield self.source
+        for vertex in self.sinks:
+            yield vertex

--- a/rig/netlist.py
+++ b/rig/netlist.py
@@ -41,7 +41,7 @@ class Net(object):
     def __contains__(self, vertex):
         """Test if a supplied vertex is a source or sink of this net."""
         return vertex == self.source or vertex in self.sinks
-    
+
     def __iter__(self):
         """Iterate over all vertices in the net, starting with the source."""
         yield self.source

--- a/rig/place_and_route/__init__.py
+++ b/rig/place_and_route/__init__.py
@@ -6,7 +6,7 @@ the use of these functions.
 """
 
 # Default algorithms
-from .place.hilbert import place
+from .place.sa import place
 from .allocate.greedy import allocate
 from .route.ner import route
 

--- a/rig/place_and_route/place/hilbert.py
+++ b/rig/place_and_route/place/hilbert.py
@@ -12,7 +12,7 @@ from ..exceptions import InsufficientResourceError, InvalidConstraintError
 from ..constraints import LocationConstraint, ReserveResourceConstraint
 
 from .utils import \
-    subtract_resources, overallocated, resources_after_reservation
+    subtract_resources, overallocated, apply_reserve_resource_constraint
 
 
 def hilbert(level, angle=1, s=None):
@@ -118,20 +118,7 @@ def place(vertices_resources, nets, machine, constraints):
             unplaced_vertices.remove(constraint.vertex)
             placements[constraint.vertex] = loc
         elif isinstance(constraint, ReserveResourceConstraint):
-            if constraint.location is None:
-                # Compensate for globally reserved resources
-                machine.chip_resources \
-                    = resources_after_reservation(
-                        machine.chip_resources, constraint)
-                for location in machine.chip_resource_exceptions:
-                    machine.chip_resource_exceptions[location] \
-                        = resources_after_reservation(
-                            machine.chip_resource_exceptions[location],
-                            constraint)
-            else:
-                # Compensate for reserved resources at a specified location
-                machine[constraint.location] = resources_after_reservation(
-                    machine[constraint.location], constraint)
+            apply_reserve_resource_constraint(machine, constraint)
 
     # Allocate chips along a Hilbert curve large enough to cover the whole
     # system

--- a/rig/place_and_route/place/sa.py
+++ b/rig/place_and_route/place/sa.py
@@ -197,7 +197,7 @@ def _net_cost(net, placements, has_wrap_around_links, machine):
             x2 = x if x > x2 else x2
             y2 = y if y > y2 else y2
 
-        return (abs(x1 - x2) + abs(y1 - y2)) * float(net.weight)
+        return ((x2 - x1) + (y2 - y1)) * float(net.weight)
 
 
 def _vertex_net_cost(vertex, v2n, placements, has_wrap_around_links, machine):

--- a/rig/place_and_route/place/sa.py
+++ b/rig/place_and_route/place/sa.py
@@ -1,493 +1,733 @@
 """An experimental simulated-annealing based placer."""
 
-from six import iteritems, iterkeys, itervalues
-
-import random
 import math
-import heapq
+import logging
 
-from rig.place_and_route.place.hilbert import hilbert
+# This is renamed to ensure that all function correctly use the random number
+# generator passed into them.
+import random as default_random
+
+from six import iteritems, next
+
+from rig.place_and_route.constraints import \
+    LocationConstraint, ReserveResourceConstraint
 
 from rig.place_and_route.exceptions import \
     InvalidConstraintError, InsufficientResourceError
 
 from rig.place_and_route.place.utils import \
     add_resources, subtract_resources, overallocated, \
-    resources_after_reservation
+    apply_reserve_resource_constraint
 
 
-def _initial_placement(movable_vertices, vertices_resources, machine):
-    """For internal use. Produces a random, sequential initial placement.
-    
-    Also updates the resource availability of each chip in the machine.
+"""
+This logger is used by the annealing algorithm to indicate progress.
+"""
+logger = logging.getLogger(__name__)
+
+
+def _initial_placement(movable_vertices, vertices_resources, machine, random):
+    """For internal use. Produces a random, sequential initial placement,
+    updating the resource availabilities of every core in the supplied machine.
+
+    Parameters
+    ----------
+    movable_vertices : [vertex, ...]
+        A list of the vertices to be given a random initial placement.
+    vertices_resources : {vertex: {resource: value, ...}, ...}
+    machine : :py:class:`rig.machine.Machine`
+        A machine object describing the machine into which the vertices should
+        be placed.
+
+        All chips hosting fixed vertices should have a chip_resource_exceptions
+        entry which accounts for the allocated resources.
+
+        When this function returns, the machine.chip_resource_exceptions will
+        be updated to account for the resources consumed by the initial
+        placement of movable vertices.
+    random : :py:class`random.Random`
+        The random number generator to use
+
+    Returns
+    -------
+    {vertex: (x, y), ...}
+        For all movable_vertices.
+
+    Raises
+    ------
+    InsufficientResourceError
+    InvalidConstraintError
     """
-    # Allocate chips along a Hilbert curve large enough to cover the whole
-    # system
-    max_dimen = max(machine.width, machine.height)
-    hilbert_levels = int(math.ceil(math.log(max_dimen, 2.0))) if max_dimen >= 1 else 0
-    location_iter = hilbert(hilbert_levels)
-    
-    placement = {}
+    # Initially fill chips in the system in a random order
+    locations = [(x, y)
+                 for x in range(machine.width)
+                 for y in range(machine.height)
+                 if (x, y) in machine]
+    random.shuffle(locations)
+    location_iter = iter(locations)
+
+    # Greedily place the vertices in a random order
     random.shuffle(movable_vertices)
     vertex_iter = iter(movable_vertices)
-    location = next(location_iter)
+
+    placement = {}
+    try:
+        location = next(location_iter)
+    except StopIteration:
+        raise InsufficientResourceError("No working chips in system.")
     while True:
         # Get a vertex to place
         try:
             vertex = next(vertex_iter)
         except StopIteration:
+            # All vertices have been placed
             break
-        
-        # Advance through the set of available locations until we can find a
-        # chip where the vertex fits
+
+        # Advance through the set of available locations until we find a chip
+        # where the vertex fits
         while True:
-            try:
-                if location not in machine:
+            resources_if_placed = subtract_resources(
+                machine[location], vertices_resources[vertex])
+
+            if overallocated(resources_if_placed):
+                # The vertex won't fit on this chip, move onto the next chip
+                try:
                     location = next(location_iter)
                     continue
-                
-                resources_if_placed = subtract_resources(
-                    machine[location], vertices_resources[vertex])
-                
-                if overallocated(resources_if_placed):
-                    # Didn't fit, try the next chip
-                    location = next(location_iter)
-                    continue
-            except StopIteration:
-                raise InsufficientResourceError(
-                    "Ran out of chips while attempting to place vertex "
-                    "{}".format(vertex))
+                except StopIteration:
+                    raise InsufficientResourceError(
+                        "Ran out of chips while attempting to place vertex "
+                        "{}".format(vertex))
             else:
-                # The vertex fit, note the consumed resources and move on to the
-                # next vertex
+                # The vertex fits: record the resources consumed and move on to
+                # the next vertex.
                 placement[vertex] = location
                 machine[location] = resources_if_placed
                 break
-    
+
     return placement
 
 
-def _net_bb(net, placement):
-    """Get the bounding-box (x1,y1, x2,y2) for the vertices in a given net."""
-    # XXX: This does not account for the hexagonal, nor torus-properties of the
-    # SpiNNaker topology.
-    x1, y1 = x2, y2 = placement[net.source]
-    for vertex in net.sinks:
-        x, y = placement[vertex]
-        x1 = x if x < x1 else x1
-        y1 = y if y < y1 else y1
-        x2 = x if x > x2 else x2
-        y2 = y if y > y2 else y2
-    return (x1, y1, x2, y2)
+def _net_cost(net, placements, has_wrap_around_links, machine):
+    """Get the cost of a given net.
+
+    This function, in principle at least, should estimate the total network
+    resources consumed by the given net. In practice this estimate is based on
+    the size of the bounding-box of the net (i.e. HPWL). This should be
+    improved at some later time to better account for the effects of large
+    fan-outs.
+
+    Parameters
+    ----------
+    net : :py:class:`rig.netlist.Net`
+    placements : {vertex: (x, y), ...}
+    has_wrap_around_links : bool
+    machine : :py:class:`rig.machine.Machine`
+
+    Returns
+    -------
+    float
+    """
+    # This function is by far the hottest code in the entire algorithm, as a
+    # result, small performance improvements in here can have significant
+    # impact on the runtime of the overall algorithm. As an unfortunate side
+    # effect, this code is rather ugly since many higher-level constructs (e.g.
+    # min/max) are outrageously slow.
+
+    # XXX: This does not account for the hexagonal properties of the SpiNNaker
+    # topology.
+    if has_wrap_around_links:
+        # When wrap-around links exist, we find the minimal bounding box and
+        # return the HPWL weighted by the net weight. To do this the largest
+        # gap between any pair of vertices is found::
+        #
+        #     |    x     x             x   |
+        #                ^-------------^
+        #                    max gap
+        #
+        # The minimal bounding box then goes the other way around::
+        #
+        #     |    x     x             x   |
+        #      ----------^             ^---
+
+        # First we collect the x and y coordinates of all vertices in the net
+        # into a pair of (sorted) lists, xs and ys.
+        x, y = placements[net.source]
+        num_vertices = len(net.sinks) + 1
+        xs = [x] * num_vertices
+        ys = [y] * num_vertices
+        i = 1
+        for v in net.sinks:
+            x, y = placements[v]
+            xs[i] = x
+            ys[i] = y
+            i += 1
+
+        xs.sort()
+        ys.sort()
+
+        # The minimal bounding box is then found as above.
+        x_max_delta = 0
+        last_x = xs[-1] - machine.width
+        for x in xs:
+            delta = x - last_x
+            last_x = x
+            if delta > x_max_delta:
+                x_max_delta = delta
+
+        y_max_delta = 0
+        last_y = ys[-1] - machine.height
+        for y in ys:
+            delta = y - last_y
+            last_y = y
+            if delta > y_max_delta:
+                y_max_delta = delta
+
+        return (((machine.width - x_max_delta) +
+                 (machine.height - y_max_delta)) *
+                net.weight)
+    else:
+        # When no wrap-around links, find the bounding box around the vertices
+        # in the net and return the HPWL weighted by the net weight.
+        x1, y1 = x2, y2 = placements[net.source]
+        for vertex in net.sinks:
+            x, y = placements[vertex]
+            x1 = x if x < x1 else x1
+            y1 = y if y < y1 else y1
+            x2 = x if x > x2 else x2
+            y2 = y if y > y2 else y2
+
+        return (abs(x1 - x2) + abs(y1 - y2)) * float(net.weight)
 
 
-def _vertex_net_cost(vertex, v2n, placement):
-    """Get the total cost of the nets connected to the given vertex."""
+def _vertex_net_cost(vertex, v2n, placements, has_wrap_around_links, machine):
+    """Get the total cost of the nets connected to the given vertex.
+
+    Parameters
+    ----------
+    vertex
+        The vertex whose nets we're interested in.
+    v2n : {vertex: [:py:class:`rig.netlist.Net`, ...], ...}
+    placements : {vertex: (x, y), ...}
+    has_wrap_around_links : bool
+    machine : :py:class:`rig.machine.Machine`
+
+    Returns
+    -------
+    float
+    """
     total_cost = 0.0
     for net in v2n[vertex]:
-        x1, y1, x2, y2 = _net_bb(net, placement)
-        net_cost = abs(x1 - x2) + abs(y1 - y2)
-        
-        total_cost += net_cost * net.weight
-    
+        total_cost += _net_cost(net, placements, has_wrap_around_links,
+                                machine)
+
     return total_cost
 
 
-def _get_candidate_swap(resources, location, l2v, vertices_resources,
-                        fixed_vertices, machine):
+def _get_candidate_swap(resources, location,
+                        l2v, vertices_resources, fixed_vertices, machine):
     """Given a chip location, select a set of vertices which would have to be
     moved elsewhere to accommodate the arrival of the specified set of
     resources.
-    
+
     Parameters
     ----------
-    resources
+    resources : {resource: value, ...}
         The amount of resources which are required at the specified location.
     location : (x, y)
-        The chip coordinates from which to find a space.
-    
+        The coordinates of the chip where the resources are sought.
+    l2v : {(x, y): [vertex, ...], ...}
+    vertices_resources : {vertex: {resource: value, ...}, ...}
+    fixed_vertices : {vertex: (x, y), ...}
+    machine : :py:class:`rig.machine.Machine`
+
     Returns
     -------
     [Vertex, ...] or None
-        If None, the situation is impossible.
         If a (possibly empty) list, gives the set of vertices which should be
         removed from the specified location to make room.
+
+        If None, the situation is impossible.
     """
+    # The resources already available at the given location
     chip_resources = machine[location]
-    
+
+    # The set of vertices at that location
     vertices = l2v[location]
-    
+
+    # The set of vertices to be moved from the location to free up the
+    # specified amount of resources
     to_move = []
+
+    # While there's not enough free resource, remove an arbitrary (movable)
+    # vertex from the chip.
     i = 0
     while overallocated(subtract_resources(chip_resources, resources)):
         if i >= len(vertices):
-            # Run out of vertices to remove from this chip, fail
+            # Run out of vertices to remove from this chip, thus the situation
+            # must be impossible.
             return None
-        
-        if vertices[i] in fixed_vertices:
-            # Don't try moving fixed vertices
+        elif vertices[i] in fixed_vertices:
+            # Can't move fixed vertices, just skip them.
             i += 1
             continue
         else:
+            # Work out the cost change when we remove the specified vertex
+            vertex = vertices[i]
             chip_resources = add_resources(chip_resources,
-                                           vertices_resources[vertices[i]])
-            to_move.append(vertices[i])
+                                           vertices_resources[vertex])
+            to_move.append(vertex)
             i += 1
-    
+
     return to_move
 
 
-def _swap(vas, vas_location, vbs, vbs_location, l2v, vertices_resources, placement, machine):
-    """Swap the positions of two sets of vertices: vas and vbs at locations
-    vas_location2v and vbs_location2v."""
+def _swap(vas, vas_location, vbs, vbs_location, l2v, vertices_resources,
+          placements, machine):
+    """Swap the positions of two sets of vertices.
+
+    Parameters
+    ----------
+    vas : [vertex, ...]
+        A set of vertices currently at vas_location.
+    vas_location : (x, y)
+    vbs : [vertex, ...]
+        A set of vertices currently at vbs_location.
+    vbs_location : (x, y)
+    l2v : {(x, y): [vertex, ...], ...}
+    vertices_resources : {vertex: {resource: value, ...}, ...}
+    placements : {vertex: (x, y), ...}
+    machine : :py:class:`rig.machine.Machine`
+    """
+    # Get the lists of vertices at either location
     vas_location2v = l2v[vas_location]
     vbs_location2v = l2v[vbs_location]
-    
+
+    # Get the resource availability at either location
     vas_resources = machine[vas_location]
     vbs_resources = machine[vbs_location]
-    
+
+    # Move all the vertices in vas into vbs.
     for va in vas:
-        placement[va] = vbs_location
+        # Update the placements
+        placements[va] = vbs_location
+
+        # Update the location-to-vertex lookup
         vas_location2v.remove(va)
         vbs_location2v.append(va)
-        
+
+        # Update the resource consumption after the move
         resources = vertices_resources[va]
         vas_resources = add_resources(vas_resources, resources)
         vbs_resources = subtract_resources(vbs_resources, resources)
-    
+
     for vb in vbs:
-        placement[vb] = vas_location
+        # Update the placements
+        placements[vb] = vas_location
+
+        # Update the location-to-vertex lookup
         vbs_location2v.remove(vb)
         vas_location2v.append(vb)
-        
+
+        # Update the resource consumption after the move
         resources = vertices_resources[vb]
         vas_resources = subtract_resources(vas_resources, resources)
         vbs_resources = add_resources(vbs_resources, resources)
-    
+
+    # Update the resources in the machine
     machine[vas_location] = vas_resources
     machine[vbs_location] = vbs_resources
 
 
-def _step(vertices, d_limit, temperature, placement, l2v, v2n, vertices_resources, fixed_vertices, machine):
-    """Attempt a single swap operation.
-    
+def _step(vertices, d_limit, temperature, placements, l2v, v2n,
+          vertices_resources, fixed_vertices, machine, has_wrap_around_links,
+          random):
+    """Attempt a single swap operation: the kernel of the Simulated Annealing
+    algorithm.
+
     Parameters
     ----------
     vertices : [vertex, ...]
+        The set of *movable* vertices.
     d_limit : int
         The maximum distance over-which swaps are allowed.
     temperature : float > 0.0 or None
         The temperature (i.e. likelihood of accepting a non-advantageous swap).
-    
+        Higher temperatures mean higher chances of accepting a swap.
+    placements : {vertex: (x, y), ...}
+        The positions of all vertices, will be updated if a swap is made.
+    l2v : {(x, y): [vertex, ...], ...}
+        Lookup from chip to vertices, will be updated if a swap is made.
+    v2n : {vertex: [:py:class:`rig.netlist.Net`, ...], ...}
+        Lookup from vertex to all nets that vertex is in.
+    vertices_resources : {vertex: {resource: value, ...}, ...}
+    fixed_vertices : {vertex: (x, y), ...}
+        The set of vertices which must not be moved.
+    machine : :py:class:`rig.machine.Machine`
+        Describes the state of the machine including the resources actually
+        available on each chip given the current placements. Updated if a swap
+        is made.
+    has_wrap_around_links : bool
+        Should the placements attempt to make use of wrap-around links?
+    random : :py:class:`random.Random`
+        The random number generator to use.
+
     Returns
     -------
     (swapped, delta)
-        swapped is a boolean indicating if the swap made was kept
-        
+        swapped is a boolean indicating if a swap was made.
+
         delta is a float indicating the change in cost resulting from the swap
         (or 0.0 when no swap is made).
     """
-    # XXX: Does not consider hexagonal/torus properties of the system!
-    
+    # Special case: If the machine is a singleton, no swaps can be made so just
+    # terminate.
+    if machine.width == 1 and machine.height == 1:
+        return (False, 0.0)
+
     # Select a vertex to swap at random
     src_vertex = random.choice(vertices)
-    
-    # Select a random (nearby) location to swap the vertex with
-    src_location = placement[src_vertex]
+
+    # Select a random (nearby) location to swap the vertex with. Note: this is
+    # guaranteed to be different from the selected vertex, otherwise the swap
+    # cannot change the cost of the placements.
+    # XXX: Does not consider hexagonal properties of the system!
+    src_location = placements[src_vertex]
     dst_location = src_location
     while dst_location == src_location:
-        dst_location = tuple(random.randint(max(v-(d_limit), 0),
-                                            min(v+(d_limit), limit-1))
-                             for v, limit
-                             in [(src_location[0], machine.width),
-                                 (src_location[1], machine.height)])
-    
-    # The selected location is dead/not in the machine
+        if has_wrap_around_links:
+            dst_location = tuple(random.randint(v - d_limit,
+                                                v + d_limit) % limit
+                                 for v, limit
+                                 in [(src_location[0], machine.width),
+                                     (src_location[1], machine.height)])
+        else:
+            dst_location = tuple(random.randint(max(v - d_limit, 0),
+                                                min(v + d_limit, limit-1))
+                                 for v, limit
+                                 in [(src_location[0], machine.width),
+                                     (src_location[1], machine.height)])
+
+    # If we've inadvertently selected a dead chip to swap to, abort the swap.
     if dst_location not in machine:
         return (False, 0.0)
-    
-    # Decide what vertex to swap with at the destination
+
+    # Find out which vertices (if any) must be swapped out of the destination
+    # to make room for the vertex we're moving.
     src_resources = vertices_resources[src_vertex]
     dst_vertices = _get_candidate_swap(src_resources, dst_location,
                                        l2v, vertices_resources,
                                        fixed_vertices, machine)
-    
-    # The destination vertex cannot fit the source vertex
+
+    # The destination simply isn't big enough (no matter how many vertices at
+    # the destination are moved), abort the swap.
     if dst_vertices is None:
         return (False, 0.0)
-    
-    # Can we fit the vertices to be moved from the destination in the space in
-    # the source when we move the source vertex?
+
+    # Make sure that any vertices moved out of the destination will fit in the
+    # space left in the source location. If there isn't enough space, abort the
+    # swap.
     resources = machine[src_location]
     resources = add_resources(resources, src_resources)
     for dst_vertex in dst_vertices:
         resources = subtract_resources(resources,
                                        vertices_resources[dst_vertex])
     if overallocated(resources):
-        # There isn't enough space in the source to make the swap.
         return (False, 0.0)
-    
+
     # Work out the cost of the nets involved *before* swapping
-    cost_before = _vertex_net_cost(src_vertex, v2n, placement)
+    cost_before = _vertex_net_cost(src_vertex, v2n, placements,
+                                   has_wrap_around_links, machine)
     for dst_vertex in dst_vertices:
-        # XXX: Counts the cost due to any source-connected nets twice!
-        cost_before += _vertex_net_cost(dst_vertex, v2n, placement)
-    
+        cost_before += _vertex_net_cost(dst_vertex, v2n, placements,
+                                        has_wrap_around_links, machine)
+
     # Swap the vertices
     _swap([src_vertex], src_location,
           dst_vertices, dst_location,
-          l2v, vertices_resources, placement, machine)
-    
+          l2v, vertices_resources, placements, machine)
+
     # Work out the new cost
-    cost_after = _vertex_net_cost(src_vertex, v2n, placement)
+    cost_after = _vertex_net_cost(src_vertex, v2n, placements,
+                                  has_wrap_around_links, machine)
     for dst_vertex in dst_vertices:
-        # XXX: Counts the cost due to any source-connected nets twice!
-        cost_after += _vertex_net_cost(dst_vertex, v2n, placement)
-    
-    # Decide whether to revert the swap or not
+        cost_after += _vertex_net_cost(dst_vertex, v2n, placements,
+                                       has_wrap_around_links, machine)
+
+    # If the swap was beneficial, keep it, otherwise keep it with a probability
+    # related to just how bad the cost change is is and the temperature.
     delta = cost_after - cost_before
-    if delta > 0.0 and random.random() > math.exp(-delta/temperature):
+    if delta <= 0.0 or random.random() < math.exp(-delta/temperature):
+        # Keep the swap!
+        return (True, delta)
+    else:
         # Revert the swap
         _swap([src_vertex], dst_location,
               dst_vertices, src_location,
-              l2v, vertices_resources, placement, machine)
+              l2v, vertices_resources, placements, machine)
         return (False, 0.0)
-    else:
-        # Keep the swap!
-        return (True, delta)
 
 
-def place(vertices_resources, nets, machine, constraints, effort=1.0):
+def place(vertices_resources, nets, machine, constraints,
+          effort=1.0, random=default_random, on_temperature_change=None):
     """A flat Simulated Annealing based placement algorithm.
-    
-    This algorithm uses simulated annealing directly on the supplied problem
-    graph with the objective of reducing wire lengths (and thus potential for
-    congestion).
-    
+
+    This placement algorithm uses simulated annealing directly on the supplied
+    problem graph with the objective of reducing wire lengths (and thus,
+    indirectly, the potential for congestion). Though computationally
+    expensive, this placer produces relatively good placement solutions.
+
+    The annealing temperature schedule used by this algorithm is taken from
+    "VPR: A New Packing, Placement and Routing Tool for FPGA Research" by
+    Vaughn Betz and Jonathan Rose from the "1997 International Workshop on
+    Field Programmable Logic and Applications".
+
+    This algorithm is written in pure Python and is not highly optimised for
+    performance.
+
+    This algorithm produces INFO level logging information describing the
+    progress made by the algorithm.
+
     .. warning:
         This algorithm does not attempt to produce good solutions to the
-        bin-packing problem of fitting vertices into chips and it may fail if a
-        good placement requires good bin packing.
-    
+        bin-packing problem of optimally fitting vertices into chips and it may
+        fail if a good placement requires good bin packing.
+
     Parameters
     ----------
     effort : float
         A scaling factor for the number of iterations the algorithm should run
         for. 1.0 is probably about as low as you'll want to go in practice and
         runtime increases linearly as you increase this parameter.
+    random : :py:class:`random.Random`
+        A Python random number generator. Defaults to ``import random`` but can
+        be set to your own instance of :py:class:`random.Random` to allow you
+        to control the seed and produce deterministic results. For results to
+        be deterministic, vertices_resources must be supplied as an
+        :py:class:`collections.OrderedDict`.
+    on_temperature_change : callback_function or None
+        An (optional) callback function which is called every time the
+        temperature is changed. This callback can be used to provide status
+        updates
+
+        The callback function is passed the following arguments:
+
+        * ``iteration_count``: the number of iterations the placer has
+          attempted (integer)
+        * ``placements``: The current placement solution.
+        * ``cost``: the weighted sum over all nets of bounding-box size.
+          (float)
+        * ``acceptance_rate``: the proportion of iterations which have resulted
+          in an accepted change since the last callback call. (float between
+          0.0 and 1.0)
+        * ``temperature``: The current annealing temperature. (float)
+        * ``distance_limit``: The maximum distance any swap may be made over.
+          (integer)
+
+        If the callback returns False, the anneal is terminated immediately and
+        the current solution is returned.
     """
-    # Create a modified machine which accounts for any constraints
+    # Special case: just return immediately when there's nothing to place
+    if len(vertices_resources) == 0:
+        return {}
+
+    # Within the algorithm we modify the resource availability values in the
+    # machine to account for the effects of the current placement. As a result,
+    # an internal copy of the structure must be made.
     machine = machine.copy()
-    
-    # A dictionary giving the positions of all fixed vertices.
+
+    # Determine if the system has wrap around links (and thus whether placement
+    # should try to use them).
+    has_wrap_around_links = machine.has_wrap_around_links()
+
+    # {vertex: (x, y), ...} gives the location of all vertices whose position
+    # is fixed by a LocationConstraint.
     fixed_vertices = {}
-    
+
     # Handle constraints
     for constraint in constraints:
         if isinstance(constraint, LocationConstraint):
             # Location constraints are handled by recording the set of fixed
             # vertex locations and subtracting their resources from the chips
-            # they're allocated to. These vertices will then not be added to the
-            # internal placement data structure to prevent annealing from moving
-            # them. They will be re-introduced at the last possible moment.
+            # they're allocated to. These vertices will then not be added to
+            # the internal placement data structure to prevent annealing from
+            # moving them. They will be re-introduced at the last possible
+            # moment.
             location = constraint.location
             if location not in machine:
                 raise InvalidConstraintError(
                     "Chip requested by {} unavailable".format(machine))
             vertex = constraint.vertex
-            
+
             # Record the constrained vertex's location
             fixed_vertices[vertex] = location
-            
-            # Discount the required resources from the specified chip
+
+            # Make sure the vertex fits at the requested location (updating the
+            # resource availability after placement)
             resources = vertices_resources[vertex]
-            machine[loc] = subtract_resources(machine[loc], resources)
-            if overallocated(machine[loc]):
+            machine[location] = subtract_resources(machine[location],
+                                                   resources)
+            if overallocated(machine[location]):
                 raise InsufficientResourceError(
                     "Cannot meet {}".format(constraint))
-        elif isinstance(constraint, ReserveResourceConstraint):
-            # Reserved resources are simply subtracted from the numbers
-            # supplied.
-            if constraint.location is None:
-                # Global resource reservation
-                machine.chip_resources \
-                    = resources_after_reservation(
-                        machine.chip_resources, constraint)
-                for location in machine.chip_resource_exceptions:
-                    machine.chip_resource_exceptions[location] \
-                        = resources_after_reservation(
-                            machine.chip_resource_exceptions[location],
-                            constraint)
-            else:
-                # Compensate for reserved resources at a specified location
-                machine[constraint.location] = resources_after_reservation(
-                    machine[constraint.location], constraint)
-    
+        elif isinstance(constraint,  # pragma: no branch
+                        ReserveResourceConstraint):
+            apply_reserve_resource_constraint(machine, constraint)
+
     # Initially randomly place the movable vertices
     movable_vertices = [v for v in vertices_resources
                         if v not in fixed_vertices]
-    placement = _initial_placement(movable_vertices,
-                                   vertices_resources,
-                                   machine)
-    placement.update(fixed_vertices)
-    
-    # Location-to-Vertices: A lookup {(x, y): [vertex, ...], ...} giving the set
-    # of vertices on a given chip.  Positions which are not usable are excluded
-    # from this lookup.
+    placements = _initial_placement(movable_vertices,
+                                    vertices_resources,
+                                    machine, random)
+
+    # Include the fixed vertices
+    placements.update(fixed_vertices)
+
+    # Special cases where no placement effort is required:
+    # * No movable vertices
+    # * No effort is to be made
+    # * There are no nets (and moving things has no effect)
+    if len(movable_vertices) == 0 or effort == 0.0 or len(nets) == 0:
+        return placements
+
+    # Location-to-Vertices: A lookup {(x, y): [vertex, ...], ...} giving the
+    # set of vertices on a given chip.  Chips which are not in the machine are
+    # excluded from this lookup.
     l2v = {(x, y): []
            for x in range(machine.width)
            for y in range(machine.height)
            if (x, y) in machine}
-    for vertex, location in iteritems(placement):
+    for vertex, location in iteritems(placements):
         l2v[location].append(vertex)
-    
-    # Vertices-to-Nets: A lookup {vertex: [Net, ...], ...}, gives a list of nets
-    # of which the given vertex is a member.
+
+    # Vertices-to-Nets: A lookup {vertex: [Net, ...], ...}, gives a list of
+    # nets of which the given vertex is a member.
     v2n = {v: [] for v in vertices_resources}
     for net in nets:
         for v in net:
             if net not in v2n[v]:
                 v2n[v].append(net)
-    
-    # Initially consider swaps the entire span of the machine away
+
+    # Specifies the maximum distance any swap can span. Initially consider
+    # swaps that span the entire machine.
     d_limit = max(machine.width, machine.height)
-    
-    # Determine initial temperature
+
+    # Determine initial temperature according to the heuristic used by VPR: 20
+    # times the standard deviation of len(movable_vertices) random swap costs.
+    # Note: though this would be better implemented by Numpy, it is implemented
+    # in pure Python to allow this module to run under pypy.
     deltas = []
     for _ in range(len(movable_vertices)):
         _, delta = _step(movable_vertices,
                          # During initial pass, work at very high temperature
-                         # since we want to get the average swap cost (including
-                         # bad ones)
+                         # since we want to get the average swap cost
+                         # (including bad ones)
                          int(d_limit), 1.e1000,
-                         placement, l2v, v2n,
-                         vertices_resources, fixed_vertices, machine)
+                         placements, l2v, v2n,
+                         vertices_resources, fixed_vertices, machine,
+                         has_wrap_around_links, random)
         deltas.append(delta)
     mean = sum(deltas) / float(len(deltas))
     std = math.sqrt(sum((v-mean)**2 for v in deltas) / len(deltas))
     temperature = 20.0 * std
-    
-    # Determine number of iterations per temperature
-    num_iterations = int(effort * len(vertices_resources)**1.33)
-    
-    import sys
-    print("Starting temperature: {} (iterations per temp: {})".format(
-        temperature, num_iterations))
-    sys.stdout.flush()
-    
+
+    # The number of swap-attempts between temperature changes is selected by
+    # the heuristic used by VPR. This value is scaled linearly by the effort
+    # parameter.
+    num_iterations = max(1, int(effort * len(vertices_resources)**1.33))
+
+    logger.info("Initial placement temperature: %0.1f", temperature)
+
+    # Counter for the number of swap attempts made (used for diagnostic
+    # purposes)
+    iteration_count = 0
+
+    # Holds the total cost of the current placement. This default value chosen
+    # to ensure the loop below iterates at least once.
     current_cost = 0.0
-    while effort > 0.0 and temperature > 0.005 * current_cost / len(movable_vertices):
+
+    # The annealing algorithm runs until a heuristic termination condition
+    # (taken from VPR) is hit. The heuristic waits until the temperature falls
+    # below a small fraction of the average net cost.
+    while temperature > (0.005 * current_cost) / len(nets):
         # Run an iteration at the current temperature
-        num_kept = 0
+        num_accepted = 0
         for _ in range(num_iterations):
-            kept, _ = _step(movable_vertices,
-                            int(d_limit), temperature,
-                            placement, l2v, v2n,
-                            vertices_resources, fixed_vertices, machine)
-            num_kept += 1 if kept else 0
-        
-        # Work out how the temperature should be changed
-        r_accept = num_kept / float(num_iterations)
-        if r_accept > 0.96: alpha = 0.5
-        elif r_accept > 0.8: alpha = 0.9
-        elif r_accept > 0.15: alpha = 0.95
-        else: alpha = 0.8
+            accepted, _ = _step(movable_vertices,
+                                int(d_limit), temperature,
+                                placements, l2v, v2n,
+                                vertices_resources, fixed_vertices, machine,
+                                has_wrap_around_links, random)
+            num_accepted += 1 if accepted else 0
+
+        # The ratio of accepted-to-not-accepted changes
+        r_accept = num_accepted / float(num_iterations)
+
+        # Work out the new total net cost for the current placement.
+        current_cost = 0.0
+        for net in nets:
+            current_cost += _net_cost(net, placements, has_wrap_around_links,
+                                      machine)
+
+        # Special case: Can't do better than 0 cost! This is a special case
+        # since the normal termination condition will not terminate if the cost
+        # doesn't drop below 0.
+        if current_cost == 0:
+            break
+
+        # The temperature is reduced by a factor heuristically based on the
+        # acceptance rate. The schedule below attempts to maximise the time
+        # spent at temperatures where a large portion (but not all) of changes
+        # are being accepted. If lots of changes are being accepted (e.g.
+        # during high-temperature periods) then most of them are likely not to
+        # be beneficial. If few changes are being accepted, we're probably
+        # pretty close to the optimal placement.
+        if r_accept > 0.96:
+            alpha = 0.5
+        elif r_accept > 0.8:
+            alpha = 0.9
+        elif r_accept > 0.15:
+            alpha = 0.95
+        else:
+            alpha = 0.8
         temperature = alpha * temperature
-    
-        # Update d_limit
+
+        # According to:
+        # * M. Huang, F. Romeo, and A. Sangiovanni-Vincentelli, "An Efficient
+        #   General Cooling Schedule for Simulated Annealing" ICCAD, 1986, pp.
+        #   381 - 384 and J. Lam
+        # * J. Delosme, "Performance of a New Annealing Schedule" DAC, 1988,
+        #   pp. 306 - 311.
+        # It is desirable to keep the acceptance ratio as close to 0.44 for as
+        # long as possible. As a result, when r_accept falls below this we can
+        # help increase the acceptance rate by reducing the set of possible
+        # swap candidates based on the observation that near the end of
+        # placement, most things are near their optimal location and thus long
+        # distance swaps are unlikely to be useful.
         d_limit *= 1.0 - 0.44 + r_accept
         d_limit = min(max(d_limit, 1), max(machine.width, machine.height))
-    
-        # End cost
-        current_cost = 0
-        for net in nets:
-            x1, y1, x2, y2 = _net_bb(net, placement)
-            current_cost += (abs(x1-x2) + abs(y1-y2)) * net.weight
-        
-        print("Iteration ended with cost {}".format(current_cost))
-        sys.stdout.flush()
-    
-    return placement
 
+        iteration_count += num_iterations
+        logger.info("After %d iterations cost is %0.1f, "
+                    "swap acceptance rate is %0.1f%%, "
+                    "temperature changing to %0.3f, "
+                    "swap distance limit now %d.",
+                    iteration_count, current_cost,
+                    r_accept*100, temperature, d_limit)
 
-if __name__=="__main__":
-    from rig.machine import Machine, Cores
-    from rig.netlist import Net
-    
-    random.seed(2)
-    
-    
-    w, h = 10, 10
-    machine = Machine(10, 10, chip_resources={Cores: 1})
-    ideal_placement = {(x, y): object()
-                       for x in range(w)
-                       for y in range(h)}
-    ideal_vertices_position = {v: xy for xy, v in iteritems(ideal_placement)}
-    
-    vertices = list(itervalues(ideal_placement))
-    
-    def i(x, y):
-        if x >= w or x < 0 or y >= h or y < 0:
-            return None
-        else:
-            return ideal_placement[(x%w, y%h)]
-    nets = []
-    ## Nearest-neighbour connectivity
-    #nets += [Net(i(x, y),
-    #             [xy for xy in [i(x+1,y+1), # Top
-    #                            i(x+0,y+1),
-    #                            i(x-1,y+1), # Left
-    #                            i(x-1,y+0),
-    #                            i(x-1,y-1), # Bottom
-    #                            i(x+0,y-1),
-    #                            i(x+1,y-1), # Right
-    #                            i(x+1,y+0),
-    #                            ]
-    #              if xy is not None])
-    #         for x in range(w)
-    #         for y in range(h)]
-    
-    ## Random connectivity
-    #fan_out = 1, 5
-    #nets += [Net(v, random.sample(vertices, random.randint(*fan_out)))
-    #         for v in vertices]
-    
-    # Thick pipeline connectivity
-    n_vertices = len(vertices)
-    thickness = 5
-    nets += [Net(vertices[i],
-                 vertices[(i//thickness + 1)*thickness: (i//thickness + 2)*thickness])
-             for i in range(n_vertices)
-             if i + thickness < n_vertices]
-    
-    placement = place({v: {Cores: 1} for v in vertices},
-                      nets, machine, [], 1.0)
-    
-    # Save the output graph as a graphviz file
-    with open("/tmp/graph.dot", "w") as f:
-        f.write("digraph {\n")
-        
-        # Set style
-        f.write("node [shape=circle label=\"\"]\n")
-        
-        # Record placements
-        for vertex, position in iteritems(placement):
-            f.write("n{} [pos=\"{},{}!\"]\n".format(
-                id(vertex), position[0], position[1]))
-        
-        # Print nets
-        for net in nets:
-            for sink in net.sinks:
-                f.write("n{} -> n{}\n".format(
-                    id(net.source),
-                    id(sink)))
-        
-        f.write("}")
-    
-    # Check the placement is valid
-    from collections import defaultdict
-    verts_on_chip = defaultdict(lambda: 0)
-    assert len(placement) == len(ideal_placement)
-    for vertex, xy in iteritems(placement):
-        verts_on_chip[xy] += 1
-        assert verts_on_chip[xy] <= machine.chip_resources[Cores]
+        # Call the user callback before the next iteration, terminating if
+        # requested.
+        if (on_temperature_change is not None and
+                on_temperature_change(iteration_count,
+                                      placements,
+                                      current_cost,
+                                      r_accept,
+                                      temperature,
+                                      d_limit) is False):
+            break
+
+    logger.info("Anneal terminated after %d iterations with final cost %0.1f.",
+                iteration_count, current_cost)
+
+    return placements

--- a/rig/place_and_route/place/sa.py
+++ b/rig/place_and_route/place/sa.py
@@ -1,0 +1,493 @@
+"""An experimental simulated-annealing based placer."""
+
+from six import iteritems, iterkeys, itervalues
+
+import random
+import math
+import heapq
+
+from rig.place_and_route.place.hilbert import hilbert
+
+from rig.place_and_route.exceptions import \
+    InvalidConstraintError, InsufficientResourceError
+
+from rig.place_and_route.place.utils import \
+    add_resources, subtract_resources, overallocated, \
+    resources_after_reservation
+
+
+def _initial_placement(movable_vertices, vertices_resources, machine):
+    """For internal use. Produces a random, sequential initial placement.
+    
+    Also updates the resource availability of each chip in the machine.
+    """
+    # Allocate chips along a Hilbert curve large enough to cover the whole
+    # system
+    max_dimen = max(machine.width, machine.height)
+    hilbert_levels = int(math.ceil(math.log(max_dimen, 2.0))) if max_dimen >= 1 else 0
+    location_iter = hilbert(hilbert_levels)
+    
+    placement = {}
+    random.shuffle(movable_vertices)
+    vertex_iter = iter(movable_vertices)
+    location = next(location_iter)
+    while True:
+        # Get a vertex to place
+        try:
+            vertex = next(vertex_iter)
+        except StopIteration:
+            break
+        
+        # Advance through the set of available locations until we can find a
+        # chip where the vertex fits
+        while True:
+            try:
+                if location not in machine:
+                    location = next(location_iter)
+                    continue
+                
+                resources_if_placed = subtract_resources(
+                    machine[location], vertices_resources[vertex])
+                
+                if overallocated(resources_if_placed):
+                    # Didn't fit, try the next chip
+                    location = next(location_iter)
+                    continue
+            except StopIteration:
+                raise InsufficientResourceError(
+                    "Ran out of chips while attempting to place vertex "
+                    "{}".format(vertex))
+            else:
+                # The vertex fit, note the consumed resources and move on to the
+                # next vertex
+                placement[vertex] = location
+                machine[location] = resources_if_placed
+                break
+    
+    return placement
+
+
+def _net_bb(net, placement):
+    """Get the bounding-box (x1,y1, x2,y2) for the vertices in a given net."""
+    # XXX: This does not account for the hexagonal, nor torus-properties of the
+    # SpiNNaker topology.
+    x1, y1 = x2, y2 = placement[net.source]
+    for vertex in net.sinks:
+        x, y = placement[vertex]
+        x1 = x if x < x1 else x1
+        y1 = y if y < y1 else y1
+        x2 = x if x > x2 else x2
+        y2 = y if y > y2 else y2
+    return (x1, y1, x2, y2)
+
+
+def _vertex_net_cost(vertex, v2n, placement):
+    """Get the total cost of the nets connected to the given vertex."""
+    total_cost = 0.0
+    for net in v2n[vertex]:
+        x1, y1, x2, y2 = _net_bb(net, placement)
+        net_cost = abs(x1 - x2) + abs(y1 - y2)
+        
+        total_cost += net_cost * net.weight
+    
+    return total_cost
+
+
+def _get_candidate_swap(resources, location, l2v, vertices_resources,
+                        fixed_vertices, machine):
+    """Given a chip location, select a set of vertices which would have to be
+    moved elsewhere to accommodate the arrival of the specified set of
+    resources.
+    
+    Parameters
+    ----------
+    resources
+        The amount of resources which are required at the specified location.
+    location : (x, y)
+        The chip coordinates from which to find a space.
+    
+    Returns
+    -------
+    [Vertex, ...] or None
+        If None, the situation is impossible.
+        If a (possibly empty) list, gives the set of vertices which should be
+        removed from the specified location to make room.
+    """
+    chip_resources = machine[location]
+    
+    vertices = l2v[location]
+    
+    to_move = []
+    i = 0
+    while overallocated(subtract_resources(chip_resources, resources)):
+        if i >= len(vertices):
+            # Run out of vertices to remove from this chip, fail
+            return None
+        
+        if vertices[i] in fixed_vertices:
+            # Don't try moving fixed vertices
+            i += 1
+            continue
+        else:
+            chip_resources = add_resources(chip_resources,
+                                           vertices_resources[vertices[i]])
+            to_move.append(vertices[i])
+            i += 1
+    
+    return to_move
+
+
+def _swap(vas, vas_location, vbs, vbs_location, l2v, vertices_resources, placement, machine):
+    """Swap the positions of two sets of vertices: vas and vbs at locations
+    vas_location2v and vbs_location2v."""
+    vas_location2v = l2v[vas_location]
+    vbs_location2v = l2v[vbs_location]
+    
+    vas_resources = machine[vas_location]
+    vbs_resources = machine[vbs_location]
+    
+    for va in vas:
+        placement[va] = vbs_location
+        vas_location2v.remove(va)
+        vbs_location2v.append(va)
+        
+        resources = vertices_resources[va]
+        vas_resources = add_resources(vas_resources, resources)
+        vbs_resources = subtract_resources(vbs_resources, resources)
+    
+    for vb in vbs:
+        placement[vb] = vas_location
+        vbs_location2v.remove(vb)
+        vas_location2v.append(vb)
+        
+        resources = vertices_resources[vb]
+        vas_resources = subtract_resources(vas_resources, resources)
+        vbs_resources = add_resources(vbs_resources, resources)
+    
+    machine[vas_location] = vas_resources
+    machine[vbs_location] = vbs_resources
+
+
+def _step(vertices, d_limit, temperature, placement, l2v, v2n, vertices_resources, fixed_vertices, machine):
+    """Attempt a single swap operation.
+    
+    Parameters
+    ----------
+    vertices : [vertex, ...]
+    d_limit : int
+        The maximum distance over-which swaps are allowed.
+    temperature : float > 0.0 or None
+        The temperature (i.e. likelihood of accepting a non-advantageous swap).
+    
+    Returns
+    -------
+    (swapped, delta)
+        swapped is a boolean indicating if the swap made was kept
+        
+        delta is a float indicating the change in cost resulting from the swap
+        (or 0.0 when no swap is made).
+    """
+    # XXX: Does not consider hexagonal/torus properties of the system!
+    
+    # Select a vertex to swap at random
+    src_vertex = random.choice(vertices)
+    
+    # Select a random (nearby) location to swap the vertex with
+    src_location = placement[src_vertex]
+    dst_location = src_location
+    while dst_location == src_location:
+        dst_location = tuple(random.randint(max(v-(d_limit), 0),
+                                            min(v+(d_limit), limit-1))
+                             for v, limit
+                             in [(src_location[0], machine.width),
+                                 (src_location[1], machine.height)])
+    
+    # The selected location is dead/not in the machine
+    if dst_location not in machine:
+        return (False, 0.0)
+    
+    # Decide what vertex to swap with at the destination
+    src_resources = vertices_resources[src_vertex]
+    dst_vertices = _get_candidate_swap(src_resources, dst_location,
+                                       l2v, vertices_resources,
+                                       fixed_vertices, machine)
+    
+    # The destination vertex cannot fit the source vertex
+    if dst_vertices is None:
+        return (False, 0.0)
+    
+    # Can we fit the vertices to be moved from the destination in the space in
+    # the source when we move the source vertex?
+    resources = machine[src_location]
+    resources = add_resources(resources, src_resources)
+    for dst_vertex in dst_vertices:
+        resources = subtract_resources(resources,
+                                       vertices_resources[dst_vertex])
+    if overallocated(resources):
+        # There isn't enough space in the source to make the swap.
+        return (False, 0.0)
+    
+    # Work out the cost of the nets involved *before* swapping
+    cost_before = _vertex_net_cost(src_vertex, v2n, placement)
+    for dst_vertex in dst_vertices:
+        # XXX: Counts the cost due to any source-connected nets twice!
+        cost_before += _vertex_net_cost(dst_vertex, v2n, placement)
+    
+    # Swap the vertices
+    _swap([src_vertex], src_location,
+          dst_vertices, dst_location,
+          l2v, vertices_resources, placement, machine)
+    
+    # Work out the new cost
+    cost_after = _vertex_net_cost(src_vertex, v2n, placement)
+    for dst_vertex in dst_vertices:
+        # XXX: Counts the cost due to any source-connected nets twice!
+        cost_after += _vertex_net_cost(dst_vertex, v2n, placement)
+    
+    # Decide whether to revert the swap or not
+    delta = cost_after - cost_before
+    if delta > 0.0 and random.random() > math.exp(-delta/temperature):
+        # Revert the swap
+        _swap([src_vertex], dst_location,
+              dst_vertices, src_location,
+              l2v, vertices_resources, placement, machine)
+        return (False, 0.0)
+    else:
+        # Keep the swap!
+        return (True, delta)
+
+
+def place(vertices_resources, nets, machine, constraints, effort=1.0):
+    """A flat Simulated Annealing based placement algorithm.
+    
+    This algorithm uses simulated annealing directly on the supplied problem
+    graph with the objective of reducing wire lengths (and thus potential for
+    congestion).
+    
+    .. warning:
+        This algorithm does not attempt to produce good solutions to the
+        bin-packing problem of fitting vertices into chips and it may fail if a
+        good placement requires good bin packing.
+    
+    Parameters
+    ----------
+    effort : float
+        A scaling factor for the number of iterations the algorithm should run
+        for. 1.0 is probably about as low as you'll want to go in practice and
+        runtime increases linearly as you increase this parameter.
+    """
+    # Create a modified machine which accounts for any constraints
+    machine = machine.copy()
+    
+    # A dictionary giving the positions of all fixed vertices.
+    fixed_vertices = {}
+    
+    # Handle constraints
+    for constraint in constraints:
+        if isinstance(constraint, LocationConstraint):
+            # Location constraints are handled by recording the set of fixed
+            # vertex locations and subtracting their resources from the chips
+            # they're allocated to. These vertices will then not be added to the
+            # internal placement data structure to prevent annealing from moving
+            # them. They will be re-introduced at the last possible moment.
+            location = constraint.location
+            if location not in machine:
+                raise InvalidConstraintError(
+                    "Chip requested by {} unavailable".format(machine))
+            vertex = constraint.vertex
+            
+            # Record the constrained vertex's location
+            fixed_vertices[vertex] = location
+            
+            # Discount the required resources from the specified chip
+            resources = vertices_resources[vertex]
+            machine[loc] = subtract_resources(machine[loc], resources)
+            if overallocated(machine[loc]):
+                raise InsufficientResourceError(
+                    "Cannot meet {}".format(constraint))
+        elif isinstance(constraint, ReserveResourceConstraint):
+            # Reserved resources are simply subtracted from the numbers
+            # supplied.
+            if constraint.location is None:
+                # Global resource reservation
+                machine.chip_resources \
+                    = resources_after_reservation(
+                        machine.chip_resources, constraint)
+                for location in machine.chip_resource_exceptions:
+                    machine.chip_resource_exceptions[location] \
+                        = resources_after_reservation(
+                            machine.chip_resource_exceptions[location],
+                            constraint)
+            else:
+                # Compensate for reserved resources at a specified location
+                machine[constraint.location] = resources_after_reservation(
+                    machine[constraint.location], constraint)
+    
+    # Initially randomly place the movable vertices
+    movable_vertices = [v for v in vertices_resources
+                        if v not in fixed_vertices]
+    placement = _initial_placement(movable_vertices,
+                                   vertices_resources,
+                                   machine)
+    placement.update(fixed_vertices)
+    
+    # Location-to-Vertices: A lookup {(x, y): [vertex, ...], ...} giving the set
+    # of vertices on a given chip.  Positions which are not usable are excluded
+    # from this lookup.
+    l2v = {(x, y): []
+           for x in range(machine.width)
+           for y in range(machine.height)
+           if (x, y) in machine}
+    for vertex, location in iteritems(placement):
+        l2v[location].append(vertex)
+    
+    # Vertices-to-Nets: A lookup {vertex: [Net, ...], ...}, gives a list of nets
+    # of which the given vertex is a member.
+    v2n = {v: [] for v in vertices_resources}
+    for net in nets:
+        for v in net:
+            if net not in v2n[v]:
+                v2n[v].append(net)
+    
+    # Initially consider swaps the entire span of the machine away
+    d_limit = max(machine.width, machine.height)
+    
+    # Determine initial temperature
+    deltas = []
+    for _ in range(len(movable_vertices)):
+        _, delta = _step(movable_vertices,
+                         # During initial pass, work at very high temperature
+                         # since we want to get the average swap cost (including
+                         # bad ones)
+                         int(d_limit), 1.e1000,
+                         placement, l2v, v2n,
+                         vertices_resources, fixed_vertices, machine)
+        deltas.append(delta)
+    mean = sum(deltas) / float(len(deltas))
+    std = math.sqrt(sum((v-mean)**2 for v in deltas) / len(deltas))
+    temperature = 20.0 * std
+    
+    # Determine number of iterations per temperature
+    num_iterations = int(effort * len(vertices_resources)**1.33)
+    
+    import sys
+    print("Starting temperature: {} (iterations per temp: {})".format(
+        temperature, num_iterations))
+    sys.stdout.flush()
+    
+    current_cost = 0.0
+    while effort > 0.0 and temperature > 0.005 * current_cost / len(movable_vertices):
+        # Run an iteration at the current temperature
+        num_kept = 0
+        for _ in range(num_iterations):
+            kept, _ = _step(movable_vertices,
+                            int(d_limit), temperature,
+                            placement, l2v, v2n,
+                            vertices_resources, fixed_vertices, machine)
+            num_kept += 1 if kept else 0
+        
+        # Work out how the temperature should be changed
+        r_accept = num_kept / float(num_iterations)
+        if r_accept > 0.96: alpha = 0.5
+        elif r_accept > 0.8: alpha = 0.9
+        elif r_accept > 0.15: alpha = 0.95
+        else: alpha = 0.8
+        temperature = alpha * temperature
+    
+        # Update d_limit
+        d_limit *= 1.0 - 0.44 + r_accept
+        d_limit = min(max(d_limit, 1), max(machine.width, machine.height))
+    
+        # End cost
+        current_cost = 0
+        for net in nets:
+            x1, y1, x2, y2 = _net_bb(net, placement)
+            current_cost += (abs(x1-x2) + abs(y1-y2)) * net.weight
+        
+        print("Iteration ended with cost {}".format(current_cost))
+        sys.stdout.flush()
+    
+    return placement
+
+
+if __name__=="__main__":
+    from rig.machine import Machine, Cores
+    from rig.netlist import Net
+    
+    random.seed(2)
+    
+    
+    w, h = 10, 10
+    machine = Machine(10, 10, chip_resources={Cores: 1})
+    ideal_placement = {(x, y): object()
+                       for x in range(w)
+                       for y in range(h)}
+    ideal_vertices_position = {v: xy for xy, v in iteritems(ideal_placement)}
+    
+    vertices = list(itervalues(ideal_placement))
+    
+    def i(x, y):
+        if x >= w or x < 0 or y >= h or y < 0:
+            return None
+        else:
+            return ideal_placement[(x%w, y%h)]
+    nets = []
+    ## Nearest-neighbour connectivity
+    #nets += [Net(i(x, y),
+    #             [xy for xy in [i(x+1,y+1), # Top
+    #                            i(x+0,y+1),
+    #                            i(x-1,y+1), # Left
+    #                            i(x-1,y+0),
+    #                            i(x-1,y-1), # Bottom
+    #                            i(x+0,y-1),
+    #                            i(x+1,y-1), # Right
+    #                            i(x+1,y+0),
+    #                            ]
+    #              if xy is not None])
+    #         for x in range(w)
+    #         for y in range(h)]
+    
+    ## Random connectivity
+    #fan_out = 1, 5
+    #nets += [Net(v, random.sample(vertices, random.randint(*fan_out)))
+    #         for v in vertices]
+    
+    # Thick pipeline connectivity
+    n_vertices = len(vertices)
+    thickness = 5
+    nets += [Net(vertices[i],
+                 vertices[(i//thickness + 1)*thickness: (i//thickness + 2)*thickness])
+             for i in range(n_vertices)
+             if i + thickness < n_vertices]
+    
+    placement = place({v: {Cores: 1} for v in vertices},
+                      nets, machine, [], 1.0)
+    
+    # Save the output graph as a graphviz file
+    with open("/tmp/graph.dot", "w") as f:
+        f.write("digraph {\n")
+        
+        # Set style
+        f.write("node [shape=circle label=\"\"]\n")
+        
+        # Record placements
+        for vertex, position in iteritems(placement):
+            f.write("n{} [pos=\"{},{}!\"]\n".format(
+                id(vertex), position[0], position[1]))
+        
+        # Print nets
+        for net in nets:
+            for sink in net.sinks:
+                f.write("n{} -> n{}\n".format(
+                    id(net.source),
+                    id(sink)))
+        
+        f.write("}")
+    
+    # Check the placement is valid
+    from collections import defaultdict
+    verts_on_chip = defaultdict(lambda: 0)
+    assert len(placement) == len(ideal_placement)
+    for vertex, xy in iteritems(placement):
+        verts_on_chip[xy] += 1
+        assert verts_on_chip[xy] <= machine.chip_resources[Cores]

--- a/rig/place_and_route/place/utils.py
+++ b/rig/place_and_route/place/utils.py
@@ -3,6 +3,22 @@
 from six import iteritems, itervalues
 
 
+def add_resources(res_a, res_b):
+    """Return the resources after adding res_b's resources to res_a.
+
+    Parameters
+    ----------
+    res_a : dict
+        Dictionary `{resource: value, ...}`.
+    res_b : dict
+        Dictionary `{resource: value, ...}`. Must be a (non-strict) subset of
+        res_a. If A resource is not present in res_b, the value is presumed to
+        be 0.
+    """
+    return {resource: value + res_b.get(resource, 0)
+            for resource, value in iteritems(res_a)}
+
+
 def subtract_resources(res_a, res_b):
     """Return the resources remaining after subtracting res_b's resources from
     res_a.

--- a/rig/place_and_route/place/utils.py
+++ b/rig/place_and_route/place/utils.py
@@ -2,6 +2,8 @@
 
 from six import iteritems, itervalues
 
+from rig.place_and_route.exceptions import InsufficientResourceError
+
 
 def add_resources(res_a, res_b):
     """Return the resources after adding res_b's resources to res_a.
@@ -56,3 +58,31 @@ def resources_after_reservation(res, constraint):
     res[constraint.resource] -= (constraint.reservation.stop -
                                  constraint.reservation.start)
     return res
+
+
+def apply_reserve_resource_constraint(machine, constraint):
+    """Apply the changes inplied by a reserve resource constraint to a
+    machine model."""
+    if constraint.location is None:
+        # Compensate for globally reserved resources
+        machine.chip_resources \
+            = resources_after_reservation(
+                machine.chip_resources, constraint)
+        if overallocated(machine.chip_resources):
+            raise InsufficientResourceError(
+                "Cannot meet {}".format(constraint))
+        for location in machine.chip_resource_exceptions:
+            machine.chip_resource_exceptions[location] \
+                = resources_after_reservation(
+                    machine.chip_resource_exceptions[location],
+                    constraint)
+            if overallocated(machine[location]):
+                raise InsufficientResourceError(
+                    "Cannot meet {}".format(constraint))
+    else:
+        # Compensate for reserved resources at a specified location
+        machine[constraint.location] = resources_after_reservation(
+            machine[constraint.location], constraint)
+        if overallocated(machine[constraint.location]):
+            raise InsufficientResourceError(
+                "Cannot meet {}".format(constraint))

--- a/tests/place_and_route/place/test_generic_place.py
+++ b/tests/place_and_route/place/test_generic_place.py
@@ -16,11 +16,13 @@ from rig.place_and_route.constraints import LocationConstraint, \
 
 from rig.place_and_route import place as default_place
 from rig.place_and_route.place.hilbert import place as hilbert_place
+from rig.place_and_route.place.sa import place as sa_place
 
 # This dictionary should be updated to contain all implemented algorithms along
 # with applicable keyword arguments.
 ALGORITHMS_UNDER_TEST = [(default_place, {}),
-                         (hilbert_place, {})]
+                         (hilbert_place, {}),
+                         (sa_place, {})]
 
 
 @pytest.mark.parametrize("algorithm,kwargs", ALGORITHMS_UNDER_TEST)

--- a/tests/place_and_route/place/test_generic_place.py
+++ b/tests/place_and_route/place/test_generic_place.py
@@ -28,7 +28,7 @@ from rig.place_and_route.place.sa import place as sa_place
 # with applicable keyword arguments.
 ALGORITHMS_UNDER_TEST = [(default_place, {}),
                          (hilbert_place, {}),
-                         (sa_place, {"effort": 1.0}),
+                         (sa_place, {}),
                          # Testing with effort = 0 tests the initial (random)
                          # placement solutions of the SA placer.
                          (sa_place, {"effort": 0.0})]

--- a/tests/place_and_route/place/test_place_utils.py
+++ b/tests/place_and_route/place/test_place_utils.py
@@ -5,7 +5,32 @@ from rig.machine import Cores
 from rig.place_and_route.constraints import ReserveResourceConstraint
 
 from rig.place_and_route.place.utils import \
-    subtract_resources, overallocated, resources_after_reservation
+    add_resources, subtract_resources, overallocated, \
+    resources_after_reservation
+
+
+def test_add_resources():
+    # Null-case
+    assert add_resources({}, {}) == {}
+
+    # Adding nothing to something
+    assert add_resources({"a": 0, "b": 0}, {}) == {"a": 0, "b": 0}
+
+    # Adding subset of zeros to something
+    assert add_resources({"a": 0, "b": 0}, {"a": 0}) \
+        == {"a": 0, "b": 0}
+
+    # Adding zeros to something
+    assert add_resources({"a": 0, "b": 0}, {"a": 0, "b": 0}) \
+        == {"a": 0, "b": 0}
+
+    # Adding subset of non-zeros to something
+    assert add_resources({"a": 10, "b": 20}, {"a": 1}) \
+        == {"a": 11, "b": 20}
+
+    # Adding non-zeros to something
+    assert add_resources({"a": 10, "b": 20}, {"a": 1, "b": 2}) \
+        == {"a": 11, "b": 22}
 
 
 def test_subtract_resources():

--- a/tests/place_and_route/place/test_place_utils.py
+++ b/tests/place_and_route/place/test_place_utils.py
@@ -1,12 +1,16 @@
 """Test utility functions for placers."""
 
-from rig.machine import Cores
+import pytest
+
+from rig.machine import Machine, Cores
+
+from rig.place_and_route.exceptions import InsufficientResourceError
 
 from rig.place_and_route.constraints import ReserveResourceConstraint
 
 from rig.place_and_route.place.utils import \
     add_resources, subtract_resources, overallocated, \
-    resources_after_reservation
+    resources_after_reservation, apply_reserve_resource_constraint
 
 
 def test_add_resources():
@@ -90,3 +94,50 @@ def test_unreserved_resources():
     # Constrain everything away
     constraint = ReserveResourceConstraint(Cores, slice(0, 10))
     assert resources_after_reservation({Cores: 10}, constraint) == {Cores: 0}
+
+
+def test_apply_reserve_resource_constraint():
+    machine = Machine(2, 1, {Cores: 3}, {(0, 0): {Cores: 1}})
+    machine_ = machine.copy()
+
+    # Null constraint changes nothing
+    constraint = ReserveResourceConstraint(Cores, slice(0, 0))
+    apply_reserve_resource_constraint(machine, constraint)
+    assert machine == machine_
+
+    # Global constraint changes global resources and resource exceptions
+    constraint = ReserveResourceConstraint(Cores, slice(0, 1))
+    apply_reserve_resource_constraint(machine, constraint)
+    assert machine == Machine(2, 1, {Cores: 2}, {(0, 0): {Cores: 0}})
+    machine = machine_.copy()
+
+    # Local constraint only modifes exceptions
+    constraint = ReserveResourceConstraint(Cores, slice(0, 1), (0, 0))
+    apply_reserve_resource_constraint(machine, constraint)
+    assert machine == Machine(2, 1, {Cores: 3}, {(0, 0): {Cores: 0}})
+    machine = machine_.copy()
+
+    constraint = ReserveResourceConstraint(Cores, slice(0, 1), (1, 0))
+    apply_reserve_resource_constraint(machine, constraint)
+    assert machine == Machine(2, 1, {Cores: 3},
+                              {(0, 0): {Cores: 1}, (1, 0): {Cores: 2}})
+    machine = machine_.copy()
+
+    # Globally tortologically impossible constraints should fail
+    constraint = ReserveResourceConstraint(Cores, slice(0, 4))
+    with pytest.raises(InsufficientResourceError):
+        apply_reserve_resource_constraint(machine, constraint)
+    machine = machine_.copy()
+
+    # Globally tortologically impossible constraints should fail when the
+    # failiure is only due to an exception
+    constraint = ReserveResourceConstraint(Cores, slice(0, 2))
+    with pytest.raises(InsufficientResourceError):
+        apply_reserve_resource_constraint(machine, constraint)
+    machine = machine_.copy()
+
+    # Local tortologically impossible constraints should fail
+    constraint = ReserveResourceConstraint(Cores, slice(0, 2), (0, 0))
+    with pytest.raises(InsufficientResourceError):
+        apply_reserve_resource_constraint(machine, constraint)
+    machine = machine_.copy()

--- a/tests/place_and_route/place/test_sa.py
+++ b/tests/place_and_route/place/test_sa.py
@@ -1,0 +1,426 @@
+import pytest
+
+from itertools import cycle
+
+from mock import Mock, call
+
+from six import iteritems, next
+
+from rig.netlist import Net
+
+from rig.machine import Machine, Cores, SDRAM
+
+from rig.place_and_route.place import sa
+
+import random
+
+
+def test__net_cost_no_wrap():
+    """Make sure net costs are calculated correctly."""
+    machine = Machine(3, 3)
+    l2v = {(x, y): [object() for _ in range(3)]
+           for x in range(3) for y in range(3)}
+    placements = {}
+    for xy, vs in iteritems(l2v):
+        for v in vs:
+            placements[v] = xy
+
+    # Should report zero cost for a net with no targets
+    assert sa._net_cost(Net(l2v[(0, 0)][0], []), placements, False, machine) == \
+        0.0
+
+    # Should report zero cost for a net with targets in the same chip
+    assert sa._net_cost(Net(l2v[(0, 0)][0],
+                            l2v[(0, 0)][1:]),
+                        placements, False, machine) == 0.0
+
+    # Should report cost 1 for a net to a chip one cell away
+    assert sa._net_cost(Net(l2v[(1, 1)][0],
+                            l2v[(1, 0)][0]),
+                        placements, False, machine) == 1.0
+    assert sa._net_cost(Net(l2v[(1, 1)][0],
+                            l2v[(2, 1)][0]),
+                        placements, False, machine) == 1.0
+
+    # Should report cost for a square net
+    assert sa._net_cost(Net(l2v[(1, 1)][0],
+                            l2v[(2, 2)][0]),
+                        placements, False, machine) == 2.0
+    assert sa._net_cost(Net(l2v[(0, 0)][0],
+                            l2v[(2, 2)][0]),
+                        placements, False, machine) == 4.0
+
+    # Should account for the weight
+    assert sa._net_cost(Net(l2v[(0, 0)][0],
+                            l2v[(2, 2)][0], 0.5),
+                        placements, False, machine) == 4.0 / 2.0
+
+
+def test__net_cost_with_wrap():
+    """Make sure net costs are calculated correctly when wrapping."""
+    machine = Machine(3, 3)
+    l2v = {(x, y): [object() for _ in range(3)]
+           for x in range(3) for y in range(3)}
+    placements = {}
+    for xy, vs in iteritems(l2v):
+        for v in vs:
+            placements[v] = xy
+
+    # Should report zero cost for a net with no targets
+    assert sa._net_cost(Net(l2v[(0, 0)][0], []), placements, True, machine) == \
+        0.0
+
+    # Should report zero cost for a net with targets in the same chip
+    assert sa._net_cost(Net(l2v[(0, 0)][0],
+                            l2v[(0, 0)][1:]),
+                        placements, True, machine) == 0.0
+
+    # Should report cost 1 for a net to a chip one cell away
+    assert sa._net_cost(Net(l2v[(1, 1)][0],
+                            l2v[(1, 0)][0]),
+                        placements, True, machine) == 1.0
+    assert sa._net_cost(Net(l2v[(1, 1)][0],
+                            l2v[(2, 1)][0]),
+                        placements, True, machine) == 1.0
+    # ...with wrapping
+    assert sa._net_cost(Net(l2v[(2, 2)][0],
+                            l2v[(2, 0)][0]),
+                        placements, True, machine) == 1.0
+    assert sa._net_cost(Net(l2v[(2, 2)][0],
+                            l2v[(0, 2)][0]),
+                        placements, True, machine) == 1.0
+
+    # Should report cost for a square net
+    assert sa._net_cost(Net(l2v[(1, 1)][0],
+                            l2v[(2, 2)][0]),
+                        placements, True, machine) == 2.0
+    assert sa._net_cost(Net(l2v[(0, 0)][0],
+                            [l2v[(1, 1)][0], l2v[(2, 2)][0]]),
+                        placements, True, machine) == 4.0
+    # With wrapping
+    assert sa._net_cost(Net(l2v[(0, 0)][0],
+                            l2v[(2, 2)][0]),
+                        placements, True, machine) == 2.0
+
+    # Should account for the weight
+    assert sa._net_cost(Net(l2v[(0, 0)][0],
+                            l2v[(2, 2)][0], 0.5),
+                        placements, True, machine) == 2.0 / 2.0
+
+
+@pytest.mark.parametrize("resources,expectation",
+                         [({}, []),
+                          # Using free resources should work
+                          ({SDRAM: 32}, []),
+                          ({Cores: 1}, []),
+                          ({Cores: 1, SDRAM: 16}, []),
+                          # Vertices should be greedily removed left-to-right
+                          # to meet a request, skipping fixed vertices
+                          ({Cores: 2}, ["v1"]),
+                          ({Cores: 3}, ["v1", "v3"]),
+                          ({SDRAM: 64}, ["v1", "v3"]),
+                          ({SDRAM: 128}, ["v1", "v3", "v4"]),
+                          # Requesting more resources than can be freed up
+                          # should fail
+                          ({Cores: 4}, None),
+                          # More resources than are available overall should
+                          # fail
+                          ({Cores: 5}, None),
+                          ({SDRAM: 129}, None)])
+def test__get_candidate_swap(resources, expectation):
+    machine = Machine(1, 1, chip_resources={Cores: 4, SDRAM: 128})
+
+    v1 = "v1"
+    v2 = "v2"
+    v3 = "v3"
+    v4 = "v4"
+
+    l2v = {(0, 0): [v1, v2, v3, v4]}
+
+    vertices_resources = {
+        v1: {Cores: 1},
+        v2: {Cores: 1},
+        v3: {Cores: 1, SDRAM: 64},
+        v4: {SDRAM: 32},
+    }
+    machine.chip_resource_exceptions = {
+        (0, 0): {Cores: 1, SDRAM: 32},
+    }
+
+    fixed_vertices = {v2: (0, 0)}
+
+    assert sa._get_candidate_swap(resources,
+                                  (0, 0), l2v, vertices_resources,
+                                  fixed_vertices, machine) == expectation
+
+
+def test__swap():
+    """Test that the swap function updates all required data structures."""
+    machine = Machine(3, 3, {Cores: 7},
+                      {(x, y): {Cores: 1}
+                       for x in range(3)
+                       for y in range(3)})
+    l2v = {(x, y): [object() for _ in range(3)]
+           for x in range(3) for y in range(3)}
+
+    # At each location, the Nth vertex uses N cores.
+    vertices_resources = {}
+    for loc, vertices in iteritems(l2v):
+        for i, vertex in enumerate(vertices):
+            vertices_resources[vertex] = {Cores: i+1}
+
+    placements = {}
+    for xy, vs in iteritems(l2v):
+        for v in vs:
+            placements[v] = xy
+
+    # Create a copy of the initial setup for easy comparison
+    machine_ = machine.copy()
+    l2v_ = {xy: vs[:] for xy, vs in iteritems(l2v)}
+    vertices_resources_ = {v: r.copy()
+                           for v, r in iteritems(vertices_resources)}
+    placements_ = placements.copy()
+
+    # A null swap should achieve nothing
+    sa._swap([], (0, 0), [], (1, 1),
+             l2v, vertices_resources, placements, machine)
+    assert machine == machine_
+    assert l2v == l2v_
+    assert vertices_resources == vertices_resources_
+    assert placements == placements_
+
+    # Moving a single object should work
+    sa._swap([l2v[(0, 0)][0]], (0, 0), [], (1, 1),
+             l2v, vertices_resources, placements, machine)
+    machine_after_move = machine_.copy()
+    machine_after_move[(0, 0)] = {Cores: 2}
+    machine_after_move[(1, 1)] = {Cores: 0}
+    assert machine == machine_after_move
+    l2v_after_move = l2v_.copy()
+    l2v_after_move[(0, 0)] = l2v_[(0, 0)][1:]
+    l2v_after_move[(1, 1)] = l2v_[(1, 1)] + [l2v_[(0, 0)][0]]
+    assert l2v == l2v_after_move
+    assert vertices_resources == vertices_resources_
+    placements_after_move = placements_.copy()
+    placements_after_move[l2v_[(0, 0)][0]] = (1, 1)
+    assert placements == placements_after_move
+
+    # Should be able to swap back again (note the re-ordering within the core)
+    sa._swap([], (0, 0), [l2v[(1, 1)][-1]], (1, 1),
+             l2v, vertices_resources, placements, machine)
+    assert machine == machine_
+    l2v_after_move = l2v_.copy()
+    l2v_after_move[(0, 0)] = l2v_[(0, 0)][1:] + [l2v_[(0, 0)][0]]
+    assert l2v == l2v_after_move
+    assert vertices_resources == vertices_resources_
+    assert placements == placements_
+
+    # Should be able to swap en-mass
+    sa._swap(l2v[(1, 2)][:], (1, 2), l2v[(2, 2)][:], (2, 2),
+             l2v, vertices_resources, placements, machine)
+    assert machine == machine_
+    l2v_after_move[(1, 2)] = l2v_[(2, 2)][:]
+    l2v_after_move[(2, 2)] = l2v_[(1, 2)][:]
+    assert l2v == l2v_after_move
+    assert vertices_resources == vertices_resources_
+    placements_after_move = placements_.copy()
+    for v in l2v_[(1, 2)]:
+        placements_after_move[v] = (2, 2)
+    for v in l2v_[(2, 2)]:
+        placements_after_move[v] = (1, 2)
+    assert placements == placements_after_move
+
+
+@pytest.mark.parametrize("has_wrap_around_links", [True, False])
+def test__step_singleton(has_wrap_around_links):
+    """Make sure that the step function always fails when there is a singleton
+    machine since there is no swap to be made."""
+    machine = Machine(1, 1)
+    l2v = {(0, 0): [object() for _ in range(3)]}
+    vertices_resources = {v: {} for v in l2v[(0, 0)]}
+    vertices = list(vertices_resources)
+    placements = {v: (0, 0) for v in l2v[(0, 0)]}
+    v2n = {}
+    fixed_vertices = {}
+
+    # The step is called with a very high temperature meaning that if it did
+    # try to swap it would probably be accepted.
+    r = random.Random()
+    for _ in range(10):
+        assert sa._step(vertices, 1, 1.e1000, placements, l2v, v2n,
+                        vertices_resources, fixed_vertices, machine,
+                        has_wrap_around_links, r) == (False, 0.0)
+
+
+@pytest.mark.parametrize("has_wrap_around_links", [True, False])
+def test__step_not_same_chip_and_rand_range(has_wrap_around_links):
+    """Make sure that the step function always chooses a chip which isn't the
+    same as the source. Also verifies that random number generator for target
+    selection is stimulated correctly."""
+    machine = Machine(3, 1)
+    l2v = {(0, 0): [object()], (1, 0): [object()]}
+    vertices_resources = {v: {} for v in [l2v[(0, 0)][0], l2v[(1, 0)][0]]}
+    vertices = list(vertices_resources)
+    placements = {l2v[(0, 0)][0]: (0, 0), l2v[(1, 0)][0]: (1, 0)}
+    v2n = {v: [] for v in vertices}
+    fixed_vertices = {}
+
+    r = random.Random()
+
+    # Hard-code the choice of vertex to swap as the one at (1, 0)
+    r.choice = Mock(return_value=l2v[(1, 0)][0])
+
+    # A fake random number generator which generates the sequence 1, 0, 0, 0 so
+    # that the initial random choice of swap location is (1, 0) followed by (0,
+    # 0). In this test we want to guaruntee that the first result is rejected
+    # (since it is the same as the "chosen" source vertex) and that the second
+    # one is accepted.
+    sequence_iter = iter([1, 0, 0, 0])
+    r.randint = Mock(side_effect=lambda a, b: next(sequence_iter))
+
+    # We don't really care what the outcome of the step is in this case
+    sa._step(vertices, 1, 1.e1000, placements, l2v, v2n,
+             vertices_resources, fixed_vertices, machine,
+             has_wrap_around_links, r)
+
+    # Make sure that the random number generator was called correctly
+    if has_wrap_around_links:
+        # Should be requesting ranges which can wrap-around
+        correct_calls = [
+            call(0, 2),
+            call(-1, 1),
+            call(0, 2),
+            call(-1, 1),
+        ]
+    else:
+        correct_calls = [
+            # Should be requesting ranges which are clamped within the system
+            call(0, 2),
+            call(0, 0),
+            call(0, 2),
+            call(0, 0),
+        ]
+    r.randint.assert_has_calls(correct_calls, any_order=False)
+
+
+@pytest.mark.parametrize("has_wrap_around_links", [True, False])
+def test__step_dest_not_dead(has_wrap_around_links):
+    """Make sure that the step function always fails when the selected
+    target chip is dead."""
+    machine = Machine(3, 1, dead_chips=set([(2, 0)]))
+    l2v = {(0, 0): [object()], (1, 0): [object()]}
+    vertices_resources = {v: {} for v in [l2v[(0, 0)][0], l2v[(1, 0)][0]]}
+    vertices = list(vertices_resources)
+    placements = {l2v[(0, 0)][0]: (0, 0), l2v[(1, 0)][0]: (1, 0)}
+    v2n = {v: [] for v in vertices}
+    fixed_vertices = {}
+
+    r = random.Random()
+
+    # Hard-code the choice of vertex to swap as the one at (1, 0)
+    r.choice = Mock(return_value=l2v[(1, 0)][0])
+
+    # Generate a sequence of numbers such that (2, 0) is always chosen (which
+    # is a dead chip)
+    sequence_iter = iter(cycle([2, 0]))
+    r.randint = Mock(side_effect=lambda a, b: next(sequence_iter))
+
+    # We simply make sure that this reliably doesn't produce a swap
+    for _ in range(10):
+        assert sa._step(vertices, 1, 1.e1000, placements, l2v, v2n,
+                        vertices_resources, fixed_vertices, machine,
+                        has_wrap_around_links, r) == (False, 0.0)
+
+
+@pytest.mark.parametrize("has_wrap_around_links", [True, False])
+def test__step_dest_too_small(has_wrap_around_links):
+    """Make sure that the step function always fails when the selected
+    target chip is too small."""
+    machine = Machine(2, 1, {Cores: 2}, {(0, 0): {Cores: 1},
+                                         (1, 0): {Cores: 0}})
+    l2v = {(0, 0): [], (1, 0): [object()]}
+    vertices_resources = {l2v[(1, 0)][0]: {Cores: 2}}
+    vertices = list(vertices_resources)
+    placements = {l2v[(1, 0)][0]: (1, 0)}
+    v2n = {v: [] for v in vertices}
+    fixed_vertices = {}
+
+    r = random.Random()
+
+    # Hard-code the choice of vertex to swap as the one at (1, 0)
+    r.choice = Mock(return_value=l2v[(1, 0)][0])
+
+    # Generate a sequence of numbers such that (0, 0) is always chosen (which
+    # is a chip which doesn't have enough resources to fit the swap)
+    sequence_iter = iter(cycle([0, 0]))
+    r.randint = Mock(side_effect=lambda a, b: next(sequence_iter))
+
+    # We simply make sure that this reliably doesn't produce a swap
+    for _ in range(10):
+        assert sa._step(vertices, 1, 1.e1000, placements, l2v, v2n,
+                        vertices_resources, fixed_vertices, machine,
+                        has_wrap_around_links, r) == (False, 0.0)
+
+
+@pytest.mark.parametrize("has_wrap_around_links", [True, False])
+def test__step_swap_too_large(has_wrap_around_links):
+    """Make sure that the step function always fails when the swap made with the
+    destination does not fit in the space left at the source."""
+    machine = Machine(2, 1, {Cores: 2}, {(0, 0): {Cores: 0},
+                                         (1, 0): {Cores: 0}})
+    l2v = {(0, 0): [object()], (1, 0): [object()]}
+    vertices_resources = {l2v[(0, 0)][0]: {Cores: 2},
+                          l2v[(1, 0)][0]: {Cores: 1}}
+    vertices = list(vertices_resources)
+    placements = {l2v[(0, 0)][0]: (0, 0), l2v[(1, 0)][0]: (1, 0)}
+    v2n = {v: [] for v in vertices}
+    fixed_vertices = {}
+
+    r = random.Random()
+
+    # Hard-code the choice of vertex to swap as the one at (1, 0)
+    r.choice = Mock(return_value=l2v[(1, 0)][0])
+
+    # Generate a sequence of numbers such that (0, 0) is always chosen (which
+    # is a chip whose only vertex is larger than the space available in (1, 0)
+    # once the swap has been made
+    sequence_iter = iter(cycle([0, 0]))
+    r.randint = Mock(side_effect=lambda a, b: next(sequence_iter))
+
+    # We simply make sure that this reliably doesn't produce a swap
+    for _ in range(10):
+        assert sa._step(vertices, 1, 1.e1000, placements, l2v, v2n,
+                        vertices_resources, fixed_vertices, machine,
+                        has_wrap_around_links, r) == (False, 0.0)
+
+
+@pytest.mark.parametrize("return_value,should_terminate",
+                         [(None, False),
+                          (123, False),
+                          (0, False),
+                          ("hi", False),
+                          ("", False),
+                          ([0], False),
+                          ([], False),
+                          (True, False),
+                          (False, True)])
+def test_callback(return_value, should_terminate):
+    """Ensure that a callback function can be registered and can control the
+    placement process."""
+    vertices = [object() for _ in range(4)]
+    vertices_resources = {v: {Cores: 1} for v in vertices}
+    nets = [Net(vertices[i], vertices[(i+1) % 4])
+            for i in range(4)]
+    machine = Machine(4, 1, {Cores: 1})
+
+    cb = Mock(return_value=return_value)
+
+    r = random.Random()
+    r.seed(1)
+    sa.place(vertices_resources, nets, machine, [],
+             on_temperature_change=cb, random=r)
+
+    if should_terminate:
+        assert len(cb.mock_calls) == 1
+    else:
+        assert len(cb.mock_calls) > 1

--- a/tests/test_machine.py
+++ b/tests/test_machine.py
@@ -267,6 +267,7 @@ def test_has_wrap_around_links():
     assert machine.has_wrap_around_links(0.5)
     assert machine.has_wrap_around_links(0.1)
 
+
 def test_links_opposite():
     assert Links.north.opposite == Links.south
     assert Links.north_east.opposite == Links.south_west

--- a/tests/test_machine.py
+++ b/tests/test_machine.py
@@ -266,3 +266,11 @@ def test_has_wrap_around_links():
     assert not machine.has_wrap_around_links(1.0)
     assert machine.has_wrap_around_links(0.5)
     assert machine.has_wrap_around_links(0.1)
+
+def test_links_opposite():
+    assert Links.north.opposite == Links.south
+    assert Links.north_east.opposite == Links.south_west
+    assert Links.east.opposite == Links.west
+    assert Links.south.opposite == Links.north
+    assert Links.south_west.opposite == Links.north_east
+    assert Links.west.opposite == Links.east

--- a/tests/test_machine.py
+++ b/tests/test_machine.py
@@ -64,6 +64,59 @@ class TestMachine(object):
         assert machine.dead_links == other_machine.dead_links
         assert machine.dead_links is not other_machine.dead_links
 
+    def test_eq(self):
+        """Ensure equality tests work."""
+        m = Machine(1, 3)
+        m.chip_resources = {Cores: 3}
+        m.chip_resource_exceptions = {(0, 0): {Cores: 1}}
+        m.dead_chips = set([(0, 1)])
+        m.dead_links = set([(0, 0, Links.north)])
+        
+        # Should always compare equal to itself
+        assert m == m
+        
+        # Should compare equal to a copy
+        m_ = m.copy()
+        assert m == m_
+        
+        # Should not compare equal when the sizes differ
+        m_.width = 2
+        assert m != m_
+        m_.width = 1
+        assert m == m_
+        m_.height = 4
+        assert m != m_
+        m_.height = 3
+        assert m == m_
+        
+        # Nor when resources differ
+        m_.chip_resources = {Cores: 10}
+        assert m != m_
+        m_.chip_resources = {Cores: 3}
+        assert m == m_
+        
+        # Nor when exceptions differ
+        m_.chip_resource_exceptions = {(0, 0): {Cores: 10}}
+        assert m != m_
+        m_.chip_resource_exceptions = {(0, 0): {Cores: 1}}
+        assert m == m_
+        
+        # Nor when dead chips differ
+        m_.dead_chips = set([])
+        assert m != m_
+        m_.dead_chips = set([(0, 1)])
+        assert m == m_
+        
+        # Nor when dead links differ
+        m_.dead_links = set([(0, 0, Links.south)])
+        assert m != m_
+        m_.dead_links = set([(0, 0, Links.north)])
+        assert m == m_
+        
+        # Should compare equal if exceptions result in the same system
+        m_.chip_resource_exceptions = {(0, 0): {Cores: 1}, (0, 2): {Cores: 3}}
+        assert m == m_
+
     def test_in(self):
         """Ensure membership tests work."""
         width = 10

--- a/tests/test_machine.py
+++ b/tests/test_machine.py
@@ -71,14 +71,14 @@ class TestMachine(object):
         m.chip_resource_exceptions = {(0, 0): {Cores: 1}}
         m.dead_chips = set([(0, 1)])
         m.dead_links = set([(0, 0, Links.north)])
-        
+
         # Should always compare equal to itself
         assert m == m
-        
+
         # Should compare equal to a copy
         m_ = m.copy()
         assert m == m_
-        
+
         # Should not compare equal when the sizes differ
         m_.width = 2
         assert m != m_
@@ -88,31 +88,31 @@ class TestMachine(object):
         assert m != m_
         m_.height = 3
         assert m == m_
-        
+
         # Nor when resources differ
         m_.chip_resources = {Cores: 10}
         assert m != m_
         m_.chip_resources = {Cores: 3}
         assert m == m_
-        
+
         # Nor when exceptions differ
         m_.chip_resource_exceptions = {(0, 0): {Cores: 10}}
         assert m != m_
         m_.chip_resource_exceptions = {(0, 0): {Cores: 1}}
         assert m == m_
-        
+
         # Nor when dead chips differ
         m_.dead_chips = set([])
         assert m != m_
         m_.dead_chips = set([(0, 1)])
         assert m == m_
-        
+
         # Nor when dead links differ
         m_.dead_links = set([(0, 0, Links.south)])
         assert m != m_
         m_.dead_links = set([(0, 0, Links.north)])
         assert m == m_
-        
+
         # Should compare equal if exceptions result in the same system
         m_.chip_resource_exceptions = {(0, 0): {Cores: 1}, (0, 2): {Cores: 3}}
         assert m == m_

--- a/tests/test_netlist.py
+++ b/tests/test_netlist.py
@@ -25,6 +25,11 @@ class TestNet(object):
         for sink in sinks:
             assert sink in net
         assert Vertex() not in net
+        
+        # Make sure iteration works
+        vertices = list(net)
+        assert len(vertices) == len(sinks) + 1
+        assert set(vertices) == set([source] + sinks)
 
     def test_init_with_object(self):
         source = Vertex()

--- a/tests/test_netlist.py
+++ b/tests/test_netlist.py
@@ -25,7 +25,7 @@ class TestNet(object):
         for sink in sinks:
             assert sink in net
         assert Vertex() not in net
-        
+
         # Make sure iteration works
         vertices = list(net)
         assert len(vertices) == len(sinks) + 1


### PR DESCRIPTION
This PR adds a simulated-annealing based placement algorithm which very closely mimics the techniques outlined by "VPR: A New Packing, Placement and Routing Tool for FPGA Research" by Vaughn Betz and Jonathan Rose from the "1997 International Workshop on Field Programmable Logic and Applications" ([PDF](http://www.eecg.toronto.edu/~vaughn/papers/fpl97.pdf)).

The placer should fulfill all the requirements of the Rig placer prototype and thus should be ready to drop into new applications.

Performance
----------------

Though this placer is implemented in relatively inefficient Python, it is probably not unusably slow for SpiNNaker systems up to perhaps the low tens of boards. It is, however, currently the first placer which attempts to produce "good" placements. I aim to perform some runtime and quality benchmarks in the immediate future to back up these hand-wavey claims... For now, here are some ballpark numbers:

* For a **SpiNN-3 board** sized system, a full place-and-route run is **1 - 4 seconds** on my laptop for networks with 64 nodes and several multicast nets per node, depending on connectivity.

* For a **SpiNN-5 board** sized system, a 784-node pipeline-style network (stages of 10 nodes each connected all-to-all to the next stage) with 10% random connectivity is placed-and-routed in **1 minute and 32 seconds** on my laptop. In terms of quality, total net length after routing is 10,768 hops with the maximum and mean number of nets passing through a single chip is 89 and 59.5 respectively. For the hilbert placer (which runs in 1 second...) total net length is 13,417 hops and max/mean nets through a chip is 279 and 117.2 respectively. (i.e. the SA placer yields substantial improvement).

* For a **three-board** system, a 2401-node network connected as a 49x49 torus (with each node having a net connecting to its 8 neighbors) and 5% random connectivity, place-and-route completes in **9 minutes 29 seconds**. Total net length, max/mean nets-per-chip are 28,818 hops, 97 and 64.5 respectively. By comparison, for the hilbert placer (which takes 6 seconds), 46,745 hops, 257 and 189.0 come out (i.e. considerably worse).
  For a visual comparison of the respective placement solutions take a look at:
  ![Placement for SA vs Hilbert](https://cloud.githubusercontent.com/assets/193514/7787928/e7293c62-021c-11e5-911c-4931700b132b.png)
  (Left: simulated annealing, Right: Hilbert). It is worth noting that the lines shown show "as-the-crow-flies" routes and not the actual router output used to generate the above stats. Also note that the very long side-to-side connections in the left image would actually be very short wrap-around hops since a three-board system is a torus.


Current (known) limitations
---------------------------------

* **The optimisation function is path length, not congestion.** Path length estimates are much easier to quickly compute and will generally indirectly improve congestion anyway.
* **The placer runs about twice as slow for systems with torus topologies.** This is due the the increased cost of computing the (minimal) bounding box around a net in a torus.
* **Heuristic cost function poorly matches high fan-out net costs.** At present the Half-Perimeter-Wire-Length (HPWL) heuristic is used (i.e. net bounding box width + height) which is known to be a poor estimator of wire length for net fan-outs > 3. There are a whole slew of alternatives in this space however I need to do some research to see how these cope with the fact that a high fan-out net may only actually fan-out to a small number of unique locations. (In real circuits, things don't get collected up into cores).
* **Heuristic cost function assumes a non-hexagonal grid.** I need to do some reading about how best to deal with this. Bounding-hexagons are harder than bounding boxes...
* **Heuristic cost function fully-evaluated for every affected net on every swap.** This means bounding-boxes are fully recomputed for all involved nets for every swap. This is possibly wasteful however quick experiments with attempting to minimise the recomputation required did not produce significantly different runtime. This would be a priority for performance improvements since the bounding-box calculation function is by far the hottest in the algorithm.
* **The placer runs much slower than it could when far more system resource is available than required.** This is because the placer has far more space to search. I may make the placer artificially constrain the search space when more resource is available than really required in a future revision.
* **The placer is written in Python...** Just to reiterate, it is *zlowwww*. Some effort has been made to optimise the implementation of the hotter loops (e.g. a 3-4x speedup is gained by not using `min` and `max`... seriously...) but the long-term plan is to write a C-based implementation. This version, however, I expect to be sufficient for casual single-board use for a surprisingly long time.