### PR TITLE
Remove __slots__ from user-facing modules.

### DIFF
--- a/rig/machine.py
+++ b/rig/machine.py
@@ -173,8 +173,6 @@ class Machine(object):
         that links have two directions and both should be defined if a link is
         dead in both directions (the typical case).
     """
-    __slots__ = ["width", "height", "chip_resources",
-                 "chip_resource_exceptions", "dead_chips", "dead_links"]
 
     def __init__(self, width, height,
                  chip_resources={Cores: 18, SDRAM: 128*1024*1024,

--- a/rig/netlist.py
+++ b/rig/netlist.py
@@ -14,7 +14,6 @@ class Net(object):
     sinks : list
         A list of vertices that the net connects to.
     """
-    __slots__ = ["source", "weight", "sinks"]
 
     def __init__(self, source, sinks, weight=1.0):
         """Create a new Net.

--- a/rig/place_and_route/constraints.py
+++ b/rig/place_and_route/constraints.py
@@ -17,8 +17,6 @@ class LocationConstraint(object):
         The x- and y-coordinates of the chip the vertex must be placed on.
     """
 
-    __slots__ = ["vertex", "location"]
-
     def __init__(self, vertex, location):
         self.vertex = vertex
         self.location = location
@@ -52,8 +50,6 @@ class ReserveResourceConstraint(object):
         reservation applies globally.
     """
 
-    __slots__ = ["resource", "reservation", "location"]
-
     def __init__(self, resource, reservation, location=None):
         self.resource = resource
         self.reservation = reservation
@@ -78,8 +74,6 @@ class AlignResourceConstraint(object):
     alignment : int
         The number of which all assigned start-indices must be a multiple.
     """
-
-    __slots__ = ["resource", "alignment"]
 
     def __init__(self, resource, alignment):
         self.resource = resource
@@ -117,8 +111,6 @@ class RouteEndpointConstraint(object):
     route : :py:class:`~rig.routing_table.Routes`
         The route to which paths will be directed.
     """
-
-    __slots__ = ["vertex", "route"]
 
     def __init__(self, vertex, route):
         self.vertex = vertex

--- a/rig/place_and_route/routing_tree.py
+++ b/rig/place_and_route/routing_tree.py
@@ -38,8 +38,6 @@ class RoutingTree(object):
           reach the vertex.
     """
 
-    __slots__ = ["chip", "children"]
-
     def __init__(self, chip, children=None):
         self.chip = chip
         self.children = children if children is not None else set()


### PR DESCRIPTION
The major motivation for this change is that in Python 2 you cannot pickle
objects with `__slots__` in the general case. This is problematic if you wish to
dump place/route artefacts, e.g. for the purposes of plotting.

Since I don't believe we're currently memory-bound adding `__slots__` probably
isn't very useful and so removing this seems like a good idea.