### PR TITLE
Remove routing table entries with an stop signal

### DIFF
--- a/rig/machine_control/machine_controller.py
+++ b/rig/machine_control/machine_controller.py
@@ -1195,6 +1195,14 @@ class MachineController(ContextMixin):
         return table
 
     @ContextMixin.use_contextual_arguments()
+    def clear_routing_table_entries(self, x, y, app_id):
+        """Clear the routing table entries associated with a given application.
+        """
+        # Construct the arguments
+        arg1 = (app_id << 8) | consts.AllocOperations.free_rtr_by_app
+        self._send_scp(x, y, 0, SCPCommands.alloc_free, arg1, 0x1)
+
+    @ContextMixin.use_contextual_arguments()
     def get_p2p_routing_table(self, x, y):
         """Dump the contents of a chip's P2P routing table.
 

--- a/rig/machine_control/machine_controller.py
+++ b/rig/machine_control/machine_controller.py
@@ -969,6 +969,20 @@ class MachineController(ContextMixin):
                 "send_signal: Cannot transmit signal of type {}".format(
                     repr(signal)))
 
+        # XXX If the signal is "stop", then we first remove all routing table
+        # entries associated with the application ID. This code will be
+        # unnecessaru when SpiNNaker tools 1.4 becomes available.
+        if signal is consts.AppSignal.stop:
+            # Get a machine object so we can determine where we need to remove
+            # the routing tables.
+            mcn = self.get_machine()
+
+            # Now remove all routing entries:
+            for (x, y) in [(x, y)
+                           for x in range(mcn.width)
+                           for y in range(mcn.height) if (x, y) in mcn]:
+                self.clear_routing_table_entries(x, y, app_id)
+
         # Construct the packet for transmission
         arg1 = consts.signal_types[signal]
         arg2 = (signal << 16) | 0xff00 | app_id

--- a/tests/machine_control/test_machine_controller.py
+++ b/tests/machine_control/test_machine_controller.py
@@ -326,7 +326,7 @@ class TestMachineControllerLive(object):
          ]
     )
     def test_load_and_retrieve_routing_tables(self, controller, routes):
-        with controller(x=1, y=1):
+        with controller(x=0, y=0):
             # Load the routing table entries
             controller.load_routing_table_entries(routes)
 
@@ -346,7 +346,7 @@ class TestMachineControllerLive(object):
         assert controller.count_cores_in_state("run") == 0
 
         # All the routing tables should have gone as well
-        with controller(x=1, y=1):
+        with controller(x=0, y=0):
             loaded = controller.get_routing_table_entries()
 
         for entry in loaded:

--- a/tests/machine_control/test_machine_controller.py
+++ b/tests/machine_control/test_machine_controller.py
@@ -1525,6 +1525,22 @@ class TestMachineController(object):
         cn.read_struct_field.assert_called_once_with("sv", "rtr_copy", x, y)
         cn.read.assert_called_once_with(addr, 1024*16, x, y)
 
+    @pytest.mark.parametrize("x, y, app_id", [(0, 1, 65), (3, 2, 55)])
+    def test_clear_routing_table_entries(self, x, y, app_id):
+        # Create the controller to ensure that appropriate packets are sent
+        cn = MachineController("localhost")
+        cn._send_scp = mock.Mock()
+
+        # Clear the routing table entries
+        with cn(app_id=app_id, x=x, y=y):
+            cn.clear_routing_table_entries()
+
+        # Assert ONE packet was sent to do this
+        arg1 = (app_id << 8) | consts.AllocOperations.free_rtr_by_app
+        arg2 = 1
+        cn._send_scp.assert_called_once_with(x, y, 0, SCPCommands.alloc_free,
+                                             arg1, arg2)
+
     def test_get_p2p_routing_table(self):
         cn = MachineController("localhost")
 


### PR DESCRIPTION
 - [x] Add a hardware test for `clear_routing_table_entries`

e223add should be removed when SpiNNaker tools 1.4 is released.