### PR TITLE
Remove dead code from NER router.

### DIFF
--- a/rig/place_and_route/route/ner.py
+++ b/rig/place_and_route/route/ner.py
@@ -118,10 +118,8 @@ def ner_net(source, destinations, width, height, wrap_around=False, radius=10):
         # Take the longest dimension first route.
         last_node = route[neighbour]
         for direction, (x, y) in ldf:
-            this_node = route.get((x, y), None)
-            if this_node is None:
-                this_node = RoutingTree((x, y))
-                route[(x, y)] = this_node
+            this_node = RoutingTree((x, y))
+            route[(x, y)] = this_node
 
             last_node.children.add((Routes(direction), this_node))
             last_node = this_node


### PR DESCRIPTION
When the cycle-creating bug in NER was fixed in 5c4bfb7, a check got left over
from the original (broken) cycle detection code.

The code this commit removes checked, during route insertion, that the route
being inserted didn't cross an existing route segment. Thanks to 5c4bfb7, the
loop which generates the route to be inserted truncates it before it encounters
any route segments and thus the old check is no longer necessary.

This dead code was spotted by the branch-coverage checker which notably
coveralls does *not* know about and hence this code going unpunished for so
long.