### PR TITLE
Naive placement refactor

### DIFF
--- a/docs/source/netlist.rst
+++ b/docs/source/netlist.rst
@@ -3,5 +3,6 @@
 
 .. automodule:: rig.netlist
     :members:
+    :special-members:
 
 

--- a/docs/source/place_and_route/placement_algorithms.rst
+++ b/docs/source/place_and_route/placement_algorithms.rst
@@ -3,6 +3,10 @@ Placement algorithms
 
 .. autofunction:: rig.place_and_route.place.sa.place
 
+.. autofunction:: rig.place_and_route.place.sequential.place
+
+.. autofunction:: rig.place_and_route.place.breadth_first.place
+
 .. autofunction:: rig.place_and_route.place.hilbert.place
 
 .. autofunction:: rig.place_and_route.place.rand.place

--- a/rig/place_and_route/place/breadth_first.py
+++ b/rig/place_and_route/place/breadth_first.py
@@ -1,0 +1,59 @@
+"""A greedy vertex-ordering heuristic for a sequential placer."""
+
+from collections import deque, defaultdict
+
+from rig.place_and_route.place.sequential import place as sequential_place
+
+
+def breadth_first_vertex_order(vertices_resources, nets):
+    """A generator which iterates over a set of vertices in a breadth-first
+    order in terms of connectivity.
+
+    For use as a vertex ordering for the sequential placer.
+    """
+    # Special case: no vertices, just stop immediately
+    if len(vertices_resources) == 0:
+        return
+
+    # Enumerate the set of nets attached to each vertex
+    vertex_neighbours = defaultdict(set)
+    for net in nets:
+        vertex_neighbours[net.source].update(net)
+        for sink in net.sinks:
+            vertex_neighbours[sink].update(net)
+
+    # Perform a breadth-first iteration over the vertices.
+    unplaced_vertices = set(vertices_resources)
+    vertex_queue = deque()
+    while vertex_queue or unplaced_vertices:
+        if not vertex_queue:
+            vertex_queue.append(unplaced_vertices.pop())
+        vertex = vertex_queue.popleft()
+
+        yield vertex
+
+        vertex_queue.extend(v for v in vertex_neighbours[vertex]
+                            if v in unplaced_vertices)
+        unplaced_vertices.difference_update(vertex_neighbours[vertex])
+
+
+def place(vertices_resources, nets, machine, constraints, chip_order=None):
+    """Places vertices in breadth-first order onto chips in the machine.
+
+    This is a thin wrapper around the :py:func:`sequential
+    <rig.place_and_route.place.sequential.place>` placement algorithm which
+    uses the :py:func:`breadth_first_vertex_order` vertex ordering.
+
+    Parameters
+    ----------
+    chip_order : None or iterable
+        The order in which chips should be tried as a candidate location for a
+        vertex. See the :py:func:`sequential
+        <rig.place_and_route.place.sequential.place>` placer's argument of the
+        same name.
+    """
+    return sequential_place(vertices_resources, nets,
+                            machine, constraints,
+                            breadth_first_vertex_order(vertices_resources,
+                                                       nets),
+                            chip_order)

--- a/rig/place_and_route/place/breadth_first.py
+++ b/rig/place_and_route/place/breadth_first.py
@@ -18,6 +18,8 @@ def breadth_first_vertex_order(vertices_resources, nets):
     # Enumerate the set of nets attached to each vertex
     vertex_neighbours = defaultdict(set)
     for net in nets:
+        # Note: Iterating over a Net object produces the set of vertices
+        # involved in the net.
         vertex_neighbours[net.source].update(net)
         for sink in net.sinks:
             vertex_neighbours[sink].update(net)

--- a/rig/place_and_route/place/sequential.py
+++ b/rig/place_and_route/place/sequential.py
@@ -1,0 +1,160 @@
+"""A flexible greedy sequential placement algorithm."""
+
+from itertools import cycle
+
+from six import next
+
+from rig.place_and_route.constraints import \
+    LocationConstraint, ReserveResourceConstraint
+
+from rig.place_and_route.exceptions import \
+    InvalidConstraintError, InsufficientResourceError
+
+from rig.place_and_route.place.utils import \
+    subtract_resources, overallocated, \
+    apply_reserve_resource_constraint, apply_same_chip_constraints, \
+    finalise_same_chip_constraints
+
+
+def place(vertices_resources, nets, machine, constraints,
+          vertex_order=None, chip_order=None):
+    """Blindly places vertices in sequential order onto chips in the machine.
+
+    This algorithm sequentially places vertices onto chips in the order
+    specified (or in an undefined order if not specified). This algorithm is
+    essentially the simplest possible valid placement algorithm and is intended
+    to form the basis of other simple sequential and greedy placers.
+
+    The algorithm proceeds by attempting to place each vertex on the a chip. If
+    the vertex fits we move onto the next vertex (but keep filling the same
+    vertex). If the vertex does not fit we move onto the next candidate chip
+    until we find somewhere the vertex fits. The algorithm will raise an
+    :py:exc:`rig.place_and_route.exceptions.InsufficientResourceError`
+    if it has failed to fit a vertex on every chip.
+
+    Parameters
+    ----------
+    vertex_order : None or iterable
+        The order in which the vertices should be attemted to be placed.
+
+        If None (the default), the vertices will be placed in the default
+        iteration order of the ``vertices_resources`` argument. If an iterable,
+        the iteration sequence should produce each vertex in vertices_resources
+        *exactly once*.
+
+    chip_order : None or iterable
+        The order in which chips should be tried as a candidate location for a
+        vertex.
+
+        If None (the default), the chips will be used in the default iteration
+        order of the ``machine`` object (a raster scan). If an iterable, the
+        iteration sequence should produce (x, y) pairs giving the coordinates
+        of chips to use. All working chip coordinates must be included in the
+        iteration sequence *exactly once*. Additional chip coordinates of
+        non-existant or dead chips are also allowed (and will simply be
+        skipped).
+    """
+    # If no vertices to place, just stop (from here on we presume that at least
+    # one vertex will be placed)
+    if len(vertices_resources) == 0:
+        return {}
+
+    # Within the algorithm we modify the resource availability values in the
+    # machine to account for the effects of the current placement. As a result,
+    # an internal copy of the structure must be made.
+    machine = machine.copy()
+
+    # {vertex: (x, y), ...} gives the location of all vertices, updated
+    # throughout the function.
+    placements = {}
+
+    # Handle constraints
+    vertices_resources, nets, constraints, substitutions = \
+        apply_same_chip_constraints(vertices_resources, nets, constraints)
+    for constraint in constraints:
+        if isinstance(constraint, LocationConstraint):
+            # Location constraints are handled by recording the set of fixed
+            # vertex locations and subtracting their resources from the chips
+            # they're allocated to.
+            location = constraint.location
+            if location not in machine:
+                raise InvalidConstraintError(
+                    "Chip requested by {} unavailable".format(machine))
+            vertex = constraint.vertex
+
+            # Record the constrained vertex's location
+            placements[vertex] = location
+
+            # Make sure the vertex fits at the requested location (updating the
+            # resource availability after placement)
+            resources = vertices_resources[vertex]
+            machine[location] = subtract_resources(machine[location],
+                                                   resources)
+            if overallocated(machine[location]):
+                raise InsufficientResourceError(
+                    "Cannot meet {}".format(constraint))
+        elif isinstance(constraint,  # pragma: no branch
+                        ReserveResourceConstraint):
+            apply_reserve_resource_constraint(machine, constraint)
+
+    if vertex_order is not None:
+        # Must modify the vertex_order to substitute the merged vertices
+        # inserted by apply_reserve_resource_constraint.
+        vertex_order = list(vertex_order)
+        for merged_vertex in reversed(substitutions):
+            # Swap the first merged vertex for its MergedVertex object and
+            # remove all other vertices from the merged set
+            vertex_order[vertex_order.index(merged_vertex.vertices[0])] \
+                = merged_vertex
+            # Remove all other vertices in the MergedVertex
+            for vertex in merged_vertex.vertices[1:]:
+                vertex_order.remove(vertex)
+
+    # The set of vertices which have not been constrained, in iteration order
+    movable_vertices = (v for v in (vertices_resources
+                                    if vertex_order is None
+                                    else vertex_order)
+                        if v not in placements)
+
+    # A cyclic iterator over all available chips
+    chips = cycle(c for c in (machine if chip_order is None else chip_order)
+                  if c in machine)
+    chips_iter = iter(chips)
+
+    try:
+        cur_chip = next(chips_iter)
+    except StopIteration:
+        raise InsufficientResourceError("No working chips in machine.")
+
+    # The last chip that we successfully placed something on. Used to detect
+    # when we've tried all available chips and not found a suitable candidate
+    last_successful_chip = cur_chip
+
+    # Place each vertex in turn
+    for vertex in movable_vertices:
+        while True:
+            resources_if_placed = subtract_resources(
+                machine[cur_chip], vertices_resources[vertex])
+
+            if not overallocated(resources_if_placed):
+                # The vertex fits: record the resources consumed and move on to
+                # the next vertex.
+                placements[vertex] = cur_chip
+                machine[cur_chip] = resources_if_placed
+                last_successful_chip = cur_chip
+                break
+            else:
+                # The vertex won't fit on this chip, move onto the next one
+                # available.
+                cur_chip = next(chips_iter)
+
+                # If we've looped around all the available chips without
+                # managing to place the vertex, give up!
+                if cur_chip == last_successful_chip:
+                    raise InsufficientResourceError(
+                        "Ran out of chips while attempting to place vertex "
+                        "{}".format(vertex))
+
+    finalise_same_chip_constraints(substitutions, placements)
+
+    return placements

--- a/rig/place_and_route/place/utils.py
+++ b/rig/place_and_route/place/utils.py
@@ -66,7 +66,7 @@ def resources_after_reservation(res, constraint):
 
 
 def apply_reserve_resource_constraint(machine, constraint):
-    """Apply the changes inplied by a reserve resource constraint to a
+    """Apply the changes implied by a reserve resource constraint to a
     machine model."""
     if constraint.location is None:
         # Compensate for globally reserved resources

--- a/rig/place_and_route/utils.py
+++ b/rig/place_and_route/utils.py
@@ -55,7 +55,7 @@ def build_routing_tables(routes, net_keys, omit_default_routes=True):
     used).
 
     .. warning::
-        A :py:exception:`~rig.place_and_route.utils.MultisourceRouteError` will
+        A :py:exc:`rig.place_and_route.utils.MultisourceRouteError` will
         be raised if entries with identical keys and masks but with differing
         routes are generated. This is not a perfect test, entries which would
         otherwise collide are not spotted.

--- a/tests/place_and_route/place/test_breadth_first.py
+++ b/tests/place_and_route/place/test_breadth_first.py
@@ -1,0 +1,66 @@
+import pytest
+
+from rig.netlist import Net
+
+from rig.place_and_route.place.breadth_first import breadth_first_vertex_order
+
+
+def test_empty():
+    assert list(breadth_first_vertex_order({}, [])) == []
+
+
+@pytest.mark.parametrize("with_net", [True, False])
+def test_singleton(with_net):
+    v0 = object()
+
+    if with_net:
+        nets = [Net(v0, v0)]
+    else:
+        nets = []
+
+    assert list(breadth_first_vertex_order({v0: {}}, nets)) == [v0]
+
+
+@pytest.mark.parametrize("with_net", [True, False])
+def test_disconnected(with_net):
+    # Should include both vertices when we provide two vertices which aren't
+    # connected together.
+    v0 = object()
+    v1 = object()
+
+    if with_net:
+        nets = [Net(v0, v0)]
+    else:
+        nets = []
+
+    assert set(breadth_first_vertex_order({v0: {}, v1: {}}, nets)) == set([
+        v0, v1
+    ])
+
+
+def test_group_together():
+    # Given a set of vertices with nets linking them into a cycle, they should
+    # be produced in order.
+    v0 = object()
+    v1 = object()
+    v2 = object()
+    v3 = object()
+    v4 = object()
+    v5 = object()
+
+    vertices_resources = {v: {} for v in [v0, v1, v2, v3, v4, v5]}
+    nets = [
+        Net(v0, [v1, v2]),
+        Net(v3, [v4, v5]),
+    ]
+
+    order = list(breadth_first_vertex_order(vertices_resources, nets))
+
+    # Should have the right set of vertices
+    assert set(order) == set(vertices_resources)
+
+    # Should do each group as a group
+    assert ((set(order[0:3]) == set([v0, v1, v2])
+             and set(order[3:6]) == set([v3, v4, v5]))
+            or (set(order[0:3]) == set([v3, v4, v5])
+                and set(order[3:6]) == set([v0, v1, v2])))

--- a/tests/place_and_route/place/test_generic_place.py
+++ b/tests/place_and_route/place/test_generic_place.py
@@ -23,6 +23,9 @@ from rig.place_and_route.constraints import LocationConstraint, \
     ReserveResourceConstraint, SameChipConstraint
 
 from rig.place_and_route import place as default_place
+from rig.place_and_route.place.sequential import place as sequential_place
+from rig.place_and_route.place.breadth_first \
+    import place as breadth_first_place
 from rig.place_and_route.place.hilbert import place as hilbert_place
 from rig.place_and_route.place.sa import place as sa_place
 from rig.place_and_route.place.rand import place as rand_place
@@ -30,7 +33,10 @@ from rig.place_and_route.place.rand import place as rand_place
 # This dictionary should be updated to contain all implemented algorithms along
 # with applicable keyword arguments.
 ALGORITHMS_UNDER_TEST = [(default_place, {}),
+                         (sequential_place, {}),
                          (hilbert_place, {}),
+                         (hilbert_place, {"breadth_first": False}),
+                         (breadth_first_place, {}),
                          (sa_place, {}),
                          # Testing with effort = 0 tests the initial (random)
                          # placement solutions of the SA placer.

--- a/tests/place_and_route/place/test_hilbert.py
+++ b/tests/place_and_route/place/test_hilbert.py
@@ -1,6 +1,8 @@
 import pytest
 
-from rig.place_and_route.place.hilbert import hilbert
+from rig.place_and_route.place.hilbert import hilbert, hilbert_chip_order
+
+from rig.machine import Machine
 
 
 class TestHilbert(object):
@@ -28,3 +30,10 @@ class TestHilbert(object):
             reference.remove(xy)
 
         assert len(reference) == 0
+
+
+@pytest.mark.parametrize("w,h", [(1, 1), (2, 2), (2, 4), (4, 2), (7, 15)])
+def test_hilbert_chip_order(w, h):
+    """Make sure the iterator covers the whole machine."""
+    machine = Machine(w, h)
+    assert set(hilbert_chip_order(machine)).issuperset(set(machine))

--- a/tests/place_and_route/place/test_sequential.py
+++ b/tests/place_and_route/place/test_sequential.py
@@ -1,0 +1,76 @@
+from collections import OrderedDict
+
+from rig.place_and_route.place.sequential import place
+
+from rig.machine import Machine, Cores
+
+
+def test_default_ordering():
+    # Make sure the default orderings use the vertex and machine ordering
+    w, h = 2, 3
+    vertices = list(range(w * h))
+    vertices_resources = OrderedDict((v, {Cores: 1}) for v in vertices)
+    nets = []
+    machine = Machine(w, h, chip_resources={Cores: 1})
+    constraints = []
+
+    placements = place(vertices_resources, nets, machine, constraints,
+                       vertex_order=None, chip_order=None)
+
+    assert placements == {v: c for v, c in zip(vertices, machine)}
+
+
+def test_vertex_ordering():
+    # Make sure the supplied vertex ordering is obeyed
+    w, h = 2, 3
+    vertices = list(range(w * h))
+    vertices_resources = OrderedDict((v, {Cores: 1}) for v in vertices)
+    nets = []
+    machine = Machine(w, h, chip_resources={Cores: 1})
+    constraints = []
+    vertex_order = reversed(vertices)
+
+    placements = place(vertices_resources, nets, machine, constraints,
+                       vertex_order=vertex_order, chip_order=None)
+
+    assert placements == {v: c for v, c in zip(reversed(vertices), machine)}
+
+
+def test_chip_ordering():
+    # Make sure the supplied chip ordering is obeyed
+    w, h = 2, 3
+    vertices = list(range(w * h))
+    vertices_resources = OrderedDict((v, {Cores: 1}) for v in vertices)
+    nets = []
+    machine = Machine(w, h, chip_resources={Cores: 1})
+    constraints = []
+    chip_order = reversed(list(machine))
+
+    placements = place(vertices_resources, nets, machine, constraints,
+                       vertex_order=None, chip_order=chip_order)
+
+    assert placements == {v: c for v, c in zip(vertices,
+                                               reversed(list(machine)))}
+
+
+def test_retry():
+    # Make sure that we go back and re-try previously filled cores
+    v0 = object()
+    v1 = object()
+    v2 = object()
+    vertices_resources = OrderedDict([
+        (v0, {Cores: 1}),
+        (v1, {Cores: 2}),
+        (v2, {Cores: 1}),
+    ])
+    nets = []
+    machine = Machine(2, 1, chip_resources={Cores: 2})
+    constraints = []
+
+    placements = place(vertices_resources, nets, machine, constraints)
+
+    assert placements == {
+        v0: (0, 0),
+        v1: (1, 0),
+        v2: (0, 0),
+    }


### PR DESCRIPTION
This change extracts the kernel of the sequential hilbert placement algorithm
and makes it available as a standalone 'sequential' placer which can be
supplied with a user-defined vertex and chip use ordering. The breadth-first
vertex ordering heuristic is also broken out (and for completeness/example
usage a breadth-first sequential placement algorithm is provided).

In addition to being a generally cleaner design this will specifically make it
much easier to produce simple application-specific sequential placement
algorithms. For example when mapping a 2D grid-style application a raster-scan
sequential placement is often pretty-much what you'd want and this will make
such an algorithm very simple to implement (coming soon!).
