### PR TITLE
Allow SDRAM to be cleared after allocation

### DIFF
--- a/rig/machine_control/consts.py
+++ b/rig/machine_control/consts.py
@@ -67,6 +67,8 @@ class SCPCommands(enum.IntEnum):
     read = 2  # Read data
     write = 3  # Write data
 
+    fill = 5  # Fill a number of words with a given value
+
     link_read = 17  # Send a NN (or FPGA reg) read command
     link_write = 18  # Send a NN (or FPGA reg) write command
 

--- a/rig/machine_control/utils.py
+++ b/rig/machine_control/utils.py
@@ -4,7 +4,8 @@ from ..machine import Cores, SDRAM
 
 def sdram_alloc_for_vertices(controller, placements, allocations,
                              core_as_tag=True, buffer_size=0,
-                             sdram_resource=SDRAM, cores_resource=Cores):
+                             sdram_resource=SDRAM, cores_resource=Cores,
+                             clear=False):
     """Allocate and return a file-like view of a region of SDRAM for each
     vertex which uses SDRAM as a resource.
 
@@ -40,6 +41,10 @@ def sdram_alloc_for_vertices(controller, placements, allocations,
         When `core_as_tag=True`, the tag allocated will be the ID of the first
         core used by the vertex (indicated by the `cores_resource`, default
         :py:class:`~rig.machine.Cores`), otherwise the tag will be set to 0.
+    clear : bool
+        If True the requested memory will be filled with zeros before the
+        pointer is returned.  If False (the default) the memory will be left
+        as-is.
 
     Other Parameters
     ----------------
@@ -85,7 +90,7 @@ def sdram_alloc_for_vertices(controller, placements, allocations,
 
             # Get the memory
             vertex_memory[vertex] = controller.sdram_alloc_as_filelike(
-                size, tag, x=x, y=y, buffer_size=buffer_size
+                size, tag, x=x, y=y, buffer_size=buffer_size, clear=clear
             )
 
     return vertex_memory

--- a/tests/machine_control/test_machine_control_utils.py
+++ b/tests/machine_control/test_machine_control_utils.py
@@ -9,7 +9,8 @@ from rig.machine import Cores, SDRAM
 
 @pytest.mark.parametrize("core_as_tag", [True, False])
 @pytest.mark.parametrize("buffer_size", [None, 400])
-def test_sdram_alloc_for_vertices(core_as_tag, buffer_size):
+@pytest.mark.parametrize("clear", [True, False])
+def test_sdram_alloc_for_vertices(core_as_tag, buffer_size, clear):
     """Test allocing and getting a map of vertices to file-like objects
     when multiple blocks of memory are requested.
     """
@@ -29,7 +30,7 @@ def test_sdram_alloc_for_vertices(core_as_tag, buffer_size):
     # Create the controller
     cn = MachineController("localhost")
 
-    def sdram_alloc(size, tag, x, y, app_id):
+    def sdram_alloc(size, tag, x, y, app_id, clear):
         return {
             (0, 0, 1): 0x67800000,
             (0, 0, 2): 0x60000000,
@@ -43,7 +44,7 @@ def test_sdram_alloc_for_vertices(core_as_tag, buffer_size):
 
     # Perform the SDRAM allocation
     with cn(app_id=33):
-        kwargs = dict(core_as_tag=core_as_tag)
+        kwargs = dict(core_as_tag=core_as_tag, clear=clear)
         if buffer_size is not None:
             kwargs["buffer_size"] = buffer_size
 
@@ -52,9 +53,9 @@ def test_sdram_alloc_for_vertices(core_as_tag, buffer_size):
 
     # Ensure the correct calls were made to sdram_alloc
     cn.sdram_alloc.assert_has_calls([
-        mock.call(400, 1 if core_as_tag else 0, 0, 0, 33),
-        mock.call(200, 2 if core_as_tag else 0, 0, 0, 33),
-        mock.call(100, 1 if core_as_tag else 0, 1, 1, 33),
+        mock.call(400, 1 if core_as_tag else 0, 0, 0, 33, clear),
+        mock.call(200, 2 if core_as_tag else 0, 0, 0, 33, clear),
+        mock.call(100, 1 if core_as_tag else 0, 1, 1, 33, clear),
     ], any_order=True)
 
     # Ensure that every vertex has a memory file-like


### PR DESCRIPTION
Adds the `clear` argument to `sdram_alloc` and `sdram_alloc_as_filelike`
which will cause the allocated memory to be cleared before use.

Note: makes project-rig/nengo_spinnaker#83 unnecessary.