### PR TITLE
Add corresponding __ne__ methods to objects with __eq__

### DIFF
--- a/rig/bitfield.py
+++ b/rig/bitfield.py
@@ -476,6 +476,9 @@ class BitField(object):
                 self.fields is other.fields and
                 self.field_values == other.field_values)
 
+    def __ne__(self, other):
+        return not (self == other)
+
     def __repr__(self):
         """Produce a human-readable representation of this bit field and its
         current value.

--- a/rig/place_and_route/machine.py
+++ b/rig/place_and_route/machine.py
@@ -131,6 +131,9 @@ class Machine(object):
                 self.dead_chips == other.dead_chips and
                 self.dead_links == other.dead_links)
 
+    def __ne__(self, other):
+        return not (self == other)
+
     def issubset(self, other):
         """Test whether the resources available in this machine description are
         a (non-strict) subset of those available in another machine.

--- a/tests/place_and_route/test_machine.py
+++ b/tests/place_and_route/test_machine.py
@@ -75,48 +75,62 @@ class TestMachine(object):
 
         # Should always compare equal to itself
         assert m == m
+        assert not (m != m)
 
         # Should compare equal to a copy
         m_ = m.copy()
         assert m == m_
+        assert not (m != m_)
 
         # Should not compare equal when the sizes differ
         m_.width = 2
         assert m != m_
         m_.width = 1
         assert m == m_
+        assert not (m != m_)
         m_.height = 4
         assert m != m_
+        assert not (m == m_)
         m_.height = 3
         assert m == m_
+        assert not (m != m_)
 
         # Nor when resources differ
         m_.chip_resources = {Cores: 10}
         assert m != m_
+        assert not (m == m_)
         m_.chip_resources = {Cores: 3}
         assert m == m_
+        assert not (m != m_)
 
         # Nor when exceptions differ
         m_.chip_resource_exceptions = {(0, 0): {Cores: 10}}
         assert m != m_
+        assert not (m == m_)
         m_.chip_resource_exceptions = {(0, 0): {Cores: 1}}
         assert m == m_
+        assert not (m != m_)
 
         # Nor when dead chips differ
         m_.dead_chips = set([])
         assert m != m_
+        assert not (m == m_)
         m_.dead_chips = set([(0, 1)])
         assert m == m_
+        assert not (m != m_)
 
         # Nor when dead links differ
         m_.dead_links = set([(0, 0, Links.south)])
         assert m != m_
+        assert not (m == m_)
         m_.dead_links = set([(0, 0, Links.north)])
         assert m == m_
+        assert not (m != m_)
 
         # Should compare equal if exceptions result in the same system
         m_.chip_resource_exceptions = {(0, 0): {Cores: 1}, (0, 2): {Cores: 3}}
         assert m == m_
+        assert not (m != m_)
 
     def test_issubset(self):
         """Ensure subset tests work."""

--- a/tests/test_bitfield.py
+++ b/tests/test_bitfield.py
@@ -855,28 +855,34 @@ def test_eq():
     ks1 = BitField(32)
     ks2 = BitField(32)
     assert ks1 != ks2
+    assert not (ks1 == ks2)
 
     ks1.add_field("test", length=2, start_at=1)
     ks2.add_field("test", length=2, start_at=1)
     assert ks1 != ks2
+    assert not (ks1 == ks2)
 
     ks1_val = ks1(test=1)
     ks2_val = ks2(test=1)
     assert ks1_val != ks2_val
+    assert not (ks1_val == ks2_val)
 
     # And that they're still different when completely different fields/values
     # are given
     ks1.add_field("test1", length=10, start_at=20)
     ks2.add_field("test2", length=20, start_at=10)
     assert ks1 != ks2
+    assert not (ks1 == ks2)
 
     ks1_val2 = ks1(test1=10)
     ks2_val2 = ks2(test2=20)
     assert ks1_val2 != ks2_val2
+    assert not (ks1_val2 == ks2_val2)
 
     # Check self-equivilence, even with fields and values set
     ks = BitField(32)
     assert ks == ks
+    assert not (ks != ks)
 
     ks.add_field("test")
     ks.add_field("split")
@@ -887,6 +893,7 @@ def test_eq():
     ks_s1.add_field("s1")
 
     assert ks == ks
+    assert not(ks != ks)
 
     ks_val0 = ks(test=0, split=1, s1=2)
     ks_val1 = ks(test=0)(split=1, s1=2)
@@ -897,9 +904,11 @@ def test_eq():
 
     # Check inequality when values do differ
     assert ks != ks_val0
+    assert not (ks == ks_val0)
 
     ks_val_diff = ks(test=123)
     assert ks_val_diff != ks_val0
+    assert not (ks_val_diff == ks_val0)
 
 
 def test_repr():


### PR DESCRIPTION
These are required for Python 2.7 compatibility: In Python 3.x if __ne__ is
omitted, it defaults to the inversion of __eq__ if __eq__ defined. In Python
2.x __ne__ defaults to id(a) != id(b).

Thanks to @alan-stokes for spotting this bug!