### PR TITLE
Fix for issue with number of dimensions being zeroed 

### DIFF
--- a/rig/type_casts.py
+++ b/rig/type_casts.py
@@ -240,7 +240,10 @@ class NumpyFloatToFixConverter(object):
         vals *= 2.0 ** self.n_frac
         vals = np.round(vals)
 
-        return self.dtype(vals)
+        # **NOTE** for some reason just casting resulted in shape
+        # being zeroed on some indeterminate selection of OSes,
+        # architectures, Python and Numpy versions"
+        return np.array(vals, copy=True, dtype=self.dtype)
 
 
 class NumpyFixToFloatConverter(object):


### PR DESCRIPTION
Seemed to occur on:
* 32-bit Fedora (surprise!) with Numpy 1.8.2 
* Windows with 32-bit Python and Numpy 1.9ish