### PR TITLE
Add SpiNN-5 board geometry functions.

### DIFF
--- a/rig/geometry.py
+++ b/rig/geometry.py
@@ -5,6 +5,10 @@ import random
 
 from math import sqrt
 
+import numpy as np
+
+from rig.machine import Links
+
 
 def to_xyz(xy):
     """Convert a two-tuple (x, y) coordinate into an (x, y, 0) coordinate."""
@@ -214,3 +218,201 @@ def standard_system_dimensions(num_boards):
     # Convert the number of triads into numbers of chips (each triad of boards
     # contributes as 12x12 block of chips).
     return (w * 12, h * 12)
+
+
+def spinn5_eth_coords(width, height):
+    """Generate a list of board coordinates with Ethernet connectivity in a
+    SpiNNaker machine.
+
+    Specifically, generates the coordinates for the Ethernet connected chips of
+    SpiNN-5 boards arranged in a standard torus topology.
+
+    Parameters
+    ----------
+    width : int
+        Width of the system in chips.
+    height : int
+        Height of the system in chips.
+    """
+    # Internally, work with the width and height rounded up to the next
+    # multiple of 12
+    w = ((width + 11) // 12) * 12
+    h = ((height + 11) // 12) * 12
+
+    for x in range(0, w, 12):
+        for y in range(0, h, 12):
+            for dx, dy in ((0, 0), (4, 8), (8, 4)):
+                nx = (x + dx) % w
+                ny = (y + dy) % h
+                # Skip points which are outside the range available
+                if nx < width and ny < height:
+                    yield (nx, ny)
+
+
+def spinn5_local_eth_coord(x, y, w, h):
+    """Get the coordinates of a chip's local ethernet connected chip.
+
+    Returns the coordinates of the ethernet connected chip on the same board as
+    the supplied chip.
+
+    .. note::
+        This function assumes the system is constructed from SpiNN-5 boards
+
+    Parameters
+    ----------
+    x : int
+    y : int
+    w : int
+        Width of the system in chips.
+    h : int
+        Height of the system in chips.
+    """
+    dx, dy = SPINN5_ETH_OFFSET[y % 12][x % 12]
+    return ((x + dx) % w), ((y + dy) % h)
+
+
+SPINN5_ETH_OFFSET = np.array([
+    [(vx - x, vy - y) for x, (vx, vy) in enumerate(row)]
+    for y, row in enumerate([
+        # Below is an enumeration of the absolute coordinates of the nearest
+        # ethernet connected chip. Note that the above list comprehension
+        # changes these into offsets to the nearest chip.
+        # X:   0         1         2         3         4         5         6         7         8         9        10        11     # noqa Y:
+        [(+0, +0), (+0, +0), (+0, +0), (+0, +0), (+0, +0), (+4, -4), (+4, -4), (+4, -4), (+4, -4), (+4, -4), (+4, -4), (+4, -4)],  # noqa  0
+        [(+0, +0), (+0, +0), (+0, +0), (+0, +0), (+0, +0), (+0, +0), (+4, -4), (+4, -4), (+4, -4), (+4, -4), (+4, -4), (+4, -4)],  # noqa  1
+        [(+0, +0), (+0, +0), (+0, +0), (+0, +0), (+0, +0), (+0, +0), (+0, +0), (+4, -4), (+4, -4), (+4, -4), (+4, -4), (+4, -4)],  # noqa  2
+        [(+0, +0), (+0, +0), (+0, +0), (+0, +0), (+0, +0), (+0, +0), (+0, +0), (+0, +0), (+4, -4), (+4, -4), (+4, -4), (+4, -4)],  # noqa  3
+        [(-4, +4), (+0, +0), (+0, +0), (+0, +0), (+0, +0), (+0, +0), (+0, +0), (+0, +0), (+8, +4), (+8, +4), (+8, +4), (+8, +4)],  # noqa  4
+        [(-4, +4), (-4, +4), (+0, +0), (+0, +0), (+0, +0), (+0, +0), (+0, +0), (+0, +0), (+8, +4), (+8, +4), (+8, +4), (+8, +4)],  # noqa  5
+        [(-4, +4), (-4, +4), (-4, +4), (+0, +0), (+0, +0), (+0, +0), (+0, +0), (+0, +0), (+8, +4), (+8, +4), (+8, +4), (+8, +4)],  # noqa  6
+        [(-4, +4), (-4, +4), (-4, +4), (-4, +4), (+0, +0), (+0, +0), (+0, +0), (+0, +0), (+8, +4), (+8, +4), (+8, +4), (+8, +4)],  # noqa  7
+        [(-4, +4), (-4, +4), (-4, +4), (-4, +4), (+4, +8), (+4, +8), (+4, +8), (+4, +8), (+4, +8), (+8, +4), (+8, +4), (+8, +4)],  # noqa  8
+        [(-4, +4), (-4, +4), (-4, +4), (-4, +4), (+4, +8), (+4, +8), (+4, +8), (+4, +8), (+4, +8), (+4, +8), (+8, +4), (+8, +4)],  # noqa  9
+        [(-4, +4), (-4, +4), (-4, +4), (-4, +4), (+4, +8), (+4, +8), (+4, +8), (+4, +8), (+4, +8), (+4, +8), (+4, +8), (+8, +4)],  # noqa 10
+        [(-4, +4), (-4, +4), (-4, +4), (-4, +4), (+4, +8), (+4, +8), (+4, +8), (+4, +8), (+4, +8), (+4, +8), (+4, +8), (+4, +8)]   # noqa 11
+    ])
+], dtype=int)
+"""SpiNN-5 ethernet connected chip lookup.
+
+Used by :py:func:`.spinn5_local_eth_coord`. Given an x and y chip position
+modulo 12, return the offset of the board's bottom-left chip from the chip's
+position.
+
+Note: the order of indexes: ``SPINN5_ETH_OFFSET[y][x]``!
+"""
+
+
+def spinn5_chip_coord(x, y):
+    """Get the coordinates of a chip on its board.
+
+    Given the coordinates of a chip in a multi-board system, calculates the
+    coordinates of the chip within its board.
+
+    .. note::
+        This function assumes the system is constructed from SpiNN-5 boards
+
+    Parameters
+    ----------
+    x : int
+    y : int
+    """
+    dx, dy = SPINN5_ETH_OFFSET[y % 12][x % 12]
+    return (-dx, -dy)
+
+
+def spinn5_fpga_link(x, y, link):
+    """Get the identity of the FPGA link which corresponds with the supplied
+    link.
+
+    .. note::
+        This function assumes the system is constructed from SpiNN-5 boards
+        whose FPGAs are loaded with the SpI/O 'spinnaker_fpgas' image.
+
+    Parameters
+    ----------
+    x : int
+    y : int
+
+    Returns
+    -------
+    (fpga_num, link_num) or None
+        If not None, the link supplied passes through an FPGA link. The
+        returned tuple indicates the FPGA responsible for the sending-side of
+        the link.
+
+        `fpga_num` is the number (0, 1 or 2) of the FPGA responsible for the
+        link.
+
+        `link_num` indicates which of the sixteen SpiNNaker links (0 to 15)
+        into an FPGA is being used. Links 0-7 are typically handled by S-ATA
+        link 0 and 8-15 are handled by S-ATA link 1.
+
+        Returns None if the supplied link does not pass through an FPGA.
+    """
+    x, y = spinn5_chip_coord(x, y)
+    return SPINN5_FPGA_LINKS.get((x, y, link))
+
+
+SPINN5_FPGA_LINKS = {
+    (0, 0, Links.south_west): (1, 0),  # noqa
+    (0, 0, Links.west):       (1, 1),  # noqa
+    (0, 1, Links.south_west): (1, 2),  # noqa
+    (0, 1, Links.west):       (1, 3),  # noqa
+    (0, 2, Links.south_west): (1, 4),  # noqa
+    (0, 2, Links.west):       (1, 5),  # noqa
+    (0, 3, Links.south_west): (1, 6),  # noqa
+    (0, 3, Links.west):       (1, 7),  # noqa
+
+    (0, 3, Links.north): (1, 8),  # noqa
+    (1, 4, Links.west):  (1, 9),  # noqa
+    (1, 4, Links.north): (1, 10),  # noqa
+    (2, 5, Links.west):  (1, 11),  # noqa
+    (2, 5, Links.north): (1, 12),  # noqa
+    (3, 6, Links.west):  (1, 13),  # noqa
+    (3, 6, Links.north): (1, 14),  # noqa
+    (4, 7, Links.west):  (1, 15),  # noqa
+
+    (4, 7, Links.north):       (2, 0),  # noqa
+    (4, 7, Links.north_east):  (2, 1),  # noqa
+    (5, 7, Links.north):       (2, 2),  # noqa
+    (5, 7, Links.north_east):  (2, 3),  # noqa
+    (6, 7, Links.north):       (2, 4),  # noqa
+    (6, 7, Links.north_east):  (2, 5),  # noqa
+    (7, 7, Links.north):       (2, 6),  # noqa
+    (7, 7, Links.north_east):  (2, 7),  # noqa
+
+    (7, 7, Links.east):        (2, 8),  # noqa
+    (7, 6, Links.north_east):  (2, 9),  # noqa
+    (7, 6, Links.east):        (2, 10),  # noqa
+    (7, 5, Links.north_east):  (2, 11),  # noqa
+    (7, 5, Links.east):        (2, 12),  # noqa
+    (7, 4, Links.north_east):  (2, 13),  # noqa
+    (7, 4, Links.east):        (2, 14),  # noqa
+    (7, 3, Links.north_east):  (2, 15),  # noqa
+
+    (7, 3, Links.east):  (0, 0),  # noqa
+    (7, 3, Links.south): (0, 1),  # noqa
+    (6, 2, Links.east):  (0, 2),  # noqa
+    (6, 2, Links.south): (0, 3),  # noqa
+    (5, 1, Links.east):  (0, 4),  # noqa
+    (5, 1, Links.south): (0, 5),  # noqa
+    (4, 0, Links.east):  (0, 6),  # noqa
+    (4, 0, Links.south): (0, 7),  # noqa
+
+    (4, 0, Links.south_west): (0, 8),  # noqa
+    (3, 0, Links.south):      (0, 9),  # noqa
+    (3, 0, Links.south_west): (0, 10),  # noqa
+    (2, 0, Links.south):      (0, 11),  # noqa
+    (2, 0, Links.south_west): (0, 12),  # noqa
+    (1, 0, Links.south):      (0, 13),  # noqa
+    (1, 0, Links.south_west): (0, 14),  # noqa
+    (0, 0, Links.south):      (0, 15),  # noqa
+}
+"""FPGA link IDs for each link leaving a SpiNN-5 board.
+
+Format::
+
+    {(x, y, link): (fpga_num, link_num), ...}
+
+Used by :py:func:`.spinn5_fpga_link`.
+"""


### PR DESCRIPTION
Adds:

* `spinn5_eth_coords`: Generate a list of board coordinates with Ethernet
  connectivity in a SpiNNaker machine.
* `spinn5_local_eth_coord`: Get the coordinates of a chip's local ethernet
  connected chip.
* `spinn5_chip_coord`: Get the coordinates of a chip on its board.
* `spinn5_fpga_link`: Get the identity of the FPGA link which corresponds with
  the supplied link.

Some of this code is taken from the numerous defunct branches aiming to improve Ethernet performance by using multiple links.