### PR TITLE
Add link_read and link_write to MachineController

### DIFF
--- a/rig/machine_control/machine_controller.py
+++ b/rig/machine_control/machine_controller.py
@@ -396,6 +396,127 @@ class MachineController(ContextMixin):
         return connection.read(self.scp_data_length, self.scp_window_size,
                                x, y, p, address, length_bytes)
 
+    @ContextMixin.use_contextual_arguments()
+    def link_write(self, address, data, x, y, link):
+        """Write a bytestring to an address in memory on a neigbouring chip.
+
+        .. warning::
+
+            This function is intended for low-level debug use only and is not
+            optimised for performance nor intended for more general use.
+
+        This method allows you to instruct a monitor processor to send 'POKE'
+        nearest-neighbour packets to a neighbouring chip. These packets are
+        handled directly by the SpiNNaker router in the neighbouring chip,
+        potentially allowing advanced debug or recovery of a chip rendered
+        otherwise unreachable.
+
+        Parameters
+        ----------
+        address : int
+            The address at which to start reading the data. Only addresses in
+            the system-wide address map may be accessed. Addresses must be word
+            aligned.
+        data : :py:class:`bytes`
+            Data to write into memory. Must be a whole number of words in
+            length. Large writes are automatically broken into a sequence of
+            SCP link-write commands.
+        x : int
+        y : int
+            The coordinates of the chip from which the command will be sent,
+            *not* the coordinates of the chip on which the write will be
+            performed.
+        link : :py:class:`rig.machine.Links`
+            The link down which the write should be sent.
+        """
+        if address & 0b11:
+            raise ValueError("Addresses must be word-aligned.")
+        if len(data) & 0b11:
+            raise ValueError("Data must be a multiple of words in length.")
+
+        length_bytes = len(data)
+        cur_byte = 0
+
+        # Write the requested data, one SCP packet worth at a time
+        while length_bytes > 0:
+            to_write = min(length_bytes, (self.scp_data_length & ~0b11))
+            cur_data = data[cur_byte:cur_byte + to_write]
+            self._send_scp(x, y, 0, SCPCommands.link_write,
+                           arg1=address, arg2=to_write, arg3=int(link),
+                           data=cur_data, expected_args=0)
+
+            # Move to the next block to write
+            address += to_write
+            cur_byte += to_write
+            length_bytes -= to_write
+
+    @ContextMixin.use_contextual_arguments()
+    def link_read(self, address, length_bytes, x, y, link):
+        """Read a bytestring from an address in memory on a neigbouring chip.
+
+        .. warning::
+
+            This function is intended for low-level debug use only and is not
+            optimised for performance nor intended for more general use.
+
+        This method allows you to instruct a monitor processor to send 'PEEK'
+        nearest-neighbour packets to a neighbouring chip. These packets are
+        handled directly by the SpiNNaker router in the neighbouring chip,
+        potentially allowing advanced debug or recovery of a chip rendered
+        otherwise unreachable.
+
+        Parameters
+        ----------
+        address : int
+            The address at which to start reading the data. Only addresses in
+            the system-wide address map may be accessed. Addresses must be word
+            aligned.
+        length_bytes : int
+            The number of bytes to read from memory. Must be a multiple of four
+            (i.e. a whole number of words). Large reads are transparently
+            broken into multiple SCP link-read commands.
+        x : int
+        y : int
+            The coordinates of the chip from which the command will be sent,
+            *not* the coordinates of the chip on which the read will be
+            performed.
+        link : :py:class:`rig.machine.Links`
+            The link down which the read should be sent.
+
+        Returns
+        -------
+        :py:class:`bytes`
+            The data is read back from memory as a bytestring.
+        """
+        if address & 0b11:
+            raise ValueError("Addresses must be word-aligned.")
+        if length_bytes & 0b11:
+            raise ValueError("Lengths must be multiples of words.")
+
+        # Prepare the buffer to receive the incoming data
+        data = bytearray(length_bytes)
+        mem = memoryview(data)
+
+        # Read the requested data, one SCP packet worth at a time
+        while length_bytes > 0:
+            to_read = min(length_bytes, (self.scp_data_length & ~0b11))
+            response = self._send_scp(x, y, 0, SCPCommands.link_read,
+                                      arg1=address,
+                                      arg2=to_read,
+                                      arg3=int(link),
+                                      expected_args=0)
+
+            # Accumulate the incoming data and advance the memoryview through
+            # the buffer.
+            mem[:to_read] = response.data
+            mem = mem[to_read:]
+
+            # Move to the next block to read
+            address += to_read
+            length_bytes -= to_read
+
+        return bytes(data)
+
     def _get_struct_field_and_address(self, struct_name, field_name):
         field = self.structs[six.b(struct_name)][six.b(field_name)]
         address = self.structs[six.b(struct_name)].base + field.offset

--- a/rig/machine_control/machine_controller.py
+++ b/rig/machine_control/machine_controller.py
@@ -397,7 +397,7 @@ class MachineController(ContextMixin):
                                x, y, p, address, length_bytes)
 
     @ContextMixin.use_contextual_arguments()
-    def link_write(self, address, data, x, y, link):
+    def write_across_link(self, address, data, x, y, link):
         """Write a bytestring to an address in memory on a neigbouring chip.
 
         .. warning::
@@ -405,7 +405,7 @@ class MachineController(ContextMixin):
             This function is intended for low-level debug use only and is not
             optimised for performance nor intended for more general use.
 
-        This method allows you to instruct a monitor processor to send 'POKE'
+        This method instructs a monitor processor to send 'POKE'
         nearest-neighbour packets to a neighbouring chip. These packets are
         handled directly by the SpiNNaker router in the neighbouring chip,
         potentially allowing advanced debug or recovery of a chip rendered
@@ -414,7 +414,7 @@ class MachineController(ContextMixin):
         Parameters
         ----------
         address : int
-            The address at which to start reading the data. Only addresses in
+            The address at which to start writing the data. Only addresses in
             the system-wide address map may be accessed. Addresses must be word
             aligned.
         data : :py:class:`bytes`
@@ -429,10 +429,10 @@ class MachineController(ContextMixin):
         link : :py:class:`rig.machine.Links`
             The link down which the write should be sent.
         """
-        if address & 0b11:
+        if address % 4:
             raise ValueError("Addresses must be word-aligned.")
-        if len(data) & 0b11:
-            raise ValueError("Data must be a multiple of words in length.")
+        if len(data) % 4:
+            raise ValueError("Data must be a whole number of words.")
 
         length_bytes = len(data)
         cur_byte = 0
@@ -451,7 +451,7 @@ class MachineController(ContextMixin):
             length_bytes -= to_write
 
     @ContextMixin.use_contextual_arguments()
-    def link_read(self, address, length_bytes, x, y, link):
+    def read_across_link(self, address, length_bytes, x, y, link):
         """Read a bytestring from an address in memory on a neigbouring chip.
 
         .. warning::
@@ -459,7 +459,7 @@ class MachineController(ContextMixin):
             This function is intended for low-level debug use only and is not
             optimised for performance nor intended for more general use.
 
-        This method allows you to instruct a monitor processor to send 'PEEK'
+        This method instructs a monitor processor to send 'PEEK'
         nearest-neighbour packets to a neighbouring chip. These packets are
         handled directly by the SpiNNaker router in the neighbouring chip,
         potentially allowing advanced debug or recovery of a chip rendered
@@ -488,9 +488,9 @@ class MachineController(ContextMixin):
         :py:class:`bytes`
             The data is read back from memory as a bytestring.
         """
-        if address & 0b11:
+        if address % 4:
             raise ValueError("Addresses must be word-aligned.")
-        if length_bytes & 0b11:
+        if length_bytes % 4:
             raise ValueError("Lengths must be multiples of words.")
 
         # Prepare the buffer to receive the incoming data

--- a/tests/machine_control/test_machine_controller.py
+++ b/tests/machine_control/test_machine_controller.py
@@ -126,6 +126,26 @@ class TestMachineControllerLive(object):
         with controller(x=0, y=0, p=1):
             assert controller.read(0x60000000, len(data)) == data
 
+    def test_link_write_and_read(self, controller):
+        """Test link-write and read capabilities by writing a string to SDRAM
+        on another chip and then reading back.
+        """
+        data = b'PEEK and POKE!!!'  # Length is a multiple of words
+
+        # You put the data in
+        with controller(x=0, y=0, link=Links.north):
+            controller.link_write(0x60000000, data[0:4])
+            controller.link_write(0x60000004, data[4:])
+
+        # You take the data out
+        with controller(x=0, y=0, link=Links.north):
+            assert controller.link_read(0x60000000, 4) == data[0:4]
+            assert controller.link_read(0x60000000, len(data)) == data
+
+        # And check the data really was put on another chip
+        with controller(x=0, y=1):
+            assert controller.read(0x60000000, len(data)) == data
+
     def test_write_and_read_struct_values(self, controller):
         """Test reading a struct value, writing a new value and then resetting
         the value.
@@ -645,6 +665,107 @@ class TestMachineController(object):
         cn.connections[0].read.assert_called_once_with(
             buffer_size, window_size, x, y, p, start_address, length
         )
+
+    @pytest.mark.parametrize(
+        "buffer_size, x, y, link, start_address, length, data",
+        [(128, 0, 1, Links.north, 0x67800000, 80, [b"\x11" * 80, ]),
+         (128, 2, 3, Links.south, 0x67800000, 152, [b"\x11" * 128,
+                                                    b"\x22" * 24]),
+         (256, 4, 5, Links.north, 0x67800000, 256, [b"\x11" * 256]),
+         (256, 6, 7, Links.south, 0x67800000, 0, []),
+         ]
+    )
+    def test_link_read(self, buffer_size, x, y, link,
+                       start_address, length, data):
+        # Create the mock controller
+        cn = MachineController("localhost")
+        cn._scp_data_length = buffer_size
+        cn.connections[0] = mock.Mock(spec_set=SCPConnection)
+        cn.connections[0].send_scp.side_effect = [mock.Mock(data=d)
+                                                  for d in data]
+
+        # Perform the read and ensure that values are passed on as appropriate
+        # and the result is correct
+        with cn(x=x, y=y, link=link):
+            assert b"".join(data) == cn.link_read(start_address, length)
+
+        # Should have one send_scp call per expected data block
+        assert len(cn.connections[0].send_scp.mock_calls) == len(data)
+
+        # The calls should be for the correct lengths etc.
+        address = start_address
+        for block, call in zip(data, cn.connections[0].send_scp.mock_calls):
+            assert call[1][1] == x
+            assert call[1][2] == y
+            assert call[1][3] == 0
+            assert call[1][4] == SCPCommands.link_read
+            assert call[2]["arg1"] == address
+            assert call[2]["arg2"] == len(block)
+            assert call[2]["arg3"] == int(link)
+            assert call[2]["expected_args"] == 0
+            address += len(block)
+
+    @pytest.mark.parametrize(
+        "start_address, length",
+        [(0x00000001, 4),
+         (0x00000004, 1),
+         (0x00000001, 1),
+         ]
+    )
+    def test_link_read_unaligned(self, start_address, length):
+        # Create the mock controller
+        cn = MachineController("localhost")
+        with pytest.raises(ValueError):
+            cn.link_read(start_address, length, x=0, y=0, link=Links.north)
+
+    @pytest.mark.parametrize(
+        "buffer_size, x, y, link, start_address, data",
+        [(128, 0, 1, Links.north, 0x67800000, [b"\x11" * 80, ]),
+         (128, 2, 3, Links.south, 0x67800000, [b"\x11" * 128, b"\x22" * 24]),
+         (256, 4, 5, Links.north, 0x67800000, [b"\x11" * 256]),
+         (256, 6, 7, Links.north, 0x67800000, []),
+         ]
+    )
+    def test_link_write(self, buffer_size, x, y, link,
+                        start_address, data):
+        # Create the mock controller
+        cn = MachineController("localhost")
+        cn._scp_data_length = buffer_size
+        cn.connections[0] = mock.Mock(spec_set=SCPConnection)
+
+        # Perform the write of the complete data
+        with cn(x=x, y=y, link=link):
+            cn.link_write(start_address, b"".join(data))
+
+        # Should have one send_scp call per expected data block
+        assert len(cn.connections[0].send_scp.mock_calls) == len(data)
+
+        # The calls should be for the correct lengths etc.
+        address = start_address
+        for block, call in zip(data, cn.connections[0].send_scp.mock_calls):
+            assert call[1][1] == x
+            assert call[1][2] == y
+            assert call[1][3] == 0
+            assert call[1][4] == SCPCommands.link_write
+            assert call[2]["arg1"] == address
+            assert call[2]["arg2"] == len(block)
+            assert call[2]["arg3"] == int(link)
+            assert call[2]["data"] == block
+            assert call[2]["expected_args"] == 0
+            address += len(block)
+
+    @pytest.mark.parametrize(
+        "start_address, data",
+        [(0x00000001, b"\0" * 4),
+         (0x00000004, b"\0" * 1),
+         (0x00000001, b"\0" * 1),
+         ]
+    )
+    def test_link_write_unaligned(self, start_address, data):
+        # Create the mock controller
+        cn = MachineController("localhost")
+        with pytest.raises(ValueError):
+            cn.link_write(start_address, data, x=0, y=0, link=Links.north)
 
     @pytest.mark.parametrize(
         "iptag, addr, port",


### PR DESCRIPTION
These methods allow users to send PEEK/POKE requests to routers of neighbouring
chips. The implementation is not performance-optimised since this feature
expected to be used in a debug setting.