### PR TITLE
Bugfix: expand_entry loses source information

### DIFF
--- a/rig/routing_table/utils.py
+++ b/rig/routing_table/utils.py
@@ -265,13 +265,13 @@ def expand_entry(entry, ignore_xs=0x0):
         if bit & xs:
             # Yield all the entries with this bit set as 0
             entry_0 = RoutingTableEntry(entry.route, entry.key,
-                                        entry.mask | bit)
+                                        entry.mask | bit, entry.sources)
             for new_entry in expand_entry(entry_0, ignore_xs):
                 yield new_entry
 
             # And yield all the entries with this bit set as 1
             entry_1 = RoutingTableEntry(entry.route, entry.key | bit,
-                                        entry.mask | bit)
+                                        entry.mask | bit, entry.sources)
             for new_entry in expand_entry(entry_1, ignore_xs):
                 yield new_entry
 

--- a/tests/routing_table/test_routing_table_utils.py
+++ b/tests/routing_table/test_routing_table_utils.py
@@ -298,21 +298,29 @@ def test_get_common_xs():
 
 
 def test_expand_entry():
+    RTE = RoutingTableEntry
     # There is one X in the entry, this should result in two new entries being
     # returned with the X set to `0' and `1' respectively.
-    entry = RoutingTableEntry({Routes.north}, 0x0, 0xfffffffe)
+    entry = RTE({Routes.north}, 0x0, 0xfffffffe)
     assert list(expand_entry(entry)) == [
-        RoutingTableEntry({Routes.north}, 0x0, 0xffffffff),
-        RoutingTableEntry({Routes.north}, 0x1, 0xffffffff),
+        RTE({Routes.north}, 0x0, 0xffffffff),
+        RTE({Routes.north}, 0x1, 0xffffffff),
+    ]
+
+    # The same, but ensuring that the source information isn't lost.
+    entry = RTE({Routes.north}, 0x0, 0xfffffffe, {Routes.south})
+    assert list(expand_entry(entry)) == [
+        RTE({Routes.north}, 0x0, 0xffffffff, {Routes.south}),
+        RTE({Routes.north}, 0x1, 0xffffffff, {Routes.south}),
     ]
 
     # There are 3 Xs, but we only allow two of them to be expanded
-    entry = RoutingTableEntry({Routes.north}, 0x0, 0xfffffff8)
+    entry = RTE({Routes.north}, 0x0, 0xfffffff8)
     assert list(expand_entry(entry, ignore_xs=0x4)) == [
-        RoutingTableEntry({Routes.north}, 0x0, 0xfffffffb),
-        RoutingTableEntry({Routes.north}, 0x1, 0xfffffffb),
-        RoutingTableEntry({Routes.north}, 0x2, 0xfffffffb),
-        RoutingTableEntry({Routes.north}, 0x3, 0xfffffffb),
+        RTE({Routes.north}, 0x0, 0xfffffffb),
+        RTE({Routes.north}, 0x1, 0xfffffffb),
+        RTE({Routes.north}, 0x2, 0xfffffffb),
+        RTE({Routes.north}, 0x3, 0xfffffffb),
     ]
 
 


### PR DESCRIPTION
Fixes a bug in `expand_entry` which would have led to the loss of source information in expanded entries.

Also affected:
 - `expand_entries`

Sorry @mossblaser I found another...