### PR TITLE
Tools for helping users get set up with SpiNNaker

### DIFF
--- a/docs/source/control.rst
+++ b/docs/source/control.rst
@@ -43,6 +43,8 @@ introductory tutorials:
     :special-members:
     :exclude-members: boot_packet, BootCommand
 
+.. autofunction:: rig.machine_control.unbooted_ping.listen
+
 Advanced SCP/SDP APIs
 ---------------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -40,6 +40,7 @@ Execution control and machine management
         :maxdepth: 2
 
         control
+        wizard
 
 
 Standalone utility applications

--- a/docs/source/utility_apps.rst
+++ b/docs/source/utility_apps.rst
@@ -78,3 +78,16 @@ And for BMPs::
     Temperature top: 28.9 *C
     Temperature bottom: 30.0 *C
 
+
+``rig-discover``
+================
+
+The ``rig-discover`` command listens for any attached unbooted SpiNNaker
+boards on the network. This can be used to determine the IP address of a
+locally attached board. Example::
+
+    $ rig-discover
+    192.168.240.253
+
+If no machines are discovered, the command will exit after a short timeout
+without printing anything.

--- a/docs/source/wizard.rst
+++ b/docs/source/wizard.rst
@@ -1,0 +1,5 @@
+:py:mod:`rig.wizard`: Stock SpiNNaker-board info gathering wizards
+==================================================================
+
+.. automodule:: rig.wizard
+    :members:

--- a/rig/geometry.py
+++ b/rig/geometry.py
@@ -3,6 +3,8 @@
 
 import random
 
+from math import sqrt
+
 
 def to_xyz(xy):
     """Convert a two-tuple (x, y) coordinate into an (x, y, 0) coordinate."""
@@ -169,3 +171,42 @@ def concentric_hexagons(radius, start=(0, 0)):
                 yield (x, y)
                 x += dx
                 y += dy
+
+
+def standard_system_dimensions(num_boards):
+    """Calculate the standard network dimensions (in chips) for a system with
+    the specified number of SpiNN-5 boards.
+
+    Returns
+    -------
+    (w, h)
+        Width and height of the network in chips.
+
+        Standard SpiNNaker systems are constructed as squarely as possible
+        given the number of boards available. When a square system cannot be
+        made, the function prefers wider systems over taller systems.
+
+      Raises
+      ------
+      ValueError
+        If the number of boards is not a multiple of three.
+    """
+    if num_boards % 3 != 0:
+        raise ValueError("{} is not a multiple of 3".format(num_boards))
+
+    # Special case to avoid division by 0
+    if num_boards == 0:
+        return (0, 0)
+
+    # Find the largest pair of factors to discover the squarest system in terms
+    # of triads of boards.
+    for h in reversed(  # pragma: no branch
+            range(1, int(sqrt(num_boards // 3)) + 1)):
+        if (num_boards // 3) % h == 0:
+            break
+
+    w = (num_boards // 3) // h
+
+    # Convert the number of triads into numbers of chips (each triad of boards
+    # contributes as 12x12 block of chips).
+    return (w * 12, h * 12)

--- a/rig/geometry.py
+++ b/rig/geometry.py
@@ -191,12 +191,16 @@ def standard_system_dimensions(num_boards):
       ValueError
         If the number of boards is not a multiple of three.
     """
-    if num_boards % 3 != 0:
-        raise ValueError("{} is not a multiple of 3".format(num_boards))
-
     # Special case to avoid division by 0
     if num_boards == 0:
         return (0, 0)
+
+    # Special case: meaningful systems with 1 board can exist
+    if num_boards == 1:
+        return (8, 8)
+
+    if num_boards % 3 != 0:
+        raise ValueError("{} is not a multiple of 3".format(num_boards))
 
     # Find the largest pair of factors to discover the squarest system in terms
     # of triads of boards.

--- a/rig/machine_control/unbooted_ping.py
+++ b/rig/machine_control/unbooted_ping.py
@@ -1,0 +1,42 @@
+"""Listen for a 'ping' broadcast message from an unbooted SpiNNaker board."""
+
+from rig.machine_control.consts import BOOT_PORT
+
+import socket
+
+
+def listen(timeout=6.0, port=BOOT_PORT):
+    """Listen for a 'ping' broadcast message from an unbooted SpiNNaker board.
+
+    Unbooted SpiNNaker boards send out a UDP broadcast message every 4-ish
+    seconds on port 54321. This function listens for such messages and reports
+    the IP address that it came from.
+
+    Parameters
+    ----------
+    timeout : float
+        Number of seconds to wait for a message to arrive.
+    port : int
+        The port number to listen on.
+
+    Returns
+    -------
+    str or None
+        The IP address of the SpiNNaker board from which a ping was received or
+        None if no ping was observed.
+    """
+
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+    # Don't take control of this socket in the system (i.e. allow other
+    # processes to bind to it) since we're listening for broadcasts.
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+
+    # Listen for the broadcasts
+    s.bind(('0.0.0.0', port))
+    s.settimeout(timeout)
+    try:
+        message, (ipaddr, port) = s.recvfrom(512)
+        return ipaddr
+    except socket.timeout:
+        return None

--- a/rig/scripts/rig_discover.py
+++ b/rig/scripts/rig_discover.py
@@ -1,0 +1,35 @@
+"""A minimal command-line utility for listening for unbooted machines.
+
+Installed as "rig-discover" by setuptools.
+"""
+
+import sys
+import argparse
+
+import rig
+
+from rig.machine_control.unbooted_ping import listen
+
+
+def main(args=None):
+    parser = argparse.ArgumentParser(
+        description="Listen for unbooted SpiNNaker boards.")
+    parser.add_argument("--version", "-V", action="version",
+                        version="%(prog)s {}".format(rig.__version__))
+
+    parser.add_argument("--timeout", "-t", type=float, default=6.0,
+                        help="Time to wait before giving up.")
+
+    args = parser.parse_args(args)
+
+    ip_address = listen(timeout=args.timeout)
+
+    if ip_address is not None:
+        print(ip_address)
+        return 0
+    else:
+        return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/rig/wizard.py
+++ b/rig/wizard.py
@@ -37,11 +37,11 @@ back into the generator. For command-line applications, a wrapper script
     {'ip_address': '192.168.240.253', 'dimensions': (48, 24)}
 
 Third-parties whose needs are not met by the supplied CLI wizard interface are
-encouraged to build their own font-ends which support the wizard protocol. The
+encouraged to build their own front-ends which support the wizard protocol. The
 wizard generator functions generate the following objects:
 
 * :py:class:`~rig.wizard.MultipleChoice` This tuple includes a question to be
-  presented to the user along with a list of valid options to chose from and
+  presented to the user along with a list of valid options to choose from and
   a default value to select (or None if no default exists). The generator
   should be sent the index of the user's selection.
 * :py:class:`~rig.wizard.Text` This tuple includes a question to be

--- a/rig/wizard.py
+++ b/rig/wizard.py
@@ -1,0 +1,255 @@
+"""
+Many applications require end-users to supply the details of a SpiNNaker system
+they wish to connect to. This module hopes to provide a more-friendly user
+interaction than just asking for an IP address and system dimensions in the
+general case.
+
+This module contains a number of wizards which extract various pieces of
+information from a user by asking simple questions. A wizard is a generator
+function which generates sequences of questions to which the answers are fed
+back into the generator. For command-line applications, a wrapper script
+:py:func:`~rig.wizard.cli_wrapper` will do all the heavy-lifting::
+
+    >> from rig.wizard import (
+    ..     dimensions_wizard, ip_address_wizard, cat, cli_wrapper)
+    >> resp = cli_wrapper(cat(dimensions_wizard(), ip_address_wizard()))
+    What type of SpiNNaker system to you have?
+        0: A single four-chip 'SpiNN-3' board
+        1: A single forty-eight-chip 'SpiNN-5' board
+        2: Multiple forty-eight-chip 'SpiNN-5' boards
+        3: Other
+    Select an option 0-3: 2
+
+    How many 'SpiNN-5' boards are in the system?
+    > 24
+
+    Would you like to auto-detect the SpiNNaker system's IP address?
+        0: Auto-detect
+        1: Manually Enter IP address or hostname
+    Select an option 0-1 (default: 0):
+
+    Make sure the SpiNNaker system is switched on and is not booted.
+    <Press enter to continue>
+
+    Discovering attached SpiNNaker systems...
+
+    >> resp
+    {'ip_address': '192.168.240.253', 'dimensions': (48, 24)}
+
+Third-parties whose needs are not met by the supplied CLI wizard interface are
+encouraged to build their own font-ends which support the wizard protocol. The
+wizard generator functions generate the following objects:
+
+* :py:class:`~rig.wizard.MultipleChoice` This tuple includes a question to be
+  presented to the user along with a list of valid options to chose from and
+  a default value to select (or None if no default exists). The generator
+  should be sent the index of the user's selection.
+* :py:class:`~rig.wizard.Text` This tuple includes a question to be
+  presented to the user.  The generator should be sent the user's free-form
+  text response as a string.
+* :py:class:`~rig.wizard.Prompt` This tuple indicates the user should be shown
+  a message which they should read and acknowledge. No response is expected.
+* :py:class:`~rig.wizard.Info` This tuple indicates the user should be shown
+  a message to which no response is required.
+
+When the information has been collected successfully,
+:py:exc:`~rig.wizard.Success` is raised by the wizard with a `data` attribute
+containing a dictionary with the information gathered by the wizard. If the
+wizard fails, a :py:exc:`~rig.wizard.Failure` exception is thrown with a
+human-readable message.
+"""
+
+from collections import namedtuple
+
+import re
+
+from six.moves import input
+
+from rig.machine_control.unbooted_ping import listen
+
+from rig.geometry import standard_system_dimensions
+
+
+MultipleChoice = namedtuple("MultipleChoice", "question,options,default")
+Text = namedtuple("Text", "question")
+Prompt = namedtuple("Prompt", "message")
+Info = namedtuple("Info", "message")
+
+
+class Failure(Exception):
+    """Indicates that the wizard couldn't determine the information
+    requested. The message indicates the reason."""
+
+
+class Success(Exception):
+    """The wizard successfully gathered the information requested.
+
+    Attributes
+    ==========
+    data : dict
+        A dictionary containing the information requested.
+    """
+
+    def __init__(self, data):
+        super(Success, self).__init__()
+        self.data = data
+
+    def __str__(self):
+        return str(self.data)
+
+
+def dimensions_wizard():
+    """A wizard which attempts to determine the dimensions of a SpiNNaker
+    system.
+
+    Returns ``{"dimensions": (x, y)}`` via the :py:exc:`~rig.wizard.Success`
+    exception.
+    """
+    option = yield MultipleChoice(
+        "What type of SpiNNaker system to you have?",
+        ["A single four-chip 'SpiNN-3' board",
+         "A single forty-eight-chip 'SpiNN-5' board",
+         "Multiple forty-eight-chip 'SpiNN-5' boards",
+         "Other"],
+        None)
+    assert 0 <= option < 4
+
+    if option == 0:
+        raise Success({"dimensions": (2, 2)})
+    elif option == 1:
+        raise Success({"dimensions": (8, 8)})
+    elif option == 2:
+        # Infer the system's dimensions from the number of boards supplied
+        num_boards = yield Text("How many 'SpiNN-5' boards are in the system?")
+        try:
+            w, h = standard_system_dimensions(int(num_boards))
+        except ValueError:
+            # May fail due to integer conversion or the function rejecting the
+            # number of boards.
+            raise Failure(
+                "'{}' is not a valid number of boards.".format(num_boards))
+        raise Success({"dimensions": (w, h)})
+    else:
+        dimensions = yield Text(
+            "What are the dimensions of the network in chips (e.g. 24x12)?")
+        match = re.match(r"\s*(\d+)\s*[xX]\s*(\d+)\s*", dimensions)
+        if not match:
+            raise Failure("'{}' is not a valid system size.".format(
+                dimensions))
+        else:
+            w = int(match.group(1))
+            h = int(match.group(2))
+            raise Success({"dimensions": (w, h)})
+
+
+def ip_address_wizard():
+    """A wizard which attempts to determine the IP of a SpiNNaker system.
+
+    Returns ``{"ip_address": "..."}`` via the :py:exc:`~rig.wizard.Success`
+    exception.
+    """
+    option = yield MultipleChoice(
+        "Would you like to auto-detect the SpiNNaker system's IP address?",
+        ["Auto-detect",
+         "Manually Enter IP address or hostname"],
+        0)
+    assert 0 <= option < 2
+
+    if option == 0:
+        yield Prompt(
+            "Make sure the SpiNNaker system is switched on and is not booted.")
+        yield Info("Discovering attached SpiNNaker systems...")
+        ip_address = listen()
+        if ip_address is None:
+            raise Failure(
+                "Did not discover a locally connected SpiNNaker system.")
+    elif option == 1:  # pragma: no branch
+        ip_address = yield Text(
+            "What is the IP address or hostname of the SpiNNaker system?")
+        if ip_address == "":
+            raise Failure("No IP address or hostname entered")
+
+    raise Success({"ip_address": ip_address})
+
+
+def cat(*wizards):
+    """A higher-order wizard which is the concatenation of a number of other
+    wizards.
+
+    The resulting data is the union of all wizard outputs.
+    """
+    data = {}
+
+    for wizard in wizards:
+        try:
+            response = None
+            while True:
+                response = yield wizard.send(response)
+        except Success as s:
+            data.update(s.data)
+
+    raise Success(data)
+
+
+def cli_wrapper(generator):
+    """Given a wizard, implements an interactive command-line human-friendly
+    interface for it.
+
+    Parameters
+    ----------
+    generator
+        A generator such as one created by calling
+        :py:func:`rig.wizard.wizard_generator`.
+
+    Returns
+    -------
+    dict or None
+        Returns a dictionary containing the results of the wizard or None if
+        the wizard failed.
+    """
+    first = True
+    response = None
+    while True:
+        # Insert blank lines between prompts
+        if not first:
+            print()
+        first = False
+
+        try:
+            message = generator.send(response)
+
+            if isinstance(message, MultipleChoice):
+                print(message.question)
+                for num, choice in enumerate(message.options):
+                    print("    {}: {}".format(num, choice))
+                option = input("Select an option 0-{}{}: ".format(
+                    len(message.options) - 1,
+                    " (default: {})".format(message.default)
+                    if message.default is not None else ""))
+
+                if option == "" and message.default is not None:
+                    option = message.default
+
+                try:
+                    response = int(option)
+                except ValueError:
+                    response = -1
+                if not (0 <= response < len(message.options)):
+                    print("ERROR: {} is not a valid option.".format(option))
+                    return None
+            elif isinstance(message, Text):
+                print(message.question)
+                response = input("> ")
+            elif isinstance(message, Prompt):
+                print(message.message)
+                input("<Press enter to continue>")
+                response = None
+            elif isinstance(message, Info):  # pragma: no branch
+                print(message.message)
+                response = None
+
+        except Failure as f:
+            print("ERROR: {}".format(str(f)))
+            return None
+        except Success as s:
+            return s.data

--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,7 @@ setup(
             "rig-boot = rig.scripts.rig_boot:main",
             "rig-power = rig.scripts.rig_power:main",
             "rig-info = rig.scripts.rig_info:main",
+            "rig-discover = rig.scripts.rig_discover:main",
         ],
     }
 )

--- a/tests/machine_control/test_unbooted_ping.py
+++ b/tests/machine_control/test_unbooted_ping.py
@@ -1,0 +1,28 @@
+import pytest
+
+from mock import Mock
+
+from rig.machine_control.unbooted_ping import listen
+
+
+@pytest.mark.parametrize("should_fail", [False, True])
+def test_listen(should_fail, monkeypatch):
+    import socket
+    mock_socket = Mock()
+    monkeypatch.setattr(socket, "socket", Mock(return_value=mock_socket))
+
+    if should_fail:
+        mock_socket.recvfrom.side_effect = socket.timeout
+    else:
+        mock_socket.recvfrom.return_value = ("foo", ("127.0.0.1", 12345))
+
+    # Make sure value returns as expected
+    retval = listen(timeout=12.0, port=12345)
+    if should_fail:
+        assert retval is None
+    else:
+        assert retval == "127.0.0.1"
+
+    # Make sure parameters were obayed
+    assert mock_socket.settimeout.called_once_with(12.0)
+    assert mock_socket.bind.called_once_with('0.0.0.0', 12345)

--- a/tests/scripts/test_rig_discover.py
+++ b/tests/scripts/test_rig_discover.py
@@ -1,0 +1,27 @@
+"""Test the discover command."""
+
+import pytest
+
+from rig.scripts import rig_discover
+
+from mock import Mock
+
+
+@pytest.mark.parametrize("should_work", [True, False])
+@pytest.mark.parametrize("args,timeout", [("", 6.0), ("-t 100.5", 100.5)])
+def test_rig_discover(args, should_work, timeout, monkeypatch, capsys):
+    if should_work:
+        mock_listen = Mock(return_value="127.0.0.1")
+    else:
+        mock_listen = Mock(return_value=None)
+    monkeypatch.setattr(rig_discover, "listen", mock_listen)
+
+    assert rig_discover.main(args.split()) == int(not should_work)
+
+    out, err = capsys.readouterr()
+    if should_work:
+        assert out == "127.0.0.1\n"
+    else:
+        assert out == ""
+
+    assert mock_listen.called_once_with(timeout)

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,6 +1,9 @@
+import pytest
+
 from rig.geometry import concentric_hexagons, to_xyz, minimise_xyz, \
     shortest_mesh_path_length, shortest_mesh_path, \
-    shortest_torus_path_length, shortest_torus_path
+    shortest_torus_path_length, shortest_torus_path, \
+    standard_system_dimensions
 
 
 def test_concentric_hexagons():
@@ -309,3 +312,25 @@ def test_shortest_torus_path():
                     break
             assert unseen_neg_minimiseds == set(), \
                 (start, end, width, height, neg_minimiseds)
+
+
+def test_standard_system_dimensions():
+    # Special case: 0
+    assert standard_system_dimensions(0) == (0, 0)
+
+    # Should crash on non-multiples of 3
+    with pytest.raises(ValueError):
+        standard_system_dimensions(1)
+    with pytest.raises(ValueError):
+        standard_system_dimensions(5)
+
+    # Square systems
+    assert standard_system_dimensions(3 * 1 * 1) == (12, 12)
+    assert standard_system_dimensions(3 * 2 * 2) == (24, 24)
+    assert standard_system_dimensions(3 * 20 * 20) == (240, 240)
+
+    # Rectangular systems (should always be wide)
+    assert standard_system_dimensions(3 * 1 * 2) == (24, 12)
+    assert standard_system_dimensions(3 * 1 * 3) == (36, 12)
+    assert standard_system_dimensions(3 * 2 * 4) == (48, 24)
+    assert standard_system_dimensions(3 * 1 * 17) == (204, 12)

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -318,9 +318,12 @@ def test_standard_system_dimensions():
     # Special case: 0
     assert standard_system_dimensions(0) == (0, 0)
 
+    # Special case: 1
+    assert standard_system_dimensions(1) == (8, 8)
+
     # Should crash on non-multiples of 3
     with pytest.raises(ValueError):
-        standard_system_dimensions(1)
+        standard_system_dimensions(2)
     with pytest.raises(ValueError):
         standard_system_dimensions(5)
 

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -58,7 +58,7 @@ def test_dimensions_wizard_invalid():
         g = wizard.dimensions_wizard()
         g.send(None)
         g.send(2)  # Num boards
-        g.send("1")
+        g.send("4")
     with pytest.raises(wizard.Failure):
         g = wizard.dimensions_wizard()
         g.send(None)

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -1,0 +1,161 @@
+import pytest
+
+from mock import Mock
+
+from six import next
+
+from rig import wizard
+
+
+def test_success_str():
+    # Make sure the success exception prints like its data
+    with pytest.raises(wizard.Success) as excinfo:
+        raise wizard.Success({"this is a": "dictionary"})
+
+    assert str(excinfo.value) == "{'this is a': 'dictionary'}"
+
+
+@pytest.mark.parametrize("option,dimensions", [(0, (2, 2)), (1, (8, 8))])
+def test_dimensions_wizard_standard_types(option, dimensions):
+    # Make sure we can select standard machine types
+    with pytest.raises(wizard.Success) as excinfo:
+        g = wizard.dimensions_wizard()
+        g.send(None)
+        g.send(option)
+
+    assert excinfo.value.data["dimensions"] == dimensions
+
+
+@pytest.mark.parametrize("num_boards,dimensions", [(3, (12, 12)),
+                                                   (24, (48, 24))])
+def test_dimensions_wizard_num_boards(num_boards, dimensions):
+    # Make sure we can select systems by number of boards
+    with pytest.raises(wizard.Success) as excinfo:
+        g = wizard.dimensions_wizard()
+        g.send(None)
+        g.send(2)  # Multiple SpiNN-5s
+        g.send(num_boards)
+
+    assert excinfo.value.data["dimensions"] == dimensions
+
+
+@pytest.mark.parametrize("dimensions", [(12, 12), (48, 24)])
+def test_dimensions_wizard_custom(dimensions):
+    # Make sure we can select systems by size
+    with pytest.raises(wizard.Success) as excinfo:
+        g = wizard.dimensions_wizard()
+        g.send(None)
+        g.send(3)  # Custom
+        g.send("{}x{}".format(*dimensions))
+
+    assert excinfo.value.data["dimensions"] == dimensions
+
+
+def test_dimensions_wizard_invalid():
+    # Shouldn't be able to enter non multiples of three boards nor
+    # non-numerical system sizes.
+    with pytest.raises(wizard.Failure):
+        g = wizard.dimensions_wizard()
+        g.send(None)
+        g.send(2)  # Num boards
+        g.send("1")
+    with pytest.raises(wizard.Failure):
+        g = wizard.dimensions_wizard()
+        g.send(None)
+        g.send(2)  # Num boards
+        g.send("foo")
+    with pytest.raises(wizard.Failure):
+        g = wizard.dimensions_wizard()
+        g.send(None)
+        g.send(3)  # Custom
+        g.send("foo")
+    with pytest.raises(wizard.Failure):
+        g = wizard.dimensions_wizard()
+        g.send(None)
+        g.send(3)  # Custom
+        g.send("fooXbar")
+
+
+@pytest.mark.parametrize("should_work", [True, False])
+def test_ip_address_wizard_auto(should_work, monkeypatch):
+    if should_work:
+        mock_listen = Mock(return_value="127.0.0.1")
+    else:
+        mock_listen = Mock(return_value=None)
+
+    monkeypatch.setattr(wizard, "listen", mock_listen)
+
+    # Make sure automatic discovery can be used
+    with pytest.raises((wizard.Success, wizard.Failure)) as excinfo:
+        g = wizard.ip_address_wizard()
+        g.send(None)
+        g.send(0)  # Automatic
+        g.send(None)  # Press enter
+        g.send(None)  # Dismiss info
+
+    if should_work:
+        assert isinstance(excinfo.value, wizard.Success)
+        assert excinfo.value.data["ip_address"] == "127.0.0.1"
+    else:
+        assert isinstance(excinfo.value, wizard.Failure)
+
+
+def test_ip_address_wizard_manual():
+    # Make sure hostname are accepted
+    with pytest.raises(wizard.Success) as excinfo:
+        g = wizard.ip_address_wizard()
+        g.send(None)
+        g.send(1)  # Manual
+        g.send("hostname")
+    assert excinfo.value.data["ip_address"] == "hostname"
+
+    # Make sure blanks are rejected
+    with pytest.raises(wizard.Failure):
+        g = wizard.ip_address_wizard()
+        g.send(None)
+        g.send(1)  # Manual
+        g.send("")
+
+
+@pytest.mark.parametrize("commands,expected", [
+    # Runs through all types of message
+    ([3,  # Custom size
+      "24x12",  # The size
+      0,  # Automatic
+      None,  # "Press enter"
+      None],  # Info...
+     {"dimensions": (24, 12), "ip_address": "127.0.0.1"}),
+    ([3,  # Custom size
+      "24x12",  # The size
+      "",  # (Default to automatic)
+      None,  # "Press enter"
+      None],  # Info...
+     {"dimensions": (24, 12), "ip_address": "127.0.0.1"}),
+    # Make the wizard fail
+    ([2,  # Number of boards
+      "4"],  # (not a multiple of three)
+     None),
+    # Give an invalid multiple choice answer
+    ([""], None),
+    (["foo"], None),
+    (["4"], None),
+    (["-12"], None),
+])
+def test_cat_and_cli_wrapper(commands, expected, monkeypatch):
+    """Run through the wizard's command line interface and make sure it
+    succeeds and fails as expected."""
+    # Make the listener always succeed
+    mock_listen = Mock(return_value="127.0.0.1")
+    monkeypatch.setattr(wizard, "listen", mock_listen)
+
+    # Stream in the specified commands
+    commands_iter = iter(commands)
+
+    def fake_input(message=None):
+        return next(commands_iter)
+    monkeypatch.setattr(wizard, "input", fake_input)
+
+    # The response should be as expected
+    assert wizard.cli_wrapper(wizard.cat(wizard.dimensions_wizard(),
+                                         wizard.ip_address_wizard())) \
+        == expected


### PR DESCRIPTION
* Adds `rig-discover` to discover the IP of locally connected, unbooted SpiNNaker boards. This uses a new function in `rig.machine_controller.unbooted_ping` to implement this functionality.
* Adds wizards which ask simple questions which can coax information about SpiNNaker systems from novice users.

Implements the more major parts of #162. I'll try and build something suitable for Nengo config file setup based on this...

**Note: Travis will fail for the moment while the SpiNNaker proxy is down. Tests do pass locally.**