### PR TITLE
Make encoding routes in RoutingTrees non-lossy.

### DIFF
--- a/docs/source/machine.rst
+++ b/docs/source/machine.rst
@@ -3,3 +3,4 @@
 
 .. automodule:: rig.machine
     :members:
+    :special-members:

--- a/rig/place_and_route/place/hilbert.py
+++ b/rig/place_and_route/place/hilbert.py
@@ -117,7 +117,8 @@ def place(vertices_resources, nets, machine, constraints):
             # Place the vertex
             unplaced_vertices.remove(constraint.vertex)
             placements[constraint.vertex] = loc
-        elif isinstance(constraint, ReserveResourceConstraint):
+        elif isinstance(constraint,  # pragma: no branch
+                        ReserveResourceConstraint):
             apply_reserve_resource_constraint(machine, constraint)
 
     # Allocate chips along a Hilbert curve large enough to cover the whole

--- a/rig/place_and_route/route/utils.py
+++ b/rig/place_and_route/route/utils.py
@@ -28,11 +28,13 @@ def longest_dimension_first(vector, start=(0, 0), width=None, height=None):
 
     Generates
     ---------
-    (x, y)
-        Produces (in order) an (x, y) pair for every hop along the longest
-        dimension first route. Ties are broken randomly. The first generated
-        value is that of the first hop after the starting position, the last
-        generated value is the destination position.
+    (:py:class:`~rig.machine.Links`, (x, y))
+        Produces (in order) a (direction, (x, y)) pair for every hop along the
+        longest dimension first route. The direction gives the direction to
+        travel in from the previous step to reach the current step. Ties are
+        broken randomly. The first generated value is that of the first hop
+        after the starting position, the last generated value is the
+        destination position.
     """
     x, y = start
 
@@ -47,12 +49,14 @@ def longest_dimension_first(vector, start=(0, 0), width=None, height=None):
         sign = 1 if magnitude > 0 else -1
         for _ in range(abs(magnitude)):
             if dimension == 0:
-                x += sign
+                dx, dy = sign, 0
             elif dimension == 1:
-                y += sign
+                dx, dy = 0, sign
             elif dimension == 2:  # pragma: no branch
-                x -= sign
-                y -= sign
+                dx, dy = -sign, -sign
+
+            x += dx
+            y += dy
 
             # Wrap-around if required
             if width is not None:
@@ -60,7 +64,9 @@ def longest_dimension_first(vector, start=(0, 0), width=None, height=None):
             if height is not None:
                 y %= height
 
-            yield (x, y)
+            direction = Links.from_vector((dx, dy))
+
+            yield (direction, (x, y))
 
 
 def links_between(a, b, machine):

--- a/rig/place_and_route/routing_tree.py
+++ b/rig/place_and_route/routing_tree.py
@@ -18,12 +18,24 @@ class RoutingTree(object):
     chip : (x, y)
         The chip the route is currently passing through.
     children : set
-        A :py:class:`set` of the next steps in the route. This may be one of:
+        A :py:class:`set` of the next steps in the route represented by a
+        (route, object) tuple.
+
+        The route must be either :py:class:`~rig.routing_table.Routes` or
+        `None`. If :py:class:`~rig.routing_table.Routes` then this indicates
+        the next step in the route uses a particular route.
+
+        The object indicates the intended destination of this step in the
+        route. It may be one of:
 
         * :py:class:`~.rig.place_and_route.routing_tree.RoutingTree`
-          representing a step onto the next chip
-        * :py:class:`~.rig.routing_table.Routes` representing a core or link to
-          terminate on.
+          representing the continuation of the routing tree after following a
+          given link. (Only used if the :py:class:`~rig.routing_table.Routes`
+          object is a link and not a core).
+        * A vertex (i.e. some other Python object) when the route terminates at
+          the supplied vertex. Note that the direction may be None and so
+          additional logic may be required to determine what core to target to
+          reach the vertex.
     """
 
     __slots__ = ["chip", "children"]
@@ -33,17 +45,18 @@ class RoutingTree(object):
         self.children = children if children is not None else set()
 
     def __iter__(self):
-        """Iterate over this node and all its children, recursively and in no
-        specific order.
+        """Iterate over this node and then all its children, recursively and in
+        no specific order. This iterator iterates over the child *objects*
+        (i.e. not the route part of the child tuple).
         """
         yield self
 
-        for child in self.children:
-            if isinstance(child, RoutingTree):
-                for subchild in child:
+        for route, obj in self.children:
+            if isinstance(obj, RoutingTree):
+                for subchild in obj:
                     yield subchild
             else:
-                yield child
+                yield obj
 
     def __repr__(self):
         return "<RoutingTree at {} with {} {}>".format(

--- a/tests/place_and_route/route/test_route_utils.py
+++ b/tests/place_and_route/route/test_route_utils.py
@@ -9,90 +9,115 @@ def test_longest_dimension_first():
     assert list(longest_dimension_first((0, 0, 0))) == []
 
     # Single hop in each dimension
-    assert list(longest_dimension_first((1, 0, 0))) == [(1, 0)]
-    assert list(longest_dimension_first((0, 1, 0))) == [(0, 1)]
-    assert list(longest_dimension_first((0, 0, 1))) == [(-1, -1)]
+    assert list(longest_dimension_first((1, 0, 0))) \
+        == [(Links.east, (1, 0))]
+    assert list(longest_dimension_first((0, 1, 0))) \
+        == [(Links.north, (0, 1))]
+    assert list(longest_dimension_first((0, 0, 1))) \
+        == [(Links.south_west, (-1, -1))]
 
     # Negative single hop in each dimension
-    assert list(longest_dimension_first((-1, 0, 0))) == [(-1, 0)]
-    assert list(longest_dimension_first((0, -1, 0))) == [(0, -1)]
-    assert list(longest_dimension_first((0, 0, -1))) == [(1, 1)]
+    assert list(longest_dimension_first((-1, 0, 0))) \
+        == [(Links.west, (-1, 0))]
+    assert list(longest_dimension_first((0, -1, 0))) \
+        == [(Links.south, (0, -1))]
+    assert list(longest_dimension_first((0, 0, -1))) \
+        == [(Links.north_east, (1, 1))]
 
     # Single hop from alternative starting point
-    assert list(longest_dimension_first((1, 0, 0), (10, 100))) == [(11, 100)]
-    assert list(longest_dimension_first((0, 1, 0), (10, 100))) == [(10, 101)]
-    assert list(longest_dimension_first((0, 0, 1), (10, 100))) == [(9, 99)]
+    assert list(longest_dimension_first((1, 0, 0), (10, 100))) \
+        == [(Links.east, (11, 100))]
+    assert list(longest_dimension_first((0, 1, 0), (10, 100))) \
+        == [(Links.north, (10, 101))]
+    assert list(longest_dimension_first((0, 0, 1), (10, 100))) \
+        == [(Links.south_west, (9, 99))]
 
     # Negative single hop from alternative starting point
-    assert list(longest_dimension_first((-1, 0, 0), (10, 100))) == [(9, 100)]
-    assert list(longest_dimension_first((0, -1, 0), (10, 100))) == [(10, 99)]
-    assert list(longest_dimension_first((0, 0, -1), (10, 100))) == [(11, 101)]
+    assert list(longest_dimension_first((-1, 0, 0), (10, 100))) \
+        == [(Links.west, (9, 100))]
+    assert list(longest_dimension_first((0, -1, 0), (10, 100))) \
+        == [(Links.south, (10, 99))]
+    assert list(longest_dimension_first((0, 0, -1), (10, 100))) \
+        == [(Links.north_east, (11, 101))]
 
     # Test wrap-around of single hop
     assert list(longest_dimension_first((1, 0, 0), width=1, height=1)) \
-        == [(0, 0)]
+        == [(Links.east, (0, 0))]
     assert list(longest_dimension_first((0, 1, 0), width=1, height=1)) \
-        == [(0, 0)]
+        == [(Links.north, (0, 0))]
     assert list(longest_dimension_first((0, 0, 1), width=1, height=1)) \
-        == [(0, 0)]
+        == [(Links.south_west, (0, 0))]
     assert list(longest_dimension_first((-1, 0, 0), width=1, height=1)) \
-        == [(0, 0)]
+        == [(Links.west, (0, 0))]
     assert list(longest_dimension_first((0, -1, 0), width=1, height=1)) \
-        == [(0, 0)]
+        == [(Links.south, (0, 0))]
     assert list(longest_dimension_first((0, 0, -1), width=1, height=1)) \
-        == [(0, 0)]
+        == [(Links.north_east, (0, 0))]
 
     # Test wrap-around in each direction
     assert list(longest_dimension_first((2, 0, 0), width=2, height=2)) \
-        == [(1, 0), (0, 0)]
+        == [(Links.east, (1, 0)), (Links.east, (0, 0))]
     assert list(longest_dimension_first((0, 2, 0), width=2, height=2)) \
-        == [(0, 1), (0, 0)]
+        == [(Links.north, (0, 1)), (Links.north, (0, 0))]
     assert list(longest_dimension_first((0, 0, 2), width=2, height=2)) \
-        == [(1, 1), (0, 0)]
+        == [(Links.south_west, (1, 1)), (Links.south_west, (0, 0))]
     assert list(longest_dimension_first((-2, 0, 0), width=2, height=2)) \
-        == [(1, 0), (0, 0)]
+        == [(Links.west, (1, 0)), (Links.west, (0, 0))]
     assert list(longest_dimension_first((0, -2, 0), width=2, height=2)) \
-        == [(0, 1), (0, 0)]
+        == [(Links.south, (0, 1)), (Links.south, (0, 0))]
     assert list(longest_dimension_first((0, 0, -2), width=2, height=2)) \
-        == [(1, 1), (0, 0)]
+        == [(Links.north_east, (1, 1)), (Links.north_east, (0, 0))]
 
     # Test wrap-around with different width & height
     assert list(longest_dimension_first((0, 0, 1), width=2, height=3)) \
-        == [(1, 2)]
+        == [(Links.south_west, (1, 2))]
 
     # Test multiple hops on single dimension
     assert list(longest_dimension_first((2, 0, 0))) \
-        == [(1, 0), (2, 0)]
+        == [(Links.east, (1, 0)), (Links.east, (2, 0))]
     assert list(longest_dimension_first((0, 2, 0))) \
-        == [(0, 1), (0, 2)]
+        == [(Links.north, (0, 1)), (Links.north, (0, 2))]
     assert list(longest_dimension_first((0, 0, 2))) \
-        == [(-1, -1), (-2, -2)]
+        == [(Links.south_west, (-1, -1)), (Links.south_west, (-2, -2))]
 
     # Test dimension ordering with all positive magnitudes and some zero
     assert list(longest_dimension_first((2, 1, 0))) \
-        == [(1, 0), (2, 0), (2, 1)]
+        == [(Links.east, (1, 0)), (Links.east, (2, 0)), (Links.north, (2, 1))]
     assert list(longest_dimension_first((0, 2, 1))) \
-        == [(0, 1), (0, 2), (-1, 1)]
+        == [(Links.north, (0, 1)), (Links.north, (0, 2)),
+            (Links.south_west, (-1, 1))]
     assert list(longest_dimension_first((1, 0, 2))) \
-        == [(-1, -1), (-2, -2), (-1, -2)]
+        == [(Links.south_west, (-1, -1)), (Links.south_west, (-2, -2)),
+            (Links.east, (-1, -2))]
     assert list(longest_dimension_first((0, 1, 2))) \
-        == [(-1, -1), (-2, -2), (-2, -1)]
+        == [(Links.south_west, (-1, -1)), (Links.south_west, (-2, -2)),
+            (Links.north, (-2, -1))]
 
     # Test dimension ordering with all positive magnitudes and no zeros
     assert list(longest_dimension_first((3, 2, 1))) \
-        == [(1, 0), (2, 0), (3, 0), (3, 1), (3, 2), (2, 1)]
+        == [(Links.east, (1, 0)), (Links.east, (2, 0)), (Links.east, (3, 0)),
+            (Links.north, (3, 1)), (Links.north, (3, 2)),
+            (Links.south_west, (2, 1))]
     assert list(longest_dimension_first((1, 3, 2))) \
-        == [(0, 1), (0, 2), (0, 3), (-1, 2), (-2, 1), (-1, 1)]
+        == [(Links.north, (0, 1)), (Links.north, (0, 2)),
+            (Links.north, (0, 3)), (Links.south_west, (-1, 2)),
+            (Links.south_west, (-2, 1)), (Links.east, (-1, 1))]
     assert list(longest_dimension_first((2, 1, 3))) \
-        == [(-1, -1), (-2, -2), (-3, -3), (-2, -3), (-1, -3), (-1, -2)]
+        == [(Links.south_west, (-1, -1)), (Links.south_west, (-2, -2)),
+            (Links.south_west, (-3, -3)), (Links.east, (-2, -3)),
+            (Links.east, (-1, -3)), (Links.north, (-1, -2))]
     assert list(longest_dimension_first((1, 2, 3))) \
-        == [(-1, -1), (-2, -2), (-3, -3), (-3, -2), (-3, -1), (-2, -1)]
+        == [(Links.south_west, (-1, -1)), (Links.south_west, (-2, -2)),
+            (Links.south_west, (-3, -3)), (Links.north, (-3, -2)),
+            (Links.north, (-3, -1)), (Links.east, (-2, -1))]
 
     # Test dimension ordering with mixed sign magnitudes
     assert list(longest_dimension_first((1, -2, 0))) \
-        == [(0, -1), (0, -2), (1, -2)]
+        == [(Links.south, (0, -1)), (Links.south, (0, -2)),
+            (Links.east, (1, -2))]
     assert list(longest_dimension_first((-2, 1, 0))) \
-        == [(-1, 0), (-2, 0), (-2, 1)]
+        == [(Links.west, (-1, 0)), (Links.west, (-2, 0)),
+            (Links.north, (-2, 1))]
 
     # Test that given ambiguity, ties are broken randomly. Note: we
     # just test that in a large number of calls, each option is tried at least
@@ -104,11 +129,11 @@ def test_longest_dimension_first():
     generated_z_first = False
     for _ in range(1000):  # pragma: no branch
         first_move = list(longest_dimension_first((1, 1, 1)))[0]
-        if first_move == (1, 0):
+        if first_move == (Links.east, (1, 0)):
             generated_x_first = True
-        elif first_move == (0, 1):
+        elif first_move == (Links.north, (0, 1)):
             generated_y_first = True
-        elif first_move == (-1, -1):
+        elif first_move == (Links.south_west, (-1, -1)):
             generated_z_first = True
         else:
             assert False, "Unexpected move made!"  # pragma: no cover

--- a/tests/place_and_route/test_routing_tree.py
+++ b/tests/place_and_route/test_routing_tree.py
@@ -1,5 +1,7 @@
 from rig.place_and_route.routing_tree import RoutingTree
 
+from rig.routing_table import Routes
+
 
 class TestRoutingTree(object):
 
@@ -15,19 +17,20 @@ class TestRoutingTree(object):
         # Multiple Children
         t2 = RoutingTree((2, 0))
         t1 = RoutingTree((1, 0))
-        t0 = RoutingTree((0, 0), set([t1, t2]))
+        t0 = RoutingTree((0, 0), set([(Routes.east, t1),
+                                      (Routes.west, t2)]))
         assert set(t0) == set([t0, t1, t2])
 
         # Grandchildren
         t2 = RoutingTree((2, 0))
-        t1 = RoutingTree((1, 0), set([t2]))
-        t0 = RoutingTree((0, 0), set([t1]))
+        t1 = RoutingTree((1, 0), set([(Routes.west, t2)]))
+        t0 = RoutingTree((0, 0), set([(Routes.west, t1)]))
         assert set(t0) == set([t0, t1, t2])
 
         # Inclusion of other types
         t2 = object()
-        t1 = RoutingTree((1, 0), set([t2]))
-        t0 = RoutingTree((0, 0), set([t1]))
+        t1 = RoutingTree((1, 0), set([(Routes.west, t2)]))
+        t0 = RoutingTree((0, 0), set([(Routes.west, t1)]))
         assert set(t0) == set([t0, t1, t2])
 
     def test_repr(self):

--- a/tests/place_and_route/test_wrapper.py
+++ b/tests/place_and_route/test_wrapper.py
@@ -8,6 +8,22 @@ from rig.netlist import Net
 from rig.place_and_route import wrapper
 
 
+class Vertex(object):
+    """A generic object which is used as the vertex type in these tests.
+
+    Explicitly meets the requirements of a vertex object according to the
+    documentation."""
+
+    def __init__(self):
+        pass
+
+    def __eq__(self, other):
+        return id(self) == id(other)
+
+    def __hash__(self):
+        return hash(id(self))
+
+
 class TestWrapper(object):
     """Simple santy-check level tests of the wrapper, no comprehensive checks
     since internal function is largely tested elsewhere."""
@@ -33,7 +49,7 @@ class TestWrapper(object):
         # Create a ring network which will consume all available cores
         num_vertices = m.width * m.height * (
             m.chip_resources[Cores] - (1 if reserve_monitor else 0))
-        vertices = [object() for _ in range(num_vertices)]
+        vertices = [Vertex() for _ in range(num_vertices)]
         vertices_resources = {v: {Cores: 1, SDRAM: 3} for v in vertices}
         vertices_applications = {v: "app.aplx" for v in vertices}
         nets = [Net(vertices[i],


### PR DESCRIPTION
Previously, the `RoutingTree` data structure did not explicitly encode the links to use to get between each hop of the route. In some circumstances (e.g. NxM with N or M <= 2), this omission means that the structure ambiguously expresses the route produced by the routing algorithm.

The specific direction chosen by a router may be more important in future routing algorithms and, in the present implementation, makes generating accurate illustrations of a generated routing solution impossible in the general case.

This commit (backward-incompatibly) modifies the `RoutingTree` data structure to include the above information as well as generally make it a little cleaner. As far as I know, nobody (except me) is doing anything but pass this structure into the `build_routing_tables` utility method (which has been updated accordingly in this commit) and thus this breaking change shouldn't impact anyone.

This change should not backward-incompatibly change the rest of the place-and-route infrastructure.