### PR TITLE
Insert entries above blocks of similar entries

### DIFF
--- a/rig/routing_table/ordered_covering.py
+++ b/rig/routing_table/ordered_covering.py
@@ -488,13 +488,13 @@ class _Merge(namedtuple("_Merge", ["routing_table", "entries", "key", "mask",
 
         # Iterate through the old table copying entries acrosss
         insert = 0
-        for remove, entry in enumerate(self.routing_table):
+        for i, entry in enumerate(self.routing_table):
             # If this is the insertion point then insert
-            if remove == self.insertion_index:
+            if i == self.insertion_index:
                 new_table[insert] = new_entry
                 insert += 1
 
-            if remove not in self.entries:
+            if i not in self.entries:
                 # If this entry isn't to be removed then copy it across to the
                 # new table.
                 new_table[insert] = entry
@@ -755,7 +755,7 @@ def _refine_downcheck(merge, aliases, min_goodness):
 
                 # Add this settable mask and the required values to the
                 # settables list.
-                bits_and_vals.update((bit, not bool(key & bit)) for bit in
+                bits_and_vals.update((bit, not (key & bit)) for bit in
                                      all_bits if bit & settable)
 
         if most_stringent == 0:

--- a/rig/routing_table/ordered_covering.py
+++ b/rig/routing_table/ordered_covering.py
@@ -124,12 +124,11 @@ As a heuristic:
       generality. If ``XX00`` were already present in the table the new entry
       ``0XX0`` must be inserted below it.
 """
-from collections import defaultdict, namedtuple
+from collections import namedtuple
 from rig.routing_table import MinimisationFailedError, RoutingTableEntry
 from rig.routing_table.remove_default_routes import \
     minimise as remove_default_routes
 from rig.routing_table.utils import intersect
-from six import itervalues
 
 
 def minimise(routing_table, target_length):
@@ -776,8 +775,8 @@ def _refine_downcheck(merge, aliases, min_goodness):
                 for i in merge.entries:
                     entry = merge.routing_table[i]
 
-                    if ((not entry.mask & bit) or 
-                        (bool(entry.key & bit) is (not val))):
+                    if ((not entry.mask & bit) or
+                            (bool(entry.key & bit) is (not val))):
                         # If the entry has an X in this position then it will
                         # need to be removed regardless of whether we want to
                         # set a 0 or a 1 in this position, likewise it will

--- a/tests/routing_table/test_routing_table_ordered_covering.py
+++ b/tests/routing_table/test_routing_table_ordered_covering.py
@@ -52,7 +52,8 @@ def test__get_insertion_index():
     assert _get_insertion_index(table, 30) == 0
 
     # Add a generality 30 expression and then check where generality 31
-    # expressions would go (they should go to the end of the table)
+    # expressions would go (they should go just before the other generality 31
+    # entries)
     table.insert(0, RoutingTableEntry({Routes.south}, 0b00, 0b11))
     assert _get_insertion_index(table, 32) == len(table)
 
@@ -61,7 +62,7 @@ def test__get_insertion_index():
     table.append(RoutingTableEntry({Routes.south}, 0x0, 0x0))
 
     # Check that generality 31 expressions should be inserted before this
-    assert _get_insertion_index(table, 31) == len(table) - 1
+    assert _get_insertion_index(table, 31) == 1
 
 
 class TestMerge(object):
@@ -233,8 +234,8 @@ class TestMinimise(object):
 
         Can be minimised to::
 
-            001X -> S
             000X -> N, NE
+            001X -> S
         """
         # Original table
         RTE = RoutingTableEntry
@@ -246,8 +247,8 @@ class TestMinimise(object):
 
         # Expected table
         expected_table = [
-            RTE({Routes.south}, 0b0010, 0b1110),
             RTE({Routes.north, Routes.north_east}, 0b0000, 0b1110),
+            RTE({Routes.south}, 0b0010, 0b1110),
         ]
 
         assert table_is_subset_of(table, expected_table), "Test is broken"
@@ -343,9 +344,9 @@ class TestMinimise(object):
         The result (worked out by hand) should be:
 
             0000 -> N NE
-            0X00 -> S SW
-            1X00 -> N NE
             X001 -> E
+            1X00 -> N NE
+            0X00 -> S SW
             X1XX -> SW
         """
         RTE = RoutingTableEntry
@@ -362,12 +363,11 @@ class TestMinimise(object):
 
         expected_table = [
             RTE({Routes.north, Routes.north_east}, 0b0000, 0b1111),
-            RTE({Routes.south, Routes.south_west}, 0b0000, 0b1011),
-            RTE({Routes.north, Routes.north_east}, 0b1000, 0b1011),
             RTE({Routes.east}, 0b0001, 0b0111),
+            RTE({Routes.north, Routes.north_east}, 0b1000, 0b1011),
+            RTE({Routes.south, Routes.south_west}, 0b0000, 0b1011),
             RTE({Routes.south_west}, 0b0100, 0b0100),
         ]
-
         assert table_is_subset_of(table, expected_table), "Test is broken"
 
         # Get the minimised table
@@ -431,8 +431,8 @@ def test_ordered_covering_simple():
 
     Can be minimised to::
 
-        001X -> S
         000X -> N, NE
+        001X -> S
     """
     # Original table
     RTE = RoutingTableEntry
@@ -444,8 +444,8 @@ def test_ordered_covering_simple():
 
     # Expected table
     expected_table = [
-        RTE({Routes.south}, 0b0010, 0b1110),
         RTE({Routes.north, Routes.north_east}, 0b0000, 0b1110),
+        RTE({Routes.south}, 0b0010, 0b1110),
     ]
 
     assert table_is_subset_of(table, expected_table), "Test is broken"


### PR DESCRIPTION
Insert entries above blocks of entries of equivalent generality. This
makes that the Python implementation of OC matches (a) the C version for
SpiNNaker (b) that described in the HPSR submission.

For table ordering, see
https://github.com/project-rig/rig_routing_tables/blob/master/include/ordered_covering.h#L16-L57

For downcheck preferring to modify more significant bits in merges see
https://github.com/project-rig/rig_routing_tables/blob/master/include/ordered_covering.h#L285-L292

For merge application, see
https://github.com/project-rig/rig_routing_tables/blob/master/include/ordered_covering.h#L409-L485