### PR TITLE
Fix infinite loop in NER routing algorithm.

### DIFF
--- a/rig/place_and_route/route/utils.py
+++ b/rig/place_and_route/route/utils.py
@@ -84,12 +84,7 @@ def links_between(a, b, machine):
     """
     ax, ay = a
     bx, by = b
-    return set(link for link, (dx, dy) in [(Links.east, (1, 0)),
-                                           (Links.north_east, (1, 1)),
-                                           (Links.north, (0, 1)),
-                                           (Links.west, (-1, 0)),
-                                           (Links.south_west, (-1, -1)),
-                                           (Links.south, (0, -1))]
+    return set(link for link, (dx, dy) in ((l, l.to_vector()) for l in Links)
                if (ax + dx) % machine.width == bx and
                (ay + dy) % machine.height == by and
                (ax, ay, link) in machine)


### PR DESCRIPTION
In the initial route-generating code, the NER routing algorithm had a bug meant
that new routes could be inserted into a routing tree which overlapped existing
tree segments sometimes resulting in cycles being added to the routing tree.
These cycles would then cause later stages of the algorithm to get stuck in an
infinite loop.

To resolve the bug, new route segments are truncated at the first point they
come into contact with the rest of the routing tree. A fuzzing test designed to
maximise the chances of similar bugs being manifested has been added. This test
reliably finds the above bug when the fix is reverted.

Note that though this bug is severe it requires very peculiar nets to manifest
itself. In particular to make the bug likely to manifest, nets must be extremely
high fan-out (but *not* connect to all chips) and the pattern must be such that
NER ends up inserting highly serpentine routes. As such most applications are
likely not to encounter this bug in normal operation. That said, @mundya and
@neworderofjamie should ideally be aware of its existence and make sure to
update their local Rig installation when this fix is merged.

This commit also fixes a test which failed to account for some legal hops in
routes (found by the fuzzing test).