### PR TITLE
Speed up application loading

### DIFF
--- a/rig/machine_control/machine_controller.py
+++ b/rig/machine_control/machine_controller.py
@@ -12,7 +12,7 @@ import pkg_resources
 
 from .consts import SCPCommands, NNCommands, NNConstants, AppFlags, LEDAction
 from . import boot, consts, regions, struct_file
-from .scp_connection import SCPConnection
+from .scp_connection import SCPConnection, scpcall
 
 from rig import routing_table
 from rig.machine import Cores, SDRAM, SRAM, Links, Machine
@@ -719,26 +719,35 @@ class MachineController(ContextMixin):
 
     def _send_ffd(self, pid, aplx_data, address):
         """Send flood-fill data packets."""
-        block = 0
-        pos = 0
         aplx_size = len(aplx_data)
 
-        while pos < aplx_size:
-            # Get the next block of data, send and progress the block
-            # counter and the address
-            data = aplx_data[pos:pos + self.scp_data_length]
-            data_size = len(data)
-            size = data_size // 4 - 1
-
+        def send_ffd(address):
+            # Precompute arg1
             arg1 = (NNConstants.forward << 24 | NNConstants.retry << 16 | pid)
-            arg2 = (block << 16) | (size << 8)
-            self._send_scp(0, 0, 0, SCPCommands.flood_fill_data,
-                           arg1, arg2, address, data)
 
-            # Increment the address and the block counter
-            block += 1
-            address += data_size
-            pos += data_size
+            # Store the current block number and offset
+            block = 0
+            pos = 0
+            while pos < aplx_size:
+                # Get the next block of data, send and progress the block
+                # counter and the address
+                data = aplx_data[pos:pos + self.scp_data_length]
+                data_size = len(data)
+                size = data_size // 4 - 1
+
+                arg2 = (block << 16) | (size << 8)
+                yield scpcall(0, 0, 0, SCPCommands.flood_fill_data,
+                              arg1, arg2, address, data)
+
+                # Increment the address and the block counter
+                block += 1
+                address += data_size
+                pos += data_size
+
+        # Transmit the data packets as a burst of SCP
+        self._get_connection(0, 0).send_scp_burst(self.scp_data_length,
+                                                  self.scp_window_size,
+                                                  send_ffd(address))
 
     def _send_ffe(self, pid, app_id, app_flags, cores, fr):
         """Send a flood-fill end packet."""

--- a/tests/machine_control/test_machine_controller.py
+++ b/tests/machine_control/test_machine_controller.py
@@ -1019,7 +1019,9 @@ class TestMachineController(object):
         """Test loading a single APLX to a set of cores."""
         BASE_ADDRESS = 0x68900000
         # Create the mock controller
+        scp_conn = mock.Mock()
         cn._send_scp = mock.Mock()
+        cn._get_connection = mock.Mock(return_value=scp_conn)
         cn.read_struct_field = mock.Mock()
         cn.read_struct_field.return_value = BASE_ADDRESS
 
@@ -1050,7 +1052,7 @@ class TestMachineController(object):
 
         # Assert that the transmitted packets were sensible, do this by
         # decoding each call to send_scp.
-        assert cn._send_scp.call_count == n_blocks + 2
+        assert cn._send_scp.call_count == 2
         # Flood-fill start
         (x, y, p, cmd, arg1, arg2, arg3) = cn._send_scp.call_args_list[0][0]
         assert x == y == p == 0
@@ -1067,15 +1069,16 @@ class TestMachineController(object):
         assert arg3 & 0x000000ff == NNConstants.retry
 
         # Flood fill data
+        assert scp_conn.send_scp_burst.called
+        burst_packets = scp_conn.send_scp_burst.call_args[0][2]
         address = BASE_ADDRESS
-        for n in range(0, n_blocks):
+        for n, call in zip(range(0, n_blocks), burst_packets):
             # Get the next block of data
             (block_data, aplx_data) = (aplx_data[:cn._scp_data_length],
                                        aplx_data[cn._scp_data_length:])
 
             # Check the sent SCP packet
-            (x_, y_, p_, cmd, arg1, arg2, arg3, data) = \
-                cn._send_scp.call_args_list[n+1][0]
+            (x_, y_, p_, cmd, arg1, arg2, arg3, data, _, _) = call
 
             # Assert the x, y and p are the same
             assert x_ == x and y_ == y and p_ == p


### PR DESCRIPTION
This commit uses `send_scp_burst` to accelerate the loading of application executables to SpiNNaker.  As they are always flood-filled from (0, 0, 0) this should result in a factor 8 speed-up of copying the application across when windowing is enabled (from 4Mbit/s to 32Mbit/s).