### PR TITLE
BUGFIX: Open APLX files for read, not read/write.

### DIFF
--- a/rig/machine_control/machine_controller.py
+++ b/rig/machine_control/machine_controller.py
@@ -852,7 +852,7 @@ class MachineController(ContextMixin):
             fills = regions.compress_flood_fill_regions(targets)
 
             # Load the APLX data
-            with open(aplx, "rb+") as f:
+            with open(aplx, "rb") as f:
                 aplx_data = f.read()
             n_blocks = ((len(aplx_data) + self.scp_data_length - 1) //
                         self.scp_data_length)


### PR DESCRIPTION
Previously APLX files to be loaded were opened with mode "rb+" in which the +
indicates read/write mode. This has been changed to "rb" since the only thing
ever done to the file is a single f.read().

Many thanks to @lplana who indirectly discovered this bug!