### PR TITLE
Fix buffering

### DIFF
--- a/rig/machine_control/machine_controller.py
+++ b/rig/machine_control/machine_controller.py
@@ -1945,7 +1945,8 @@ class _WriteBuffer(object):
         else:
             # The write either starts outside the used area of the buffer, or
             # would overflow the buffer.
-            if start_offset < self.buffer_size:
+            if (start_offset < self.buffer_size and
+                    start_offset <= self.current_end):
                 # We would overflow the buffer, so store as much into the
                 # buffer as possible.
                 end = self.buffer_size - start_offset

--- a/rig/machine_control/machine_controller.py
+++ b/rig/machine_control/machine_controller.py
@@ -1936,7 +1936,12 @@ class _WriteBuffer(object):
         start_offset = start_address - self.start_address
         end_offset = start_offset + len(data)  # Byte AFTER the end of the data
 
-        if start_offset <= self.current_end and end_offset <= self.buffer_size:
+        if start_offset < 0:
+            # The write starts from before this buffer, so we flush and add a
+            # new write
+            self.flush()
+            self.add_new_write(start_address, data)
+        elif start_offset <= self.current_end and end_offset <= self.buffer_size:
             # The write is entirely contained within the buffer and starts
             # within the area of the buffer which already contains data, so we
             # can just modify the buffer.

--- a/rig/machine_control/machine_controller.py
+++ b/rig/machine_control/machine_controller.py
@@ -1941,7 +1941,8 @@ class _WriteBuffer(object):
             # new write
             self.flush()
             self.add_new_write(start_address, data)
-        elif start_offset <= self.current_end and end_offset <= self.buffer_size:
+        elif (start_offset <= self.current_end and
+                end_offset <= self.buffer_size):
             # The write is entirely contained within the buffer and starts
             # within the area of the buffer which already contains data, so we
             # can just modify the buffer.

--- a/tests/machine_control/test_machine_controller.py
+++ b/tests/machine_control/test_machine_controller.py
@@ -2214,6 +2214,27 @@ class TestMemoryIO(object):
             mock.call(4, b'\x30\x40', 9, 2, 0),
         ])
 
+    def test_coalescing_writes_flushes_on_non_coalesced_write_2(self):
+        """Tests that writes from multiple slices of the same file-like view of
+        memory are buffered until a non-contiguous write occurs.
+        """
+        # Set up
+        cn = mock.Mock(spec_set=MachineController)
+        parent = MemoryIO(cn, 9, 2, 0, 8, buffer_size=8)
+
+        with parent:
+            child_0 = parent[:4]
+            child_1 = parent[4:]
+
+            child_1.write(b'\x30\x40')
+            child_0.write(b'\x12')  # Does not meet child 1
+
+        # The writes should have been performed
+        cn.write.assert_has_calls([
+            mock.call(4, b'\x30\x40', 9, 2, 0),
+            mock.call(0, b'\x12', 9, 2, 0),
+        ])
+
     def test_buffer_overflows(self):
         """Tests that writes from multiple slices of the same file-like view of
         memory are buffered until a non-contiguous write occurs.

--- a/tests/machine_control/test_machine_controller.py
+++ b/tests/machine_control/test_machine_controller.py
@@ -1940,7 +1940,7 @@ class TestMemoryIO(object):
         # Assert that reading with no parameter reads the full number of bytes
         sdram_file.seek(offset)
         sdram_file.read()
-        mock_controller.read.assert_called_one_with(
+        mock_controller.read.assert_called_once_with(
             start_address + offset, length - offset, x, y, 0)
 
     def test_read_beyond(self, mock_controller):
@@ -2209,7 +2209,7 @@ class TestMemoryIO(object):
             child_1.write(b'\x30\x40')
 
         # The writes should have been performed
-        cn.write.assert_any_calls([
+        cn.write.assert_has_calls([
             mock.call(0, b'\x12', 9, 2, 0),
             mock.call(4, b'\x30\x40', 9, 2, 0),
         ])


### PR DESCRIPTION
Fixes:
 * Two typos in the machine controller tests
 * Non-contiguous writes that were within the potential range of a buffer didn't cause a flush to occur
   * Non-contiguous writes that started before the range of a buffer were ignored