### PR TITLE
Add missing rig-discover command to README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,8 @@ The utilities provided by Rig can be broken down approximately as follows:
   * ``rig-info``: No-nonsense command line utility to get high-level
     information about a SpiNNaker system, e.g. "what is it running, is it on
     fire?".
+  * ``rig-discover``: No-nonsense command line utility for discovering the IP of
+    connected, unbooted SpiNNaker boards.
 
 Python Version Support
 ----------------------


### PR DESCRIPTION
Whoops.

I've not mentioned the wizard stuff. I'm not sure if that is good/bad. I'm sure it doesn't matter much... It is in the docs...