### PR TITLE
Fault tolerant rig-ps and get_machine

### DIFF
--- a/rig/machine_control/consts.py
+++ b/rig/machine_control/consts.py
@@ -18,14 +18,6 @@ SCP_SVER_RECEIVE_LENGTH_MAX = 512
 produce (256 + 8 bytes).
 """
 
-SCP_RC_OK = 0x80
-"""SCP response code which indicates that everything was fine."""
-
-SCP_RC_TIMEOUT = {0x8b, 0x8c, 0x8d, 0x8e}
-"""SCP response codes which should be treated as if they were a packet timing
-out.
-"""
-
 SPINNAKER_RTR_BASE = 0xE1000000  # Unbuffered
 """Base address of router hardware registers."""
 
@@ -91,6 +83,58 @@ class SCPCommands(enum.IntEnum):
     bmp_info = 48  # Request various info structs from a BMP
 
     power = 57  # BMP main board power control
+
+
+@add_int_enums_to_docstring
+class SCPReturnCodes(enum.IntEnum):
+    """SCP return codes"""
+    ok = 0x80  # Command completed OK
+    len = 0x81  # Bad packet length (Fatal)
+    sum = 0x82  # Bad checksum (Retryable)
+    cmd = 0x83  # Bad/invalid command (Fatal)
+    arg = 0x84  # Invalid arguments (Fatal)
+    port = 0x85  # Bad port number (Fatal)
+    timeout = 0x86  # Monitor <-> app-core comms timeout (Fatal)
+    route = 0x87  # No P2P route (Fatal)
+    cpu = 0x88  # Bad CPU number (Fatal)
+    dead = 0x89  # SHM dest dead (Fatal)
+    buf = 0x8a  # No free SHM buffers (Fatal)
+    p2p_noreply = 0x8b  # No reply to open (Fatal)
+    p2p_reject = 0x8c  # Open rejected (Fatal)
+    p2p_busy = 0x8d  # Dest busy (Retryable)
+    p2p_timeout = 0x8e  # Eth chip <--> destination comms timeout (Fatal)
+    pkt_tx = 0x8f  # Pkt Tx failed (Fatal)
+
+RETRYABLE_SCP_RETURN_CODES = set([
+    SCPReturnCodes.sum,
+    SCPReturnCodes.p2p_busy,
+])
+"""The set of :py:class:`.SCPReturnCodes` values which indicate a non-fatal
+retryable fault."""
+
+
+FATAL_SCP_RETURN_CODES = {
+    SCPReturnCodes.len: "Bad command length.",
+    SCPReturnCodes.cmd: "Bad/invalid command.",
+    SCPReturnCodes.arg: "Invalid command arguments.",
+    SCPReturnCodes.port: "Bad port number.",
+    SCPReturnCodes.timeout:
+        "Timeout waiting for the application core to respond to "
+        "the monitor core's request.",
+    SCPReturnCodes.route: "No P2P route to the target chip is available.",
+    SCPReturnCodes.cpu: "Bad CPU number.",
+    SCPReturnCodes.dead: "SHM dest dead.",
+    SCPReturnCodes.buf: "No free SHM buffers.",
+    SCPReturnCodes.p2p_noreply:
+        "No response packets from the target reached the "
+        "ethernet connected chip.",
+    SCPReturnCodes.p2p_reject: "The target chip rejected the packet.",
+    SCPReturnCodes.p2p_timeout:
+        "Communications between the ethernet connected chip and target chip "
+        "timedout.",
+    SCPReturnCodes.pkt_tx: "Packet transmission failed.",
+}
+"""The set of fatal SCP errors and a human-readable error."""
 
 
 @add_int_enums_to_docstring

--- a/rig/machine_control/packets.py
+++ b/rig/machine_control/packets.py
@@ -144,8 +144,9 @@ class SCPPacket(SDPPacket):
         return scp_header + self.data
 
     def __repr__(self):
-        """Produce a human-redaable summary of (the most important parts of)
-        the packet."""
+        """Produce a human-readable summary of (the most important parts of)
+        the packet.
+        """
         return ("<{} x: {}, y: {}, cpu: {}, "
                 "cmd_rc: {}, arg1: {}, arg2: {}, arg3: {}, "
                 "data: {}>".format(self.__class__.__name__,

--- a/rig/machine_control/packets.py
+++ b/rig/machine_control/packets.py
@@ -143,6 +143,17 @@ class SCPPacket(SDPPacket):
         # Return the SCP header and the rest of the data
         return scp_header + self.data
 
+    def __repr__(self):
+        """Produce a human-redaable summary of (the most important parts of)
+        the packet."""
+        return ("<{} x: {}, y: {}, cpu: {}, "
+                "cmd_rc: {}, arg1: {}, arg2: {}, arg3: {}, "
+                "data: {}>".format(self.__class__.__name__,
+                                   self.dest_x, self.dest_y, self.dest_cpu,
+                                   self.cmd_rc,
+                                   self.arg1, self.arg2, self.arg3,
+                                   repr(self.data)))
+
 
 def _unpack_sdp_into_packet(packet, bytestring):
     """Unpack the SDP header from a bytestring into a packet.

--- a/rig/machine_control/scp_connection.py
+++ b/rig/machine_control/scp_connection.py
@@ -429,12 +429,12 @@ class SCPError(IOError):
         specific packet was involved.
     """
 
-    def __init__(self, message, packet=None):
+    def __init__(self, message="", packet=None):
         self.packet = packet
         if self.packet is not None:
             message = "{} (Packet: {})".format(message, packet)
 
-        super(SCPError, self).__init__(message)
+        super(SCPError, self).__init__(message.lstrip())
 
 
 class TimeoutError(SCPError):

--- a/tests/machine_control/test_packets.py
+++ b/tests/machine_control/test_packets.py
@@ -1,5 +1,7 @@
 from rig.machine_control.packets import SDPPacket, SCPPacket
 
+import sys
+
 
 class TestSDPPacket(object):
     """Test SDPPacket representations."""
@@ -263,3 +265,15 @@ class TestSCPPacket(object):
         # Check that the bytestring this packet creates is the same as the one
         # we specified before.
         assert scp_packet.bytestring == packet
+
+    def test_repr(self):
+        """Test the string representation of an SCP packet makes sense."""
+        scp_packet = SCPPacket(dest_x=10, dest_y=20, dest_cpu=3,
+                               cmd_rc=2, arg1=123, arg2=456,
+                               data=b"foobar")
+        # Note: Python 2 does not have the "b" prefix on byte strings
+        assert repr(scp_packet) == (
+            "<SCPPacket x: 10, y: 20, cpu: 3, "
+            "cmd_rc: 2, arg1: 123, arg2: 456, arg3: None, "
+            "data: {}'foobar'>".format(
+                "b" if sys.version_info >= (3, 0) else ""))

--- a/tests/machine_control/test_scp_connection.py
+++ b/tests/machine_control/test_scp_connection.py
@@ -348,9 +348,10 @@ class TestBursts(object):
                 mock.patch("select.select", new=mock_select):
             mock_conn.send_scp_burst(512, 8, packets())
 
+    @pytest.mark.parametrize("wrong_seq_num", [True, False])
     @pytest.mark.parametrize("rc",
                              list(map(int, FATAL_SCP_RETURN_CODES)) + [0x00])
-    def test_errors(self, mock_conn, rc):
+    def test_errors(self, mock_conn, rc, wrong_seq_num):
         """Test that errors are raised when error RCs are returned."""
         # Create an object which returns a packet with an error code
         class ReturnPacket(object):
@@ -359,6 +360,8 @@ class TestBursts(object):
 
             def __call__(self, packet):
                 self.packet = SCPPacket.from_bytestring(packet)
+                if wrong_seq_num:
+                    self.packet.seq += 1
                 self.packet.cmd_rc = rc
                 self.packet.arg1 = None
                 self.packet.arg2 = None


### PR DESCRIPTION
This series of commits makes the rig-ps command and underlying get_machine() commands more robust on limping SpiNNaker machines.

A point worth repeating from 2548035 is:

> This change (strictly speaking) breaks backward compatibility as it renames
> exceptions of the RC-specific types. @mundya are you using these exceptions
> anywhere and is breaking compatibility here a problem?

Also, this commit changes the set of commands considered a "timeout" [following a discussion on c151b26](https://github.com/project-rig/rig/commit/c151b264a2aaadc41268a7891d4ed816e50a0589#commitcomment-12202415). In summary: the `RC_P2P_*` errors, with the exception of `RC_P2P_BUSY`, should be considered fatal errors, not retryable. When working on windowing to non 0, 0 chips with SARK 133 treating these as a timeout was a workaround to allow some outstanding packets to be used. Since SARK 140 should no longer require this work-around and since outstanding packets are not used with SARK 133, this should not be a problem.