### PR TITLE
Add get_location_and_length to BitField

### DIFF
--- a/rig/bitfield.py
+++ b/rig/bitfield.py
@@ -416,6 +416,42 @@ class BitField(object):
         """
         return self.fields.get_field(field, self.field_values).tags.copy()
 
+    def get_location_and_length(self, field):
+        """Get the location and length of a field within the bitfield.
+
+        .. note::
+            The named field must be accessible given the current set of values
+            defined.
+
+        Parameters
+        ----------
+        field : str
+            The field of interest.
+
+        Returns
+        -------
+        location, length
+            A pair of integers defining the bit-number of the least-significant
+            bit in the field and the total number of bits in the field
+            respectively.
+
+        Raises
+        ------
+        ValueError
+            If a field's length or position has not been defined. (e.g.
+            :py:meth:`.assign_fields` has not been called).
+        UnavailableFieldError
+            If the field does not exist or is not available.
+        """
+        field_obj = self.fields.get_field(field, self.field_values)
+
+        if field_obj.length is None or field_obj.start_at is None:
+            raise ValueError(
+                "Field '{}' does not have a fixed size/position.".format(
+                    field))
+
+        return (field_obj.start_at, field_obj.length)
+
     def assign_fields(self):
         """Assign a position & length to any fields which do not have one.
 

--- a/tests/test_bitfield.py
+++ b/tests/test_bitfield.py
@@ -849,6 +849,36 @@ class TestFullAuto(object):
         assert ks_h(s=1, s1=1).get_mask(field="s11") == 0x00000001
 
 
+def test_get_location_and_length():
+    ks = BitField(32)
+    ks.add_field("foo")
+    ks.add_field("bar", length=5)
+    ks.add_field("baz", start_at=1)
+    ks.add_field("qux", start_at=10, length=5)
+
+    # Getting non-existant fields should fail
+    with pytest.raises(UnavailableFieldError):
+        ks.get_location_and_length("norf")
+
+    # Getting fields whose location/size is not known should fail
+    with pytest.raises(ValueError):
+        ks.get_location_and_length("foo")
+    with pytest.raises(ValueError):
+        ks.get_location_and_length("bar")
+    with pytest.raises(ValueError):
+        ks.get_location_and_length("baz")
+
+    # Getting fields whose location was predefined should work
+    assert ks.get_location_and_length("qux") == (10, 5)
+
+    # Fixing everything should allow other fields to be determined too
+    ks.assign_fields()
+    assert ks.get_location_and_length("foo") == (0, 1)
+    assert ks.get_location_and_length("bar") == (2, 5)
+    assert ks.get_location_and_length("baz") == (1, 1)
+    assert ks.get_location_and_length("qux") == (10, 5)
+
+
 def test_eq():
     # Check that two bit fields with the same fields and values (but defined
     # seperately) are not equivilent.


### PR DESCRIPTION
This new method allows the direct querying of the size and location allocated
to fields in a bit field, without having to deconstruct a mask.

This should address the need expressed by @alan-stokes in SpiNNakerManchester/PACMAN#35 while being less wasteful than just computing these values from the mask.