### PR TITLE
Fix PyPI badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ Rig
 .. image:: ./docs/source/logo.png?raw=True
    :alt: The Rig Logo
 
-.. image:: https://pypip.in/v/rig/badge.png?style=flat
+.. image:: https://img.shields.io/pypi/v/rig.svg?style=flat
    :alt: PyPi version
    :target: https://pypi.python.org/pypi/rig/
 .. image:: https://readthedocs.org/projects/rig/badge/?version=stable


### PR DESCRIPTION
Switched to `shields.io` as badge provider.

Clearly this is a critical bugfix... It has been bothering me for a good while now though...