### PR TITLE
Add rig-boot 'num_boards' interface.

### DIFF
--- a/docs/source/utility_apps.rst
+++ b/docs/source/utility_apps.rst
@@ -8,7 +8,11 @@ For example, to boot a SpiNN-3 board::
 
     $ rig-boot HOSTNAME --spin3
 
-Or to boot a large SpiNNaker machine comprising many boards::
+Or to boot a standard configuration of multiple SpiNN-5 boards::
+
+    $ rig-boot HOSTNAME NUM_BOARDS
+
+Or to boot a SpiNNaker machine with a particular dimensionality::
 
     $ rig-boot HOSTNAME WIDTH HEIGHT
 

--- a/tests/scripts/test_rig_boot.py
+++ b/tests/scripts/test_rig_boot.py
@@ -13,11 +13,15 @@ import tempfile
 
 import os
 
-from rig.machine_control.boot import spin3_boot_options
+from rig.machine_control.boot import spin3_boot_options, spin5_boot_options
 
 spin3_boot_options_modified = spin3_boot_options.copy()
 spin3_boot_options_modified["width"] = 8
 spin3_boot_options_modified["height"] = 4
+
+spin5_boot_options_modified = spin5_boot_options.copy()
+spin5_boot_options_modified["width"] = 48
+spin5_boot_options_modified["height"] = 24
 
 
 @pytest.mark.parametrize("arguments", [
@@ -25,9 +29,8 @@ spin3_boot_options_modified["height"] = 4
     [],
     # No width/height/predfined type
     ["localhost"],
-    # No height
+    # Non-multiple-of-three number of boards
     ["localhost", "8"],
-    ["localhost", "8", "--spin3"],
     # Wrong type
     ["localhost", "a", "8"],
     ["localhost", "8", "a"],
@@ -105,6 +108,15 @@ def binary(request):
                                "height": 4,
                                "hardware_version": 0,
                                "led_config": 0x00000001}),
+    # Number of boards only only
+    (["localhost", "3"], {"width": 12,
+                          "height": 12,
+                          "hardware_version": 0,
+                          "led_config": 0x00000001}),
+    (["localhost", "24"], {"width": 48,
+                           "height": 24,
+                           "hardware_version": 0,
+                           "led_config": 0x00000001}),
     # Hardware version set
     (["localhost", "8", "4", "--hardware-version", "2"],
      {"width": 8,
@@ -121,6 +133,7 @@ def binary(request):
     (["localhost", "--spin3"], spin3_boot_options),
     # Preset with explicit options overriding
     (["localhost", "8", "4", "--spin3"], spin3_boot_options_modified),
+    (["localhost", "24", "--spin5"], spin5_boot_options_modified),
 ])
 @pytest.mark.parametrize("specify_binary", [True, False])
 def test_boot_options(monkeypatch, args, options, binary, specify_binary):


### PR DESCRIPTION
You can use this to boot a standard arrangement of `num_boards` SpiNN-5 boards
without having to work out what dimensionality the resulting network will have.

For example:

	$ rig-boot HOSTNAME 120

Will boot a 120-board SpiNNaker system. All previous argument formats are still
supported. For example, the old-school version of the above would be:

	$ rig-boot HOSTNAME 96 60