### PR TITLE
Add work-around for BMP power-on bug

### DIFF
--- a/docs/source/utility_apps.rst
+++ b/docs/source/utility_apps.rst
@@ -24,17 +24,17 @@ The ``rig-power`` command lets you quickly and easily power on and off
 SpiNNaker systems consisting of SpiNN-5 boards via their Board Management
 Processors (BMP).
 
-For example, to power cycle a single SpiNN-5 board::
+For example, to power cycle a SpiNN-5 board (or a 24-board frame there-of)::
 
     $ rig-power BMP_HOSTNAME
 
-To power-off a single SpiNN-5 board::
+To power-off::
 
     $ rig-power BMP_HOSTNAME off
 
-To power-cycle an entire rack of 24 SpiNN-5 boards::
+To power-cycle board 3 and the last 12 boards in frame::
 
-    $ rig-power BMP_HOSTNAME -b 0-23
+    $ rig-power BMP_HOSTNAME -b 3,12-23
 
 To get a complete listing of available options::
 

--- a/docs/source/utility_apps.rst
+++ b/docs/source/utility_apps.rst
@@ -24,7 +24,7 @@ The ``rig-power`` command lets you quickly and easily power on and off
 SpiNNaker systems consisting of SpiNN-5 boards via their Board Management
 Processors (BMP).
 
-For example, to power cycle a SpiNN-5 board (or a 24-board frame there-of)::
+For example, to power cycle a SpiNN-5 board (or a 24-board frame thereof)::
 
     $ rig-power BMP_HOSTNAME
 

--- a/rig/machine_control/bmp_controller.py
+++ b/rig/machine_control/bmp_controller.py
@@ -194,7 +194,7 @@ class BMPController(ContextMixin):
                        buffer_size, sver.arg3, sver.data.decode("utf-8"))
 
     @ContextMixin.use_contextual_arguments()
-    def set_power(self, state, cabinet, frame, boards,
+    def set_power(self, state, cabinet, frame, board,
                   delay=0.0, post_power_on_delay=5.0):
         """Control power to the SpiNNaker chips and FPGAs on a board.
 
@@ -202,7 +202,7 @@ class BMPController(ContextMixin):
         -------
         state : bool
             True for power on, False for power off.
-        boards : int or iterable
+        board : int or iterable
             Specifies the board to control the power of. This may also be an
             iterable of multiple boards (in the same frame). The command will
             actually be sent board 0, regardless of the set of boards
@@ -223,10 +223,10 @@ class BMPController(ContextMixin):
                 boards other than board 0 but wait for the FPGAs to be loaded
                 before responding when board 0 is powered on.
         """
-        if isinstance(boards, int):
-            boards = [boards]
+        if isinstance(board, int):
+            boards = [board]
         else:
-            boards = list(boards)
+            boards = list(board)
 
         arg1 = int(delay * 1000) << 16 | (1 if state else 0)
         arg2 = sum(1 << b for b in boards)

--- a/rig/machine_control/bmp_controller.py
+++ b/rig/machine_control/bmp_controller.py
@@ -194,7 +194,7 @@ class BMPController(ContextMixin):
                        buffer_size, sver.arg3, sver.data.decode("utf-8"))
 
     @ContextMixin.use_contextual_arguments()
-    def set_power(self, state, cabinet, frame, board,
+    def set_power(self, state, cabinet, frame, boards,
                   delay=0.0, post_power_on_delay=5.0):
         """Control power to the SpiNNaker chips and FPGAs on a board.
 
@@ -202,10 +202,11 @@ class BMPController(ContextMixin):
         -------
         state : bool
             True for power on, False for power off.
-        board : int or iterable
+        boards : int or iterable
             Specifies the board to control the power of. This may also be an
             iterable of multiple boards (in the same frame). The command will
-            actually be sent to the first board in the iterable.
+            actually be sent board 0, regardless of the set of boards
+            specified.
         delay : float
             Number of seconds delay between power state changes of different
             boards.
@@ -214,19 +215,29 @@ class BMPController(ContextMixin):
             command has been carried out. A short delay (default) is useful at
             this point since power-supplies and SpiNNaker chips may still be
             coming on line immediately after the power-on command is sent.
+
+            .. warning::
+                If the set of boards to be powered-on does not include board 0,
+                this timeout should be extended by 2-3 seconds. This is due to
+                the fact that BMPs immediately acknowledge power-on commands to
+                boards other than board 0 but wait for the FPGAs to be loaded
+                before responding when board 0 is powered on.
         """
-        if isinstance(board, int):
-            boards = [board]
+        if isinstance(boards, int):
+            boards = [boards]
         else:
-            boards = list(board)
-            board = boards[0]
+            boards = list(boards)
 
         arg1 = int(delay * 1000) << 16 | (1 if state else 0)
         arg2 = sum(1 << b for b in boards)
 
         # Allow additional time for response when powering on (since FPGAs must
-        # be loaded)
-        self._send_scp(cabinet, frame, board, SCPCommands.power,
+        # be loaded). Also, always send the command to board 0. This is
+        # required by the BMPs which do not correctly handle the power-on
+        # command being sent to anything but board 0. Though this is a bug in
+        # the BMP firmware, it is considered sufficiently easy to work-around
+        # that no fix is planned.
+        self._send_scp(cabinet, frame, 0, SCPCommands.power,
                        arg1=arg1, arg2=arg2,
                        timeout=consts.BMP_POWER_ON_TIMEOUT if state else 0.0,
                        expected_args=0)

--- a/rig/scripts/rig_power.py
+++ b/rig/scripts/rig_power.py
@@ -82,9 +82,9 @@ def main(args=None):
 
         # Actually send the command
         if args.power_on_delay is None:
-            bc.set_power(state=state, board=boards)
+            bc.set_power(state=state, boards=boards)
         else:
-            bc.set_power(state=state, board=boards,
+            bc.set_power(state=state, boards=boards,
                          post_power_on_delay=args.power_on_delay)
     except TimeoutError:
         sys.stderr.write("{}: error: bmp did not respond to command\n".format(

--- a/rig/scripts/rig_power.py
+++ b/rig/scripts/rig_power.py
@@ -31,7 +31,7 @@ def main(args=None):
     parser.add_argument("state", type=str, default=ON_CHOICES[0], nargs="?",
                         choices=ON_CHOICES + OFF_CHOICES)
 
-    parser.add_argument("-b", "--board", type=str, default="0",
+    parser.add_argument("-b", "--board", type=str, default="0-23",
                         help="board number (e.g. 0) "
                              "or range of boards (e.g.  1,3,4-6)")
 

--- a/rig/scripts/rig_power.py
+++ b/rig/scripts/rig_power.py
@@ -82,9 +82,9 @@ def main(args=None):
 
         # Actually send the command
         if args.power_on_delay is None:
-            bc.set_power(state=state, boards=boards)
+            bc.set_power(state=state, board=boards)
         else:
-            bc.set_power(state=state, boards=boards,
+            bc.set_power(state=state, board=boards,
                          post_power_on_delay=args.power_on_delay)
     except TimeoutError:
         sys.stderr.write("{}: error: bmp did not respond to command\n".format(

--- a/tests/machine_control/test_bmp_controller.py
+++ b/tests/machine_control/test_bmp_controller.py
@@ -72,8 +72,8 @@ class TestBMPControllerLive(object):
     @pytest.mark.no_boot  # Don't run if booting is disabled
     def test_power_cycle(self, live_controller):
         # Power-cycle a board, also checks both types of board listings
-        live_controller.set_power(False, board=0)
-        live_controller.set_power(True, board=[0])
+        live_controller.set_power(False, boards=0)
+        live_controller.set_power(True, boards=[0])
 
     def test_set_led(self, live_controller):
         # Toggle the LEDs
@@ -129,7 +129,7 @@ def test_power_down_on_finished(live_controller):
     The "order" marking on this test ensures that this test unit will run after
     all SpiNNaker hardware tests are complete.
     """
-    live_controller.set_power(False, board=0)
+    live_controller.set_power(False, boards=0)
 
 
 class TestBMPController(object):
@@ -202,23 +202,25 @@ class TestBMPController(object):
         bc = BMPController("localhost")
         bc._send_scp = Mock()
 
-        # Check single device and power down
+        # Check single device and power down (also check always sent to board
+        # 0)
         bc.set_power(False, 0, 0, 2)
         arg1 = 0 << 16 | 0
         arg2 = 1 << 2
         bc._send_scp.assert_called_once_with(
-            0, 0, 2, SCPCommands.power,
+            0, 0, 0, SCPCommands.power,
             arg1=arg1, arg2=arg2, timeout=0.0, expected_args=0
         )
         bc._send_scp.reset_mock()
 
-        # Check multiple device, power on and a delay
+        # Check multiple device, power on and a delay (also check always sent
+        # to board 0)
         bc.set_power(True, 0, 0, [1, 2, 4, 8], delay=0.1,
                      post_power_on_delay=0.0)
         arg1 = 100 << 16 | 1
         arg2 = (1 << 1) | (1 << 2) | (1 << 4) | (1 << 8)
         bc._send_scp.assert_called_once_with(
-            0, 0, 1, SCPCommands.power,
+            0, 0, 0, SCPCommands.power,
             arg1=arg1, arg2=arg2, timeout=consts.BMP_POWER_ON_TIMEOUT,
             expected_args=0
         )

--- a/tests/machine_control/test_bmp_controller.py
+++ b/tests/machine_control/test_bmp_controller.py
@@ -72,8 +72,8 @@ class TestBMPControllerLive(object):
     @pytest.mark.no_boot  # Don't run if booting is disabled
     def test_power_cycle(self, live_controller):
         # Power-cycle a board, also checks both types of board listings
-        live_controller.set_power(False, boards=0)
-        live_controller.set_power(True, boards=[0])
+        live_controller.set_power(False, board=0)
+        live_controller.set_power(True, board=[0])
 
     def test_set_led(self, live_controller):
         # Toggle the LEDs
@@ -129,7 +129,7 @@ def test_power_down_on_finished(live_controller):
     The "order" marking on this test ensures that this test unit will run after
     all SpiNNaker hardware tests are complete.
     """
-    live_controller.set_power(False, boards=0)
+    live_controller.set_power(False, board=0)
 
 
 class TestBMPController(object):

--- a/tests/scripts/test_rig_power.py
+++ b/tests/scripts/test_rig_power.py
@@ -66,13 +66,13 @@ def test_timeout_fails(monkeypatch):
 
 @pytest.mark.parametrize("args,options", [
     # Defaults to powering on
-    (["localhost"], {"state": True, "boards": {0}}),
+    (["localhost"], {"state": True, "boards": set(range(24))}),
     # Power on
-    (["localhost", "1"], {"state": True, "boards": {0}}),
-    (["localhost", "on"], {"state": True, "boards": {0}}),
+    (["localhost", "1"], {"state": True, "boards": set(range(24))}),
+    (["localhost", "on"], {"state": True, "boards": set(range(24))}),
     # Power off
-    (["localhost", "0"], {"state": False, "boards": {0}}),
-    (["localhost", "off"], {"state": False, "boards": {0}}),
+    (["localhost", "0"], {"state": False, "boards": set(range(24))}),
+    (["localhost", "off"], {"state": False, "boards": set(range(24))}),
     # Specify ranges of boards
     (["localhost", "-b=3"], {"state": True, "boards": {3}}),
     (["localhost", "--board=0"], {"state": True, "boards": {0}}),
@@ -82,9 +82,10 @@ def test_timeout_fails(monkeypatch):
     (["localhost", "--board=0-2"], {"state": True, "boards": {0, 1, 2}}),
     (["localhost", "--board=1,5-6"], {"state": True, "boards": {1, 5, 6}}),
     # Power-on delay
-    (["localhost", "--power-on-delay=1.0"], {"state": True, "boards": {0},
+    (["localhost", "--power-on-delay=1.0"], {"state": True,
+                                             "boards": set(range(24)),
                                              "post_power_on_delay": 1.0}),
-    (["localhost", "-d=0.0"], {"state": True, "boards": {0},
+    (["localhost", "-d=0.0"], {"state": True, "boards": set(range(24)),
                                "post_power_on_delay": 0.0}),
 ])
 def test_power_options(monkeypatch, args, options):

--- a/tests/scripts/test_rig_power.py
+++ b/tests/scripts/test_rig_power.py
@@ -66,25 +66,25 @@ def test_timeout_fails(monkeypatch):
 
 @pytest.mark.parametrize("args,options", [
     # Defaults to powering on
-    (["localhost"], {"state": True, "board": {0}}),
+    (["localhost"], {"state": True, "boards": {0}}),
     # Power on
-    (["localhost", "1"], {"state": True, "board": {0}}),
-    (["localhost", "on"], {"state": True, "board": {0}}),
+    (["localhost", "1"], {"state": True, "boards": {0}}),
+    (["localhost", "on"], {"state": True, "boards": {0}}),
     # Power off
-    (["localhost", "0"], {"state": False, "board": {0}}),
-    (["localhost", "off"], {"state": False, "board": {0}}),
+    (["localhost", "0"], {"state": False, "boards": {0}}),
+    (["localhost", "off"], {"state": False, "boards": {0}}),
     # Specify ranges of boards
-    (["localhost", "-b=3"], {"state": True, "board": {3}}),
-    (["localhost", "--board=0"], {"state": True, "board": {0}}),
-    (["localhost", "--board=1"], {"state": True, "board": {1}}),
-    (["localhost", "--board=0,2,3"], {"state": True, "board": {0, 2, 3}}),
-    (["localhost", "--board=0-0"], {"state": True, "board": {0}}),
-    (["localhost", "--board=0-2"], {"state": True, "board": {0, 1, 2}}),
-    (["localhost", "--board=1,5-6"], {"state": True, "board": {1, 5, 6}}),
+    (["localhost", "-b=3"], {"state": True, "boards": {3}}),
+    (["localhost", "--board=0"], {"state": True, "boards": {0}}),
+    (["localhost", "--board=1"], {"state": True, "boards": {1}}),
+    (["localhost", "--board=0,2,3"], {"state": True, "boards": {0, 2, 3}}),
+    (["localhost", "--board=0-0"], {"state": True, "boards": {0}}),
+    (["localhost", "--board=0-2"], {"state": True, "boards": {0, 1, 2}}),
+    (["localhost", "--board=1,5-6"], {"state": True, "boards": {1, 5, 6}}),
     # Power-on delay
-    (["localhost", "--power-on-delay=1.0"], {"state": True, "board": {0},
+    (["localhost", "--power-on-delay=1.0"], {"state": True, "boards": {0},
                                              "post_power_on_delay": 1.0}),
-    (["localhost", "-d=0.0"], {"state": True, "board": {0},
+    (["localhost", "-d=0.0"], {"state": True, "boards": {0},
                                "post_power_on_delay": 0.0}),
 ])
 def test_power_options(monkeypatch, args, options):

--- a/tests/scripts/test_rig_power.py
+++ b/tests/scripts/test_rig_power.py
@@ -66,26 +66,26 @@ def test_timeout_fails(monkeypatch):
 
 @pytest.mark.parametrize("args,options", [
     # Defaults to powering on
-    (["localhost"], {"state": True, "boards": set(range(24))}),
+    (["localhost"], {"state": True, "board": set(range(24))}),
     # Power on
-    (["localhost", "1"], {"state": True, "boards": set(range(24))}),
-    (["localhost", "on"], {"state": True, "boards": set(range(24))}),
+    (["localhost", "1"], {"state": True, "board": set(range(24))}),
+    (["localhost", "on"], {"state": True, "board": set(range(24))}),
     # Power off
-    (["localhost", "0"], {"state": False, "boards": set(range(24))}),
-    (["localhost", "off"], {"state": False, "boards": set(range(24))}),
+    (["localhost", "0"], {"state": False, "board": set(range(24))}),
+    (["localhost", "off"], {"state": False, "board": set(range(24))}),
     # Specify ranges of boards
-    (["localhost", "-b=3"], {"state": True, "boards": {3}}),
-    (["localhost", "--board=0"], {"state": True, "boards": {0}}),
-    (["localhost", "--board=1"], {"state": True, "boards": {1}}),
-    (["localhost", "--board=0,2,3"], {"state": True, "boards": {0, 2, 3}}),
-    (["localhost", "--board=0-0"], {"state": True, "boards": {0}}),
-    (["localhost", "--board=0-2"], {"state": True, "boards": {0, 1, 2}}),
-    (["localhost", "--board=1,5-6"], {"state": True, "boards": {1, 5, 6}}),
+    (["localhost", "-b=3"], {"state": True, "board": {3}}),
+    (["localhost", "--board=0"], {"state": True, "board": {0}}),
+    (["localhost", "--board=1"], {"state": True, "board": {1}}),
+    (["localhost", "--board=0,2,3"], {"state": True, "board": {0, 2, 3}}),
+    (["localhost", "--board=0-0"], {"state": True, "board": {0}}),
+    (["localhost", "--board=0-2"], {"state": True, "board": {0, 1, 2}}),
+    (["localhost", "--board=1,5-6"], {"state": True, "board": {1, 5, 6}}),
     # Power-on delay
     (["localhost", "--power-on-delay=1.0"], {"state": True,
-                                             "boards": set(range(24)),
+                                             "board": set(range(24)),
                                              "post_power_on_delay": 1.0}),
-    (["localhost", "-d=0.0"], {"state": True, "boards": set(range(24)),
+    (["localhost", "-d=0.0"], {"state": True, "board": set(range(24)),
                                "post_power_on_delay": 0.0}),
 ])
 def test_power_options(monkeypatch, args, options):


### PR DESCRIPTION
When a power-on command is sent to a BMP on a board other than board 0, the
board does not return an acknowledgement. Though this is acknowledged as a bug
in the BMP firmware by ST, there are no plans to fix it since in practical
systems there are no scenarios where board 0 does not exist.

The fix for this is always sending power-on/off commands to board 0, whether
board 0 is in the mask or not.

**Bonus** While I was at it, this code also makes the `rig-power` command power-on all boards in a frame by default without breaking behaviour for single board setups.