### PR TITLE
Changes to RegionTree for FFCS

### DIFF
--- a/rig/machine_control/machine_controller.py
+++ b/rig/machine_control/machine_controller.py
@@ -1249,9 +1249,9 @@ class MachineController(ContextMixin):
         for (aplx, targets) in iteritems(application_map):
             # Determine the minimum number of flood-fills that are necessary to
             # load the APLX. The regions and cores should be sorted into
-            # ascending order.
-            fills = list(regions.compress_flood_fill_regions(targets))
-            fills.sort(key=lambda rc: (rc[0] << 18) | rc[1])
+            # ascending order, `compress_flood_fill_regions` ensures this is
+            # done.
+            fills = regions.compress_flood_fill_regions(targets)
 
             # Load the APLX data
             with open(aplx, "rb") as f:

--- a/rig/machine_control/regions.py
+++ b/rig/machine_control/regions.py
@@ -159,7 +159,7 @@ class RegionCoreTree(object):
             # Iterate through the subregions and recurse, we iterate through in
             # the order which ensures that anything we yield is in increasing
             # order.
-            for i in (4*y + x for x in range(4) for y in range(4)):
+            for i in (4*x + y for y in range(4) for x in range(4)):
                 subregion = self.subregions[i]
                 if subregion is not None:
                     for (region, coremask) in \

--- a/rig/machine_control/regions.py
+++ b/rig/machine_control/regions.py
@@ -12,6 +12,7 @@ selected.
 A complete introduction and specification of the region system is given in
 "Managing Big SpiNNaker Machines" By Steve Temple.
 """
+import array
 import collections
 from six import iteritems
 
@@ -51,26 +52,6 @@ def get_region_for_chip(x, y, level=3):
     return region
 
 
-def minimise_regions(chips):
-    """Create a reduced set of regions by minimising a hierarchy tree.
-
-    Parameters
-    ----------
-    chips : iterable
-        An iterable returning x and y co-ordinate pairs.
-
-    Returns
-    -------
-    generator
-        A generator which yields 32-bit region codes which minimally cover the
-        set of given chips.
-    """
-    t = RegionTree()
-    for (x, y) in chips:
-        t.add_coordinate(x, y)
-    return t.get_regions()
-
-
 def compress_flood_fill_regions(targets):
     """Generate a reduced set of flood fill parameters.
 
@@ -82,34 +63,27 @@ def compress_flood_fill_regions(targets):
         :py:func:`~rig.place_and_route.util.build_application_map` when indexed
         by an application.
 
-    Returns
-    -------
-    generator
-        A generator which yields region and core mask pairs indicating
-        parameters to use to flood-fill an application.  `region` and
-        `core_mask` are both integer representations of bit fields that are
-        understood by SCAMP.
+    Yields
+    ------
+    (region, core mask)
+        Pair of integers which represent a region of a SpiNNaker machine and a
+        core mask of selected cores within that region for use in flood-filling
+        an application.  `region` and `core_mask` are both integer
+        representations of bit fields that are understood by SCAMP.
+
+        The pairs are yielded in an order suitable for direct use with SCAMP's
+        flood-fill core select (FFCS) method of loading.
     """
-    # Build a dictionary mapping core mask -> chips where this should be
-    # applied.
-    cores_to_targets = collections.defaultdict(set)
+    t = RegionCoreTree()
+
     for (x, y), cores in iteritems(targets):
-        # Build the core mask
-        core_mask = 0x0000
-        for c in cores:
-            core_mask |= 1 << c
+        for p in cores:
+            t.add_core(x, y, p)
 
-        # Add to the targets dict
-        cores_to_targets[core_mask].add((x, y))
-
-    # For each of these cores build the minimal set of regions
-    for core_mask, coordinates in iteritems(cores_to_targets):
-        regions = minimise_regions(coordinates)
-        for r in regions:
-            yield (r, core_mask)
+    return t.get_regions_and_coremasks()
 
 
-class RegionTree(object):
+class RegionCoreTree(object):
     """A tree structure for use in minimising sets of regions.
 
     A tree is defined which reflects the definition of SpiNNaker regions like
@@ -119,24 +93,23 @@ class RegionTree(object):
     broken up into 16x16 grids which are represented by their (level 2)
     children. These level 2 nodes have their 16x16 grids broken up into 4x4
     grids represented by their (level 3) children. Level 3 children explicitly
-    list which of their sixteen cores are part of the region.
+    list which cores of their sixteen chips are part of the region.
 
-    If any of a level 2 node's level 3 children have all of their cores
-    selected, these level 3 nodes can be removed and replaced by a level 2
-    region with the corresponding 4x4 grid selected. If multiple children can
-    be replaced with level 2 regions, these can be combined into a single level
-    2 region with the corresponding 4x4 grids selected, resulting in a
-    reduction in the number of regions required. The same process can be
+    If any of a level 2 node's level 3 children have all of their chips
+    selected for a given core, these level 3 nodes can be removed and replaced
+    by a level 2 region with the corresponding 4x4 grid selected. If multiple
+    children can be replaced with level 2 regions, these can be combined into a
+    single level 2 region with the corresponding 4x4 grids selected, resulting
+    in a reduction in the number of regions required. The same process can be
     repeated at each level of the hierarchy eventually producing a minimal set
     of regions.
 
-    This data structure is specified by supplying a sequence of (x, y)
-    coordinates of chips to be represented by a series of regions using
-    :py:meth:`.add_coordinate`. This method minimises the tree during insertion
-    meaning a minimal set of regions can be extracted by
-    :py:meth:`.get_regions` which simply traverses the tree.
+    This data structure is specified by supplying a sequence of (x, y, p)
+    coordinates of cores to be represented by a series of regions using
+    :py:meth:`.add_core`. This method minimises the tree during insertion and
+    an ordered set of regions and core masks can be extracted by
+    :py:meth:`.get_regions_and_coremasks` which simply traverses the tree.
     """
-
     def __init__(self, base_x=0, base_y=0, level=0):
         self.base_x = base_x
         self.base_y = base_y
@@ -144,75 +117,102 @@ class RegionTree(object):
         self.shift = 6 - 2*level
         self.level = level
 
-        # Each region has locally selected components
-        self.locally_selected = set()
+        # For each core number (0-17) we maintain a bitfield indicating for
+        # which subregions this core should be filled.
+        self.locally_selected = array.array('H', (0x0 for _ in range(18)))
 
-        # And possibly contains subregions
+        # If this is a coarser region tree then we also maintain a subtree of
+        # fixed size.
         if level < 3:
             self.subregions = [None] * 16
 
-    def get_regions(self):
-        """Generate a set of integer region representations.
+    def get_regions_and_coremasks(self):
+        """Generate a set of ordered paired region and core mask representations.
 
-        Returns
-        -------
-        generator
-            Generator which yields 32-bit region codes as might be generated by
-            :py:func:`.get_region_for_chip`.
+        .. note::
+            The region and core masks are ordered such that ``(region << 32) |
+            core_mask`` is monotonically increasing. Consequently region and
+            core masks generated by this method can be used with SCAMP's
+            Flood-Fill Core Select (FFSC) method.
+
+        Yields
+        ------
+        (region, core mask)
+            Pair of integers which represent a region of a SpiNNaker machine
+            and a core mask of selected cores within that region.
         """
         region_code = ((self.base_x << 24) | (self.base_y << 16) |
                        (self.level << 16))
 
-        # Build up the returned set of regions
-        if self.locally_selected != set():
-            elements = 0x0000
-            for e in self.locally_selected:
-                elements |= 1 << e
-            yield (region_code | elements)
+        # Generate core masks for any regions which are selected at this level
+        # Create a mapping from subregion mask to core numbers
+        subregions_cores = collections.defaultdict(lambda: 0x0)
+        for core, subregions in enumerate(self.locally_selected):
+            if subregions:  # If any subregions are selected on this level
+                subregions_cores[subregions] |= 1 << core
 
-        # Include subregions if they exist
+        # Order the locally selected items and then yield them
+        sorted_subregion_coremasks = sorted(list(subregions_cores.items()),
+                                            key=lambda x: (x[0] << 32) | x[1])
+        for (subregions, coremask) in sorted_subregion_coremasks:
+            yield (region_code | subregions), coremask
+
         if self.level < 3:
-            for i, sr in enumerate(self.subregions):
-                if i not in self.locally_selected and sr is not None:
-                    for r in sr.get_regions():
-                        yield r
+            # Iterate through the subregions and recurse, we iterate through in
+            # the order which ensures that anything we yield is in increasing
+            # order.
+            for i in (4*x + y for y in range(4) for x in range(4)):
+                subregion = self.subregions[i]
+                if subregion is not None:
+                    for x in subregion.get_regions_and_coremasks():
+                        yield x
 
-    def add_coordinate(self, x, y):
-        """Add a new coordinate to the region tree.
+    def add_core(self, x, y, p):
+        """Add a new core to the region tree.
 
         Raises
         ------
         ValueError
-            If the co-ordinate is not contained within the region.
+            If the co-ordinate is not contained within this part of the tree or
+            the core number is out of range.
 
         Returns
         -------
         bool
-            If all contained subregions are full.
+            True if the specified core is to be loaded to all subregions.
         """
         # Check that the co-ordinate is contained in this region
-        if ((x < self.base_x or x >= self.base_x + self.scale) or
+        if ((p < 0 or p > 17) or
+                (x < self.base_x or x >= self.base_x + self.scale) or
                 (y < self.base_y or y >= self.base_y + self.scale)):
-            raise ValueError((x, y))
+            raise ValueError((x, y, p))
 
         # Determine which subregion this refers to
         subregion = ((x >> self.shift) & 0x3) + 4*((y >> self.shift) & 0x3)
 
         if self.level == 3:
             # If level-3 then we just add to the locally selected regions
-            self.locally_selected.add(subregion)
-        else:
-            # Otherwise we delegate, if that level is full then we store it as
-            # a region that is full.
+            self.locally_selected[p] |= 1 << subregion
+        elif not self.locally_selected[p] & (1 << subregion):
+            # If the subregion isn't in `locally_selected` for this core number
+            # then add the core to the subregion.
             if self.subregions[subregion] is None:
                 # "Lazy": if the subtree doesn't exist yet then add it
                 base_x = int(self.base_x + (self.scale / 4) * (subregion % 4))
                 base_y = int(self.base_y + (self.scale / 4) * (subregion // 4))
-                self.subregions[subregion] = RegionTree(base_x, base_y,
-                                                        self.level + 1)
+                self.subregions[subregion] = RegionCoreTree(base_x, base_y,
+                                                            self.level + 1)
 
-            if self.subregions[subregion].add_coordinate(x, y):
-                self.locally_selected.add(subregion)
+            # If the subregion reports that all of its subregions for this core
+            # are selected then we need to add it to `locally_selected`.
+            if self.subregions[subregion].add_core(x, y, p):
+                self.locally_selected[p] |= 1 << subregion
 
-        # If "full" then return True (i.e., would be 0x____ffff if converted)
-        return self.locally_selected == {i for i in range(16)}
+        # If all subregions are selected for this core and this is not the top
+        # level in the hierarchy then return True after emptying the local
+        # selection for the core.
+        if self.locally_selected[p] == 0xffff and self.level != 0:
+            self.locally_selected[p] = 0x0
+            return True
+        else:
+            return False

--- a/rig/machine_control/regions.py
+++ b/rig/machine_control/regions.py
@@ -152,20 +152,19 @@ class RegionCoreTree(object):
                 subregions_cores[subregions] |= 1 << core
 
         # Order the locally selected items and then yield them
-        sorted_subregion_coremasks = sorted(list(subregions_cores.items()),
-                                            key=lambda x: (x[0] << 32) | x[1])
-        for (subregions, coremask) in sorted_subregion_coremasks:
+        for (subregions, coremask) in sorted(subregions_cores.items()):
             yield (region_code | subregions), coremask
 
         if self.level < 3:
             # Iterate through the subregions and recurse, we iterate through in
             # the order which ensures that anything we yield is in increasing
             # order.
-            for i in (4*x + y for y in range(4) for x in range(4)):
+            for i in (4*y + x for x in range(4) for y in range(4)):
                 subregion = self.subregions[i]
                 if subregion is not None:
-                    for x in subregion.get_regions_and_coremasks():
-                        yield x
+                    for (region, coremask) in \
+                            subregion.get_regions_and_coremasks():
+                        yield (region, coremask)
 
     def add_core(self, x, y, p):
         """Add a new core to the region tree.

--- a/tests/machine_control/test_regions.py
+++ b/tests/machine_control/test_regions.py
@@ -1,8 +1,8 @@
+import collections
 import pytest
 
 from rig.machine_control.regions import (
-    get_region_for_chip, compress_flood_fill_regions, minimise_regions,
-    RegionTree)
+    get_region_for_chip, compress_flood_fill_regions, RegionCoreTree)
 
 
 # NOTE: Test vectors taken from C implementation
@@ -29,90 +29,223 @@ def test_get_region_for_chip(x, y, level, region):
     assert get_region_for_chip(x, y, level) == region
 
 
-@pytest.mark.parametrize(
-    "chips, regions",
-    [({(i, j) for i in range(4) for j in range(4)}, {0x00020001}),
-     ({(i+4, j) for i in range(4) for j in range(4)}, {0x00020002}),
-     ({(i, j+4) for i in range(4) for j in range(4)}, {0x00020010}),
-     ({(i, j) for i in range(4) for j in range(4)} |
-      {(i+4, j) for i in range(4) for j in range(4)}, {0x00020003}),
-     ])
-def test_reduce_regions(chips, regions):
-    """Test hierarchical reduction of regions."""
-    assert set(minimise_regions(chips)) == regions
-
-
 def test_get_regions_and_cores_for_floodfill():
     """This test looks at trying to minimise the number of flood-fills required
     to load an application.  The required chips are in two level-3 regions and
     have different core requirements for each chip.
     """
     targets = {
-        # One region (the same cores)
         (0, 0): {1, 2, 4},
         (0, 1): {1, 2, 4},
-        # The next region (same block, different cores)
         (1, 0): {2, 3},
-        # The next region (different block)
         (4, 0): {1, 2, 4},
     }
 
-    # This is the return data structure format
-    fills = {
-        (get_region_for_chip(0, 0, 3) | get_region_for_chip(0, 1, 3),
-         (1 << 1) | (1 << 2) | (1 << 4)),
-        (get_region_for_chip(1, 0, 3), (1 << 2) | (1 << 3)),
-        (get_region_for_chip(4, 0, 3), (1 << 1) | (1 << 2) | (1 << 4)),
-    }
-
     # Test
-    assert set(compress_flood_fill_regions(targets)) == fills
+    seen_fills = collections.defaultdict(set)
+    last = 0
+    for (region, cores) in compress_flood_fill_regions(targets):
+        assert (region << 32) | cores >= last
+        last = (region << 32) | cores
+
+        # Extract the data from the region
+        level = (region >> 16) & 0x3
+        assert level == 3
+
+        # Base x and y
+        nx = (region >> 24) & 0xfc
+        ny = (region >> 16) & 0xfc
+
+        for x in range(4):
+            for y in range(4):
+                # Subregion select bit
+                bit = 1 << ((x & 3) | 4*(y & 3))
+
+                if region & bit:
+                    seen_fills[(nx + x, ny + y)].update(
+                        {i for i in range(18) if cores & (1 << i)})
+
+    assert seen_fills == targets
 
 
-class TestRegionTree(object):
-    def test_add_coordinate_fails(self):
-        t = RegionTree(level=3)
+class TestRegionCoreTree(object):
+    @pytest.mark.parametrize("x, y, p", [(16, 0, 1), (0, 16, 1), (0, 0, 25)])
+    def test_add_core_fails(self, x, y, p):
+        t = RegionCoreTree(level=3)
 
         with pytest.raises(ValueError):
-            t.add_coordinate(16, 0)
+            t.add_core(x, y, p)
 
-        with pytest.raises(ValueError):
-            t.add_coordinate(0, 16)
+    def test_add_core_normal_level_3(self):
+        """Test adding cores to a level 3 tree works as expected."""
+        t = RegionCoreTree(level=3)
 
-    def test_add_coordinate_normal(self):
-        t = RegionTree()
-        t.add_coordinate(8, 0)
-        assert (t.subregions[0].subregions[0].subregions[2].locally_selected ==
-                {0})
+        assert not t.add_core(0, 0, 5)
+        assert t.locally_selected[5] == 0b1
 
-        t.add_coordinate(0, 8)
-        assert (t.subregions[0].subregions[0].subregions[8].locally_selected ==
-                {0})
+        assert not t.add_core(0, 1, 0)
+        assert t.locally_selected[0] == 0b10000
 
-        t.add_coordinate(255, 255)
-        assert (
-            t.subregions[15].subregions[15].subregions[15].locally_selected ==
-            {15}
-        )
+        assert not t.add_core(3, 0, 0)
+        assert t.locally_selected[0] == 0b11000
 
-        pr = t.subregions[0].subregions[0]
-        pr.add_coordinate(0, 0)
-        sr = t.subregions[0].subregions[0].subregions[0]
+        assert not t.add_core(2, 0, 0)
+        assert t.locally_selected[0] == 0b11100
 
-        # Should return true when all 16 subregions are filled
-        for i in range(4):
-            for j in range(4):
-                assert sr.add_coordinate(i, j) == (i == 3 and j == 3)
+        assert not t.add_core(1, 0, 0)
+        assert t.locally_selected[0] == 0b11110
 
-        # This should propagate up
-        assert pr.add_coordinate(3, 3) is False
-        assert pr.locally_selected == {0}
+        assert not t.add_core(0, 0, 0)
+        assert t.locally_selected[0] == 0b11111
 
-        # We should be able to get a minimised regions out of this tree
-        assert set(t.get_regions()) == {
-            0x00020001,  # The last cores to be added should have caused this
-            # The other chips we added
-            get_region_for_chip(255, 255),
-            get_region_for_chip(0, 8),
-            get_region_for_chip(8, 0),
+        # Add core 7 to all chips and ensure that add_core returns true for the
+        # last entry.
+        for x in range(4):
+            for y in range(4):
+                if (x, y) != (3, 3):
+                    t.add_core(x, y, 7)
+
+        assert t.locally_selected[7] == 0x7fff
+
+        # Selecting a core in all regions should cause `add_core` to return
+        # true and to deselect the all regions for that core.
+        assert t.add_core(3, 3, 7) is True
+        assert t.locally_selected[7] == 0x0
+
+    def test_add_core_normal_level_2(self):
+        """Test adding cores to a level 2 tree works as expected, this is a
+        test of the hierarchy.
+        """
+        t = RegionCoreTree(level=2)
+
+        # Add a core to the first subregion
+        assert not t.add_core(0, 0, 0)
+        assert t.subregions[0].locally_selected[0] == 0x1
+
+        # Add a core to the other subregions
+        i = 0
+        for _y in range(4):
+            for _x in range(4):
+                x = _x * 4
+                y = _y * 4
+
+                assert not t.add_core(x, y, 0)
+                assert t.subregions[i].locally_selected[0] == 0x1
+                i += 1
+
+        # Fill a core in one of the subregions and ensure that it gets selected
+        # at the level-2 level.
+        for _x in range(4):
+            for _y in range(4):
+                x = _x + 12
+                y = _y + 12
+
+                assert not t.add_core(x, y, 5)
+
+        assert t.locally_selected[5] == 0x8000
+        assert t.subregions[15].locally_selected[5] == 0x0
+
+    def test_get_regions_cores_level_3(self):
+        """Test for correct computation and ordering of regions and cores when
+        extracted from a level 3 region.
+        """
+        t = RegionCoreTree(level=3)
+
+        # Add cores to the tree
+        t.add_core(0, 0, 1)
+        t.add_core(3, 3, 1)
+        t.add_core(3, 3, 2)
+        t.add_core(0, 0, 2)
+        t.add_core(3, 0, 0)
+        t.add_core(0, 1, 3)
+
+        # Check that all the expected regions and core masks are produced IN
+        # THE EXPECTED ORDER.
+        # NB: The first three entries above are merged to become the first
+        # entry below.
+        expected_regions_cores = {
+            (get_region_for_chip(3, 3) | get_region_for_chip(0, 0), 0b0110),
+            (get_region_for_chip(3, 0), 0b0001),
+            (get_region_for_chip(0, 1), 0b1000),
         }
+        seen_regions_cores = set([])
+
+        last = 0x0
+        for (region, coremask) in t.get_regions_and_coremasks():
+            # Check the ordering
+            assert (region << 32 | coremask) >= last
+            last = (region << 32 | coremask)
+
+            # Add to the entries we've seen
+            seen_regions_cores.add((region, coremask))
+
+        assert seen_regions_cores == expected_regions_cores
+
+    def test_get_regions_cores_with_subregions(self):
+        """Test for correct computation and ordering of regions and cores when
+        extracted from a tree with more depth.
+        """
+        t = RegionCoreTree()
+
+        # Add cores to the tree
+        # Cores 0 and 10 are present on all chips
+        for x in range(256):
+            for y in range(256):
+                t.add_core(x, y, 0)
+                t.add_core(x, y, 10)
+
+        # Core 1 is present on all but one level 3 region in the level 2 region
+        # beginning at (128, 64)
+        for x in range(16):
+            for y in range(16):
+                if x < 4 and y < 4:
+                    continue
+
+                t.add_core(x + 128, y + 64, 1)
+
+        # ORDER TEST
+        # Core 4 is present on all chips in the level 3 region beginning at (0,
+        # 252); this should come before Core 2 is on (0, 252) [higher level
+        # regions before lower level regions]; which should come before Core 3
+        # on (252, 0) [obey the region indexing - increasing y before
+        # increasing x].
+        for x in range(4):
+            for y in range(4):
+                t.add_core(0+x, 252+y, 4)
+        t.add_core(0, 252, 2)
+        t.add_core(252, 0, 3)
+
+        # Check that all the expected regions and core masks are produced IN
+        # THE EXPECTED ORDER.
+        expected_regions_cores = {
+            (get_region_for_chip(0, 0, level=0) | 0xffff, 0x1 | (1 << 10)),
+            ((get_region_for_chip(128, 64, level=2) & 0xffff0000) | 0xfffe,
+             0b0010),
+            (get_region_for_chip(0, 252), 0b0100),
+            (get_region_for_chip(0, 252, level=2), 0b10000),
+            (get_region_for_chip(252, 0), 0b1000),
+        }
+        seen_regions_cores = set([])
+
+        last = 0x0
+        for (region, coremask) in t.get_regions_and_coremasks():
+            # Check the ordering
+            assert (region << 32 | coremask) >= last
+            last = (region << 32 | coremask)
+
+            # Add to the entries we've seen
+            seen_regions_cores.add((region, coremask))
+
+        assert seen_regions_cores == expected_regions_cores
+
+    def test_get_regions_cores_with_subregions_no_repeats(self):
+        t = RegionCoreTree()
+
+        for x in range(4):
+            for y in range(4):
+                t.add_core(x, y, 1)
+
+        # This core added after a region merge occurred
+        t.add_core(x, y, 1)
+
+        assert len(list(t.get_regions_and_coremasks())) == 1


### PR DESCRIPTION
Minimising flood-fill regions is hard. This commit changes the RegionTree structure such that it:

 - Will generate region and core masks in the order required by SCAMP (that is, in increasing order of ``region << 32 | coremask``)
 - Has some knowledge of cores, and so can perform a bit more minimisation internally.