### PR TITLE
Set build timestamp time-zone to UTC.

### DIFF
--- a/rig/scripts/rig_info.py
+++ b/rig/scripts/rig_info.py
@@ -10,6 +10,7 @@ from six import iteritems, itervalues
 from collections import defaultdict
 
 from datetime import datetime
+from pytz import utc
 
 import rig
 
@@ -29,7 +30,8 @@ def get_spinnaker_info(mc):
     yield "Software: {} v{} (Built {})".format(
         info.version_string.split("/")[0],
         info.version,
-        datetime.fromtimestamp(info.build_date).strftime('%Y-%m-%d %H:%M:%S'),
+        datetime.fromtimestamp(info.build_date, tz=utc).strftime(
+            '%Y-%m-%d %H:%M:%S'),
     )
 
     yield ""
@@ -107,7 +109,8 @@ def get_bmp_info(bc):
     yield "Software: {} v{} (Built {})".format(
         info.version_string.split("/")[0],
         info.version,
-        datetime.fromtimestamp(info.build_date).strftime('%Y-%m-%d %H:%M:%S'),
+        datetime.fromtimestamp(info.build_date, tz=utc).strftime(
+            '%Y-%m-%d %H:%M:%S'),
     )
     yield "Code block in use: {}".format(info.code_block)
     yield "Board ID (slot number): {}".format(info.board_id)

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setup(
     keywords="spinnaker placement routing graph fixed-point",
 
     # Requirements
-    install_requires=["numpy>1.6", "six", "enum34", "sentinel"],
+    install_requires=["numpy>1.6", "six", "enum34", "sentinel", "pytz"],
 
     # Scripts
     entry_points={


### PR DESCRIPTION
Fixes #157.

Though I strongly suspect that the build times are actually relative to the Europe/London timezone (i.e. what ST has on his machine), it really should be UTC. Further, the error of a maximum of 1-ish hour is unlikely to cause confusion since software builds are infrequent.

A very good spot by @mundya and proof that I am yet another victim of the many [Falsehoods programmers believe about time](http://infiniteundo.com/post/25326999628/falsehoods-programmers-believe-about-time). Specifically this falls afoul of 8. "The machine that a program runs on will always be in the GMT time zone."...