### PR TITLE
Add 'rand' uniform-random placer.

### DIFF
--- a/docs/source/place_and_route/placement_algorithms.rst
+++ b/docs/source/place_and_route/placement_algorithms.rst
@@ -4,3 +4,5 @@ Placement algorithms
 .. autofunction:: rig.place_and_route.place.sa.place
 
 .. autofunction:: rig.place_and_route.place.hilbert.place
+
+.. autofunction:: rig.place_and_route.place.rand.place

--- a/rig/place_and_route/place/rand.py
+++ b/rig/place_and_route/place/rand.py
@@ -1,7 +1,7 @@
 """A trivial random placer."""
 
-# This is renamed to ensure that all function correctly use the random number
-# generator passed into them.
+# This is renamed to ensure that the random module isn't accidentally used
+# directly.
 import random as default_random
 
 from rig.place_and_route.constraints import \
@@ -27,10 +27,10 @@ def place(vertices_resources, nets, machine, constraints,
     Parameters
     ----------
     random : :py:class:`random.Random`
-        A Python random number generator. Defaults to ``import random`` but can
-        be set to your own instance of :py:class:`random.Random` to allow you
-        to control the seed and produce deterministic results. For results to
-        be deterministic, vertices_resources must be supplied as an
+        Defaults to ``import random`` but can be set to your own instance of
+        :py:class:`random.Random` to allow you to control the seed and produce
+        deterministic results. For results to be deterministic,
+        vertices_resources must be supplied as an
         :py:class:`collections.OrderedDict`.
     """
     # Within the algorithm we modify the resource availability values in the
@@ -76,7 +76,7 @@ def place(vertices_resources, nets, machine, constraints,
     locations = set(machine)
 
     for vertex in movable_vertices:
-        # Keep chosing random chips until we find one where the vertex fits.
+        # Keep choosing random chips until we find one where the vertex fits.
         while True:
             if len(locations) == 0:
                 raise InsufficientResourceError(

--- a/rig/place_and_route/place/rand.py
+++ b/rig/place_and_route/place/rand.py
@@ -1,0 +1,101 @@
+"""A trivial random placer."""
+
+# This is renamed to ensure that all function correctly use the random number
+# generator passed into them.
+import random as default_random
+
+from rig.place_and_route.constraints import \
+    LocationConstraint, ReserveResourceConstraint
+
+from rig.place_and_route.exceptions import \
+    InvalidConstraintError, InsufficientResourceError
+
+from rig.place_and_route.place.utils import \
+    subtract_resources, overallocated, \
+    apply_reserve_resource_constraint
+
+
+def place(vertices_resources, nets, machine, constraints,
+          random=default_random):
+    """A random placer.
+
+    This algorithm performs uniform-random placement of vertices (completely
+    ignoring connectivty) and thus in the general case is likely to produce
+    very poor quality placements. It exists primarily as a baseline comparison
+    for placement quality and is probably of little value to most users.
+
+    Parameters
+    ----------
+    random : :py:class:`random.Random`
+        A Python random number generator. Defaults to ``import random`` but can
+        be set to your own instance of :py:class:`random.Random` to allow you
+        to control the seed and produce deterministic results. For results to
+        be deterministic, vertices_resources must be supplied as an
+        :py:class:`collections.OrderedDict`.
+    """
+    # Within the algorithm we modify the resource availability values in the
+    # machine to account for the effects of the current placement. As a result,
+    # an internal copy of the structure must be made.
+    machine = machine.copy()
+
+    # {vertex: (x, y), ...} gives the location of all vertices, updated
+    # throughout the function.
+    placements = {}
+
+    # Handle constraints
+    for constraint in constraints:
+        if isinstance(constraint, LocationConstraint):
+            # Location constraints are handled by recording the set of fixed
+            # vertex locations and subtracting their resources from the chips
+            # they're allocated to.
+            location = constraint.location
+            if location not in machine:
+                raise InvalidConstraintError(
+                    "Chip requested by {} unavailable".format(machine))
+            vertex = constraint.vertex
+
+            # Record the constrained vertex's location
+            placements[vertex] = location
+
+            # Make sure the vertex fits at the requested location (updating the
+            # resource availability after placement)
+            resources = vertices_resources[vertex]
+            machine[location] = subtract_resources(machine[location],
+                                                   resources)
+            if overallocated(machine[location]):
+                raise InsufficientResourceError(
+                    "Cannot meet {}".format(constraint))
+        elif isinstance(constraint,  # pragma: no branch
+                        ReserveResourceConstraint):
+            apply_reserve_resource_constraint(machine, constraint)
+
+    # The set of vertices which have not been constrained.
+    movable_vertices = [v for v in vertices_resources
+                        if v not in placements]
+
+    locations = set(machine)
+
+    for vertex in movable_vertices:
+        # Keep chosing random chips until we find one where the vertex fits.
+        while True:
+            if len(locations) == 0:
+                raise InsufficientResourceError(
+                    "Ran out of chips while attempting to place vertex "
+                    "{}".format(vertex))
+            location = random.sample(locations, 1)[0]
+
+            resources_if_placed = subtract_resources(
+                machine[location], vertices_resources[vertex])
+
+            if overallocated(resources_if_placed):
+                # The vertex won't fit on this chip, we'll assume it is full
+                # and not try it in the future.
+                locations.remove(location)
+            else:
+                # The vertex fits: record the resources consumed and move on to
+                # the next vertex.
+                placements[vertex] = location
+                machine[location] = resources_if_placed
+                break
+
+    return placements

--- a/tests/place_and_route/place/test_generic_place.py
+++ b/tests/place_and_route/place/test_generic_place.py
@@ -23,6 +23,7 @@ from rig.place_and_route.constraints import LocationConstraint, \
 from rig.place_and_route import place as default_place
 from rig.place_and_route.place.hilbert import place as hilbert_place
 from rig.place_and_route.place.sa import place as sa_place
+from rig.place_and_route.place.rand import place as rand_place
 
 # This dictionary should be updated to contain all implemented algorithms along
 # with applicable keyword arguments.
@@ -31,7 +32,8 @@ ALGORITHMS_UNDER_TEST = [(default_place, {}),
                          (sa_place, {}),
                          # Testing with effort = 0 tests the initial (random)
                          # placement solutions of the SA placer.
-                         (sa_place, {"effort": 0.0})]
+                         (sa_place, {"effort": 0.0}),
+                         (rand_place, {})]
 
 
 @pytest.mark.parametrize("algorithm,kwargs", ALGORITHMS_UNDER_TEST)


### PR DESCRIPTION
This placer is intended as a baseline for comparing placement algorithms. It
places each vertex on a random core (not sequentially filling random chips like
the sa placer with effort=0.0) and respects all constraints.