### PR TITLE
Fix Numpy 1.8.1 issue

### DIFF
--- a/rig/type_casts.py
+++ b/rig/type_casts.py
@@ -240,7 +240,7 @@ class NumpyFloatToFixConverter(object):
         vals *= 2.0 ** self.n_frac
         vals = np.round(vals)
 
-        return self.dtype(vals)
+        return np.array(vals, dtype=self.dtype)
 
 
 class NumpyFixToFloatConverter(object):

--- a/tests/test_type_casts.py
+++ b/tests/test_type_casts.py
@@ -199,6 +199,17 @@ class TestNumpyFloatToFixConverter(object):
                         *[ftf(v) for v in values])
         )
 
+    def test_shape_is_retained(self):
+        # Format
+        fpf = NumpyFloatToFixConverter(True, 32, 15)
+
+        # Create the input matrix
+        matrix = np.array([[1.0]])
+
+        # Convert, ensure that the shape is the same
+        fixed = fpf(matrix)
+        assert fixed.shape == matrix.shape
+
 
 class TestNumpyFixToFloat(object):
     @pytest.mark.parametrize(


### PR DESCRIPTION
Calling `np.uint32([[1.0]])` returns a 0-d array.  This avoids this type
of call and should retain the shape of the original array when
typecasting.

Could someone with NumPy 1.8.1 confirm that the added test fails without the change to `rig/type_casts.py`? @neworderofjamie?

(Reported by @tcstewar)