### PR TITLE
SameChipConstraint

### DIFF
--- a/docs/source/place_and_route.rst
+++ b/docs/source/place_and_route.rst
@@ -83,12 +83,22 @@ Constraint
     Vertices which consume no cores are typically only useful when describing
     external devices connected to the SpiNNaker system.
     
-    Vertices which consume more than one core are typically only useful when a
-    vertex represents a group of applications which share memory. This is
-    because vertices will always be placed on a single SpiNNaker chip: they
-    cannot be split across many chips. If an application requires this type of
-    behaviour, users must perform this step in an application-defined process
-    prior to placement.
+    Vertices which consume more than one core are unlikely to be of frequent
+    use:
+    
+    * Vertices will always be placed on a single SpiNNaker chip: they cannot
+      be split across many chips. If an application requires this type of
+      behaviour, users must perform this step in an application-defined process
+      prior to placement.
+    
+    * If in an application where several cores share some on-chip resource
+      (e.g. SDRAM) and must be placed on the same chip, a
+      :py:class:`~rig.place_and_route.constraints.SameChipConstraint` can be
+      used to enforce this requirement. This has the principle advantage of
+      allowing each vertex to be connected independently via nets to other
+      vertices in the application. If a single vertex with multiple cores
+      assigned was used, all nets would be routed to and from every core
+      allocated to the vertex.
 
 :py:func:`~rig.place_and_route.wrapper`: common case wrapper
 ------------------------------------------------------------

--- a/docs/source/place_and_route.rst
+++ b/docs/source/place_and_route.rst
@@ -83,22 +83,20 @@ Constraint
     Vertices which consume no cores are typically only useful when describing
     external devices connected to the SpiNNaker system.
     
-    Vertices which consume more than one core are unlikely to be of frequent
-    use:
+    Vertices which consume more than one core are unlikely to be used
+    frequently:
     
     * Vertices will always be placed on a single SpiNNaker chip: they cannot
       be split across many chips. If an application requires this type of
       behaviour, users must perform this step in an application-defined process
       prior to placement.
     
-    * If in an application where several cores share some on-chip resource
+    * If several cores' applications must share some on-chip resource
       (e.g. SDRAM) and must be placed on the same chip, a
       :py:class:`~rig.place_and_route.constraints.SameChipConstraint` can be
-      used to enforce this requirement. This has the principle advantage of
-      allowing each vertex to be connected independently via nets to other
-      vertices in the application. If a single vertex with multiple cores
-      assigned was used, all nets would be routed to and from every core
-      allocated to the vertex.
+      used to enforce this requirement. Unlike a vertex with multiple cores,
+      each individual vertex (core) can have independent routes directly to and
+      from them.
 
 :py:func:`~rig.place_and_route.wrapper`: common case wrapper
 ------------------------------------------------------------

--- a/rig/place_and_route/constraints.py
+++ b/rig/place_and_route/constraints.py
@@ -22,6 +22,20 @@ class LocationConstraint(object):
         self.location = location
 
 
+class SameChipConstraint(object):
+    """Ensure that a group of vertices is always placed on the same chip.
+
+    Attributes
+    ----------
+    vertices : [object, ...]
+        The list of user-supplied objects representing the vertices to be
+        placed together.
+    """
+
+    def __init__(self, vertices):
+        self.vertices = vertices
+
+
 class ReserveResourceConstraint(object):
     """Reserve a range of a resource on all or a specific chip.
 

--- a/rig/place_and_route/place/rand.py
+++ b/rig/place_and_route/place/rand.py
@@ -12,7 +12,8 @@ from rig.place_and_route.exceptions import \
 
 from rig.place_and_route.place.utils import \
     subtract_resources, overallocated, \
-    apply_reserve_resource_constraint
+    apply_reserve_resource_constraint, apply_same_chip_constraints, \
+    finalise_same_chip_constraints
 
 
 def place(vertices_resources, nets, machine, constraints,
@@ -43,6 +44,8 @@ def place(vertices_resources, nets, machine, constraints,
     placements = {}
 
     # Handle constraints
+    vertices_resources, nets, constraints, substitutions = \
+        apply_same_chip_constraints(vertices_resources, nets, constraints)
     for constraint in constraints:
         if isinstance(constraint, LocationConstraint):
             # Location constraints are handled by recording the set of fixed
@@ -97,5 +100,7 @@ def place(vertices_resources, nets, machine, constraints,
                 placements[vertex] = location
                 machine[location] = resources_if_placed
                 break
+
+    finalise_same_chip_constraints(substitutions, placements)
 
     return placements

--- a/rig/place_and_route/place/utils.py
+++ b/rig/place_and_route/place/utils.py
@@ -168,7 +168,8 @@ def apply_same_chip_constraints(vertices_resources, nets, constraints):
         if len(same_chip_constraint.vertices) <= 1:
             continue
 
-        # The new (merged) vertex to replace the constrained vertices with
+        # The new (merged) vertex with which to replace the constrained
+        # vertices
         merged_vertex = MergedVertex(same_chip_constraint.vertices)
         substitutions.append(merged_vertex)
 
@@ -194,10 +195,8 @@ def apply_same_chip_constraints(vertices_resources, nets, constraints):
 
             # Change net sources
             if net.source in merged_vertices:
-                if not net_changed:
-                    net = Net(net.source, net.sinks, net.weight)
                 net_changed = True
-                net.source = merged_vertex
+                net = Net(merged_vertex, net.sinks, net.weight)
 
             # Change net sinks
             for sink_num, sink in enumerate(net.sinks):

--- a/tests/machine_control/test_machine_controller.py
+++ b/tests/machine_control/test_machine_controller.py
@@ -1170,7 +1170,7 @@ class TestMachineController(object):
         BASE_ADDRESS = 0x68900000
         # Create the mock controller
         cn._send_scp = mock.Mock()
-        cn.read_struct_field = mock.Mock(return_value = BASE_ADDRESS)
+        cn.read_struct_field = mock.Mock(return_value=BASE_ADDRESS)
 
         # Override _send_ffcs such that it ensures increasing values of
         # ((region << 18) | cores)

--- a/tests/place_and_route/place/test_place_utils.py
+++ b/tests/place_and_route/place/test_place_utils.py
@@ -2,15 +2,22 @@
 
 import pytest
 
-from rig.machine import Machine, Cores
+from rig.machine import Machine, Cores, SDRAM
+
+from rig.netlist import Net
+
+from rig.routing_table import Routes
 
 from rig.place_and_route.exceptions import InsufficientResourceError
 
-from rig.place_and_route.constraints import ReserveResourceConstraint
+from rig.place_and_route.constraints import \
+    LocationConstraint, ReserveResourceConstraint, SameChipConstraint, \
+    RouteEndpointConstraint
 
 from rig.place_and_route.place.utils import \
     add_resources, subtract_resources, overallocated, \
-    resources_after_reservation, apply_reserve_resource_constraint
+    resources_after_reservation, apply_reserve_resource_constraint, \
+    MergedVertex, apply_same_chip_constraints, finalise_same_chip_constraints
 
 
 def test_add_resources():
@@ -141,3 +148,171 @@ def test_apply_reserve_resource_constraint():
     with pytest.raises(InsufficientResourceError):
         apply_reserve_resource_constraint(machine, constraint)
     machine = machine_.copy()
+
+
+class TestApplySameChipConstraints(object):
+    """Tests for the apply_same_chip_constraints function and friends."""
+
+    @pytest.mark.parametrize("vertices_resources,nets",
+                             [({}, []),
+                              ({"v0": {Cores: 1}}, [Net("v0", "v0")])])
+    @pytest.mark.parametrize("constraints",
+                             [[],
+                              [ReserveResourceConstraint(Cores, slice(0, 1))]])
+    def test_null(self, vertices_resources, nets, constraints):
+        # Should do nothing except copy the input when no constraints are given
+        vr_out, n_out, c_out, substitutions = apply_same_chip_constraints(
+            vertices_resources, nets, constraints)
+        assert vr_out == vertices_resources
+        assert n_out == nets
+        assert c_out == constraints
+        assert substitutions == []
+
+    def test_substitute(self):
+        # In this test we attempt to apply the constraint when we supply four
+        # SameChipConstraints:
+        # * One which is empty (shouldn't change anything, nor fail!)
+        # * One which contains just v0 which shouldn't change anything
+        # * One which constrains v0 and v1 together
+        # * One which constrains v1 and v2 together
+        v0 = object()
+        v1 = object()
+        v2 = object()
+        v3 = object()
+        vertices_resources = {
+            v0: {Cores: 1},
+            v1: {Cores: 2, SDRAM: 4},
+            v2: {SDRAM: 8},
+            v3: {Cores: 16, SDRAM: 32},
+        }
+        nets = [
+            Net(v0, [v0, v1, v2, v3], 123),
+            Net(v1, v2, 456),
+            Net(v3, v0, 789),
+        ]
+        constraints = [
+            # The SameChipConstraints under test
+            SameChipConstraint([]),
+            SameChipConstraint([v0]),
+            SameChipConstraint([v0, v1]),
+            SameChipConstraint([v1, v2]),
+
+            # One should be modified due to the SameChipConstraint, the other
+            # should not.
+            LocationConstraint(v0, (1, 2)),
+            LocationConstraint(v3, (3, 4)),
+
+            # One should be modified due to the SameChipConstraint, the other
+            # should not.
+            RouteEndpointConstraint(v2, Routes.north),
+            RouteEndpointConstraint(v3, Routes.south),
+
+            # This should not be touched
+            ReserveResourceConstraint(Cores, slice(0, 1)),
+        ]
+
+        # Should do nothing except copy the input when no constraints are given
+        vr_out, n_out, c_out, substitutions = apply_same_chip_constraints(
+            vertices_resources, nets, constraints)
+
+        # Should have a substitution only for the two constraints which
+        # actually achieve anything
+        assert len(substitutions) == 2
+        assert substitutions[0].vertices == [v0, v1]
+        assert substitutions[1].vertices == [substitutions[0], v2]
+
+        # The vertex used for the merged vertices
+        vm = substitutions[1]
+
+        # The merged vertices should have their resources combined
+        assert vr_out == {
+            vm: {Cores: 3, SDRAM: 12},
+            v3: {Cores: 16, SDRAM: 32},
+        }
+
+        # The nets should be the same as those supplied except with merged
+        # vertices substituted in
+        assert len(n_out) == len(nets)
+
+        assert n_out[0].source == vm
+        assert n_out[0].sinks == [vm, vm, vm, v3]
+        assert n_out[0].weight == 123
+
+        assert n_out[1].source == vm
+        assert n_out[1].sinks == [vm]
+        assert n_out[1].weight == 456
+
+        assert n_out[2].source == v3
+        assert n_out[2].sinks == [vm]
+        assert n_out[2].weight == 789
+
+        # The constraints should be updated accordingly
+        assert len(c_out) == len(constraints)
+        assert c_out[0].vertices == []
+        assert c_out[1].vertices == [vm]
+        assert c_out[2].vertices == [vm, vm]
+        assert c_out[3].vertices == [vm, vm]
+
+        assert c_out[4].vertex == vm
+        assert c_out[4].location == (1, 2)
+
+        assert c_out[5].vertex == v3
+        assert c_out[5].location == (3, 4)
+
+        assert c_out[6].vertex == vm
+        assert c_out[6].route == Routes.north
+
+        assert c_out[7].vertex == v3
+        assert c_out[7].route == Routes.south
+
+        assert c_out[8] is constraints[8]
+
+
+class TestFinaliseSameChipConstraints(object):
+    """Tests for the finalise_same_chip_constraints function."""
+
+    def test_null(self):
+        # Test that the finalise_same_chip_constraints works when there's
+        # nothing to do...
+        v0 = object()
+        v1 = object()
+        v2 = object()
+        v3 = object()
+        placements = {
+            v0: (0, 1),
+            v1: (1, 2),
+            v2: (2, 3),
+            v3: (3, 4),
+        }
+        orig_placements = placements.copy()
+
+        finalise_same_chip_constraints([], placements)
+
+        # Should be no change!
+        assert orig_placements == placements
+
+    def test_multiple(self):
+        # Test that the finalise_same_chip_constraints works when there's
+        # several overlapping substitutions to be made
+        v0 = object()
+        v1 = object()
+        v2 = object()
+        v3 = object()
+        m0 = MergedVertex([v0, v1])
+        m1 = MergedVertex([m0, v2])
+
+        placements = {
+            m1: (0, 1),
+            v3: (1, 2),
+        }
+
+        finalise_same_chip_constraints([m0, m1], placements)
+
+        # Should have unpacked one after the other (note in reverse order) and
+        # no merged vertices should remain.
+        assert placements == {
+            v0: (0, 1),
+            v1: (0, 1),
+            v2: (0, 1),
+            v3: (1, 2),
+        }


### PR DESCRIPTION
This new constraint allows applications to specify that a given collection of
vertices should always be placed on the same chip. This functionality is being
added to address an imminent need for this functionality in nengo_spinnaker and
a perhaps less imminent need in pinus_rigida.

@mundya and @neworderofjamie please could you confirm this will meet your future needs!