### PR TITLE
Replace enum34 with enum-compat in requirements-docs.txt

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,6 +1,6 @@
 sphinx
 numpydoc
 six
-enum34
+enum-compat
 sentinel
 mock


### PR DESCRIPTION
Makes the documentation build process work correctly with Python 3.5+. See
ae3b2d70c255e0cbf6a8bee78fd8616dda06421c for the equivilent change in the
setup.py dependencies list.