### PR TITLE
Fix live get_machine test

### DIFF
--- a/tests/machine_control/test_machine_controller.py
+++ b/tests/machine_control/test_machine_controller.py
@@ -270,7 +270,6 @@ class TestMachineControllerLive(object):
         for x, y, link in m.dead_links:
             assert 0 <= x < m.width
             assert 0 <= y < m.height
-            assert (x, y) not in m.chip_resource_exceptions
             assert link in Links
 
     def test_get_machine_spinn_5(self, live_machine, spinnaker_width,


### PR DESCRIPTION
Removes an erroneous test that checked that chips with dead links had no resource exceptions (which was there due to a copy-pasta fail...).

Many thanks to @mundya for finding this bug.

(Sorry!)