### PR TITLE
Use core count to speed application loading

### DIFF
--- a/rig/machine_control/machine_controller.py
+++ b/rig/machine_control/machine_controller.py
@@ -852,19 +852,18 @@ class MachineController(ContextMixin):
             Time to pause (in seconds) after loading to ensure that the
             application successfully reaches the wait state before checking for
             success.
-        all_cores : bool
-            If True then the targets dictionary will be assumed to represent
-            _all_ the cores that will be loaded and a faster method to
-            determine whether all applications have been loaded correctly will
-            be used. If False (the default) then a fallback method will be
-            used.
+        use_count : bool
+            If True (the default) then the targets dictionary will be assumed
+            to represent _all_ the cores that will be loaded and a faster
+            method to determine whether all applications have been loaded
+            correctly will be used. If False a fallback method will be used.
         """
         # Get keyword arguments
         app_id = kwargs.pop("app_id")
         wait = kwargs.pop("wait")
         n_tries = kwargs.pop("n_tries")
         app_start_delay = kwargs.pop("app_start_delay")
-        all_cores = kwargs.pop("all_cores", False)
+        use_count = kwargs.pop("use_count", True)
 
         # Coerce the arguments into a single form.  If there are two arguments
         # then assume that we have filename and a map of chips and cores;
@@ -903,7 +902,7 @@ class MachineController(ContextMixin):
 
             # If running in "fast" mode then check that the correct number of
             # cores are in the "wait" state, if so then break out of this loop.
-            if (all_cores and
+            if (use_count and
                     core_count == self.count_cores_in_state("wait", app_id)):
                 unloaded = {}
                 continue

--- a/rig/machine_control/machine_controller.py
+++ b/rig/machine_control/machine_controller.py
@@ -852,12 +852,19 @@ class MachineController(ContextMixin):
             Time to pause (in seconds) after loading to ensure that the
             application successfully reaches the wait state before checking for
             success.
+        all_cores : bool
+            If True then the targets dictionary will be assumed to represent
+            _all_ the cores that will be loaded and a faster method to
+            determine whether all applications have been loaded correctly will
+            be used. If False (the default) then a fallback method will be
+            used.
         """
         # Get keyword arguments
         app_id = kwargs.pop("app_id")
         wait = kwargs.pop("wait")
         n_tries = kwargs.pop("n_tries")
         app_start_delay = kwargs.pop("app_start_delay")
+        all_cores = kwargs.pop("all_cores", False)
 
         # Coerce the arguments into a single form.  If there are two arguments
         # then assume that we have filename and a map of chips and cores;
@@ -875,6 +882,12 @@ class MachineController(ContextMixin):
                 "targets"
             )
 
+        # Count the number of cores being loaded
+        core_count = sum(
+            len(cores) for ts in six.itervalues(application_map) for
+            cores in six.itervalues(ts)
+        )
+
         # Mark all targets as unloaded
         unloaded = application_map
 
@@ -887,6 +900,13 @@ class MachineController(ContextMixin):
             # the wait state
             self.flood_fill_aplx(unloaded, app_id=app_id, wait=True)
             time.sleep(app_start_delay)
+
+            # If running in "fast" mode then check that the correct number of
+            # cores are in the "wait" state, if so then break out of this loop.
+            if (all_cores and
+                    core_count == self.count_cores_in_state("wait", app_id)):
+                unloaded = {}
+                continue
 
             # Query each target in turn to determine if it is loaded or
             # otherwise.  If it is loaded (in the wait state) then remove it


### PR DESCRIPTION
The current implementation of `load_application` queries the state of each loaded core to ensure that loading was successful. This is good for cases where the application map isn't _all_ the applications that will be loaded (i.e., a count of all cores in the `wait` state is not necessarily a count of all the cores we just tried to load), or when a failure mode may allow the right number of cores in the wrong place.
However, in the majority of cases this is overkill because:

1. This failure mode isn't currently possible.
2. Most of the time `load_application` is called once to load all applications.

The result is that loading applications takes noticeably more time than loading application data.

This commit provides a new parameter to `load_application`. If `all_cores` is True then the core count is used to quickly determine whether all applications are loaded. If False (the default) then the
current method is used.