### PR TITLE
Add Routes metadata and make Machine iterable

### DIFF
--- a/rig/machine.py
+++ b/rig/machine.py
@@ -265,6 +265,27 @@ class Machine(object):
 
         self.chip_resource_exceptions[xy] = resources
 
+    def __iter__(self):
+        """Iterate over the working chips in the machine.
+
+        Generates a series of (x, y) tuples.
+        """
+        for x in range(self.width):
+            for y in range(self.height):
+                if (x, y) in self:
+                    yield (x, y)
+
+    def iter_links(self):
+        """An iterator over the working links in the machine.
+
+        Generates a series of (x, y, link) tuples.
+        """
+        for x in range(self.width):
+            for y in range(self.height):
+                for link in Links:
+                    if (x, y, link) in self:
+                        yield (x, y, link)
+
     def has_wrap_around_links(self, minimum_working=0.9):
         """Test if a machine has wrap-around connections installed.
 

--- a/rig/machine_control/machine_controller.py
+++ b/rig/machine_control/machine_controller.py
@@ -1006,9 +1006,7 @@ class MachineController(ContextMixin):
             mcn = self.get_machine()
 
             # Now remove all routing entries:
-            for (x, y) in [(x, y)
-                           for x in range(mcn.width)
-                           for y in range(mcn.height) if (x, y) in mcn]:
+            for (x, y) in mcn:
                 self.clear_routing_table_entries(x, y, app_id)
 
         # Construct the packet for transmission

--- a/rig/place_and_route/place/sa.py
+++ b/rig/place_and_route/place/sa.py
@@ -59,10 +59,7 @@ def _initial_placement(movable_vertices, vertices_resources, machine, random):
     InvalidConstraintError
     """
     # Initially fill chips in the system in a random order
-    locations = [(x, y)
-                 for x in range(machine.width)
-                 for y in range(machine.height)
-                 if (x, y) in machine]
+    locations = list(machine)
     random.shuffle(locations)
     location_iter = iter(locations)
 
@@ -594,10 +591,7 @@ def place(vertices_resources, nets, machine, constraints,
     # Location-to-Vertices: A lookup {(x, y): [vertex, ...], ...} giving the
     # set of vertices on a given chip.  Chips which are not in the machine are
     # excluded from this lookup.
-    l2v = {(x, y): []
-           for x in range(machine.width)
-           for y in range(machine.height)
-           if (x, y) in machine}
+    l2v = {xy: [] for xy in machine}
     for vertex, location in iteritems(placements):
         l2v[location].append(vertex)
 

--- a/rig/routing_table.py
+++ b/rig/routing_table.py
@@ -40,8 +40,15 @@ class Routes(IntEnum):
 
     @classmethod
     def core(cls, num):
-        """Get the :py:class:`.Routes` for the numbered core."""
-        assert 0 <= num <= 17, "Cores are numbered from 0 to 17"
+        """Get the :py:class:`.Routes` for the numbered core.
+
+        Raises
+        ------
+        ValueError
+            If the core number isn't in the range 0-17 inclusive.
+        """
+        if not (0 <= num <= 17):
+            raise ValueError("Cores are numbered from 0 to 17")
         return cls(6 + num)
 
     east = 0
@@ -69,3 +76,27 @@ class Routes(IntEnum):
     core_15 = 21
     core_16 = 22
     core_17 = 23
+
+    @property
+    def is_link(self):
+        """True iff a Routes object represents a chip to chip link."""
+        return self < 6
+
+    @property
+    def is_core(self):
+        """True iff a Routes object represents a route to a core."""
+        return not self.is_link
+
+    @property
+    def core_num(self):
+        """Get the core number being routed to.
+
+        Raises
+        ------
+        ValueError
+            If the route is not to a core.
+        """
+        if self.is_core:
+            return self - 6
+        else:
+            raise ValueError("{} is not a core".format(repr(self)))

--- a/rig/scripts/rig_info.py
+++ b/rig/scripts/rig_info.py
@@ -85,12 +85,10 @@ def get_spinnaker_info(mc):
     # count}}
     yield "Application states:"
     app_states = defaultdict(lambda: defaultdict(lambda: 0))
-    for x in range(machine.width):
-        for y in range(machine.height):
-            if (x, y) in machine:
-                for p in range(machine[(x, y)][Cores]):
-                    status = mc.get_processor_status(x=x, y=y, p=p)
-                    app_states[status.app_name][status.cpu_state] += 1
+    for x, y in machine:
+        for p in range(machine[(x, y)][Cores]):
+            status = mc.get_processor_status(x=x, y=y, p=p)
+            app_states[status.app_name][status.cpu_state] += 1
     for app_name, states in sorted(iteritems(app_states),
                                    key=(lambda s: sum(itervalues(s[1])))):
         state_counts = []

--- a/tests/place_and_route/test_wrapper.py
+++ b/tests/place_and_route/test_wrapper.py
@@ -104,10 +104,9 @@ class TestWrapper(object):
 
         # Check the correct application map is given (same app on every core)
         assert application_map == {  # pragma: no branch
-            "app.aplx": {(x, y): set(range(1 if reserve_monitor else 0,
-                                           m.chip_resources[Cores]))
-                         for x in range(m.width)
-                         for y in range(m.height)}}
+            "app.aplx": {xy: set(range(1 if reserve_monitor else 0,
+                                       m.chip_resources[Cores]))
+                         for xy in m}}
 
         # Check that all routing keys are observed at least once
         used_keys = set()

--- a/tests/test_machine.py
+++ b/tests/test_machine.py
@@ -185,6 +185,26 @@ class TestMachine(object):
         with pytest.raises(IndexError):
             machine[(-1, -1)] = new_resource_exception
 
+    def test_iter(self):
+        machine = Machine(3, 2, dead_chips=set([(0, 0), (1, 1)]))
+        assert set(machine) == set([(1, 0), (2, 0), (0, 1), (2, 1)])
+
+    def test_iter_links(self):
+        machine = Machine(1, 2, dead_links=set([(0, 0, Links.south),
+                                                (0, 1, Links.north)]))
+        assert set(machine.iter_links()) == set([
+            (0, 0, Links.east),
+            (0, 0, Links.west),
+            (0, 0, Links.north),
+            (0, 0, Links.north_east),
+            (0, 0, Links.south_west),
+            (0, 1, Links.east),
+            (0, 1, Links.west),
+            (0, 1, Links.south),
+            (0, 1, Links.north_east),
+            (0, 1, Links.south_west),
+        ])
+
 
 def test_links_from_vector():
     # In all but the last of the following tests we assume we're in a 4x8

--- a/tests/test_routing_table.py
+++ b/tests/test_routing_table.py
@@ -34,8 +34,25 @@ def test_routes():
     assert Routes.core(16) is Routes.core_16
     assert Routes.core(17) is Routes.core_17
 
+    # Make sure route type methods work
+    for link in Links:
+        assert Routes(link).is_link
+        assert not Routes(link).is_core
+    for core_num in range(18):
+        assert not Routes.core(core_num).is_link
+        assert Routes.core(core_num).is_core
+
     # Lookups out of range should fail
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         Routes.core(-1)
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         Routes.core(18)
+
+    # The core number property should work
+    for core_num in range(18):
+        assert Routes.core(core_num).core_num == core_num
+
+    # But should fail for links
+    for link in Links:
+        with pytest.raises(ValueError):
+            Routes(link).core_num


### PR DESCRIPTION
This PR adds:

* Properties `.is_link`, `.is_core` and `core_num` to the `Routes` enumeration to reduce the amount of magic numbers required when dealing with these types.
* An `__iter__` method to Machine which iterates over all live chips (a much wished for feature in recent times!)
* A similar `iter_links` method to Machine which iterates over working links in the system.

Nothing groundbreaking but makes life much more pleasant.