### PR TITLE
High throughput I/O (Multiple Ethernet Connections) - Rebase

### DIFF
--- a/rig/machine_control/machine_controller.py
+++ b/rig/machine_control/machine_controller.py
@@ -629,7 +629,7 @@ class MachineController(ContextMixin):
         return bytes(data)
 
     @ContextMixin.use_contextual_arguments()
-    def read_into(self, address, buffer, length_bytes, x, y, p=0):
+    def readinto(self, address, buffer, length_bytes, x, y, p=0):
         """Read a from an address in memory into the supplied buffer.
 
         Parameters
@@ -645,9 +645,9 @@ class MachineController(ContextMixin):
         """
         # Call the SCPConnection to perform the read on our behalf
         connection = self._get_connection(x, y)
-        connection.read_into(buffer, self.scp_data_length,
-                             self.scp_window_size,
-                             x, y, p, address, length_bytes)
+        connection.readinto(buffer, self.scp_data_length,
+                            self.scp_window_size,
+                            x, y, p, address, length_bytes)
 
     def _get_struct_field_and_address(self, struct_name, field_name):
         field = self.structs[six.b(struct_name)][six.b(field_name)]
@@ -2555,11 +2555,11 @@ class MemoryIO(object):
             return b''
         else:
             data = bytearray(n_bytes)
-            self.read_into(data, n_bytes)
+            self.readinto(data, n_bytes)
             return data
 
     @_if_not_closed
-    def read_into(self, buffer, n_bytes=-1):
+    def readinto(self, buffer, n_bytes=-1):
         """Read a number of bytes from the memory into a supplied buffer.
 
         .. note::
@@ -2583,7 +2583,7 @@ class MemoryIO(object):
             return
         else:
             # Perform the read and increment the offset
-            self._machine_controller.read_into(
+            self._machine_controller.readinto(
                 self.address, buffer, n_bytes, self._x, self._y, 0)
             self._offset += n_bytes
 

--- a/rig/machine_control/machine_controller.py
+++ b/rig/machine_control/machine_controller.py
@@ -628,6 +628,27 @@ class MachineController(ContextMixin):
 
         return bytes(data)
 
+    @ContextMixin.use_contextual_arguments()
+    def read_into(self, address, buffer, length_bytes, x, y, p=0):
+        """Read a from an address in memory into the supplied buffer.
+
+        Parameters
+        ----------
+        address : int
+            The address at which to start reading the data.
+        buffer : bytearray
+            A bufferable object (e.g. bytearray) into which the data will be
+            read.
+        length_bytes : int
+            The number of bytes to read from memory. Large reads are
+            transparently broken into multiple SCP read commands.
+        """
+        # Call the SCPConnection to perform the read on our behalf
+        connection = self._get_connection(x, y)
+        connection.read_into(buffer, self.scp_data_length,
+                             self.scp_window_size,
+                             x, y, p, address, length_bytes)
+
     def _get_struct_field_and_address(self, struct_name, field_name):
         field = self.structs[six.b(struct_name)][six.b(field_name)]
         address = self.structs[six.b(struct_name)].base + field.offset
@@ -2494,6 +2515,20 @@ class MemoryIO(object):
         """Exit a block and call :py:meth:`~.close`."""
         self.close()
 
+    def _read_n_bytes(self, n_bytes):
+        """Return the number of bytes to actually read accounting for the
+        cursor position.
+        """
+        # If n_bytes is negative then calculate it as the number of bytes left
+        if n_bytes < 0:
+            n_bytes = self._end_address - self.address
+
+        # Determine how far to read, then read nothing beyond that point.
+        if self.address + n_bytes > self._end_address:
+            n_bytes = min(n_bytes, self._end_address - self.address)
+
+        return n_bytes
+
     @_if_not_closed
     def read(self, n_bytes=-1):
         """Read a number of bytes from the memory.
@@ -2515,22 +2550,42 @@ class MemoryIO(object):
         # Flush this write buffer
         self.flush()
 
-        # If n_bytes is negative then calculate it as the number of bytes left
-        if n_bytes < 0:
-            n_bytes = self._end_address - self.address
-
-        # Determine how far to read, then read nothing beyond that point.
-        if self.address + n_bytes > self._end_address:
-            n_bytes = min(n_bytes, self._end_address - self.address)
-
+        n_bytes = self._read_n_bytes(n_bytes)
         if n_bytes <= 0:
             return b''
+        else:
+            data = bytearray(n_bytes)
+            self.read_into(data, n_bytes)
+            return data
 
-        # Perform the read and increment the offset
-        data = self._machine_controller.read(
-            self.address, n_bytes, self._x, self._y, 0)
-        self._offset += n_bytes
-        return data
+    @_if_not_closed
+    def read_into(self, buffer, n_bytes=-1):
+        """Read a number of bytes from the memory into a supplied buffer.
+
+        .. note::
+            Reads beyond the specified memory range will be truncated.
+
+        Parameters
+        ----------
+        buffer : bytearray
+            A bufferable object (e.g. bytearray) into which the data will be
+            read.
+        n_bytes : int
+            A number of bytes to read.  If the number of bytes is negative or
+            omitted then read all data until the end of memory region.
+        """
+        # Flush this write buffer
+        self.flush()
+
+        n_bytes = self._read_n_bytes(n_bytes)
+
+        if n_bytes <= 0:
+            return
+        else:
+            # Perform the read and increment the offset
+            self._machine_controller.read_into(
+                self.address, buffer, n_bytes, self._x, self._y, 0)
+            self._offset += n_bytes
 
     @_if_not_closed
     def write(self, bytes):

--- a/rig/machine_control/scp_connection.py
+++ b/rig/machine_control/scp_connection.py
@@ -327,12 +327,12 @@ class SCPConnection(object):
         """
         # Prepare the buffer to receive the incoming data
         data = bytearray(length_bytes)
-        self.read_into(data, buffer_size, window_size, x, y, p, address,
-                       length_bytes)
+        self.readinto(data, buffer_size, window_size, x, y, p, address,
+                      length_bytes)
         return bytes(data)
 
-    def read_into(self, data, buffer_size, window_size, x, y, p, address,
-                  length_bytes):
+    def readinto(self, data, buffer_size, window_size, x, y, p, address,
+                 length_bytes):
         """Read a bytestring from an address in memory into a supplied buffer.
 
         ..note::

--- a/rig/machine_control/scp_connection.py
+++ b/rig/machine_control/scp_connection.py
@@ -327,6 +327,39 @@ class SCPConnection(object):
         """
         # Prepare the buffer to receive the incoming data
         data = bytearray(length_bytes)
+        self.read_into(data, buffer_size, window_size, x, y, p, address,
+                       length_bytes)
+        return bytes(data)
+
+    def read_into(self, data, buffer_size, window_size, x, y, p, address,
+                  length_bytes):
+        """Read a bytestring from an address in memory into a supplied buffer.
+
+        ..note::
+            This method is included here to maintain API compatibility with an
+            `alternative implementation of SCP
+            <https://github.com/project-rig/rig-scp>`_.
+
+        Parameters
+        ----------
+        data : bytearray
+            An object into which supports the buffer protocol (e.g. bytearray)
+            into which the data will be read.
+        buffer_size : int
+            Number of bytes held in an SCP buffer by SARK, determines how many
+            bytes will be expected in a socket and how many bytes of data will
+            be read back in each packet.
+        window_size : int
+        x : int
+        y : int
+        p : int
+        address : int
+            The address at which to start reading the data.
+        length_bytes : int
+            The number of bytes to read from memory. Large reads are
+            transparently broken into multiple SCP read commands.
+        """
+        # Prepare the buffer to receive the incoming data
         mem = memoryview(data)
 
         # Create a callback which will write the data from a packet into a
@@ -360,7 +393,6 @@ class SCPConnection(object):
         # Run the event loop and then return the retrieved data
         self.send_scp_burst(buffer_size, window_size,
                             packets(length_bytes, data))
-        return bytes(data)
 
     def write(self, buffer_size, window_size, x, y, p, address, data):
         """Write a bytestring to an address in memory.

--- a/tests/machine_control/test_machine_controller.py
+++ b/tests/machine_control/test_machine_controller.py
@@ -977,6 +977,34 @@ class TestMachineController(object):
                                  x=0, y=0, link=Links.north)
 
     @pytest.mark.parametrize(
+        "buffer_size, window_size, x, y, p, start_address, length, data",
+        [(128, 1, 0, 1, 2, 0x67800000, 100, b"\x00" * 100),
+         (256, 5, 1, 4, 5, 0x67801000, 2, b"\x10\x23"),
+         ]
+    )
+    def test_read_into(self, buffer_size, window_size, x, y, p,
+                       start_address, length, data):
+        # Create the mock controller
+        cn = MachineController("localhost")
+        cn._scp_data_length = buffer_size
+        cn._window_size = window_size
+        cn.connections[None] = mock.Mock(spec_set=SCPConnection)
+
+        def mock_read_into(buffer, *args, **kwargs):
+            buffer[:] = data
+        cn.connections[None].read_into.side_effect = mock_read_into
+
+        # Perform the read and ensure that values are passed on as appropriate
+        with cn(x=x, y=y, p=p):
+            read_data = bytearray(length)
+            cn.read_into(start_address, read_data, length)
+            assert data == read_data
+
+        assert len(cn.connections[None].read_into.mock_calls) == 1
+        assert cn.connections[None].read_into.mock_calls[0][1][1:] == \
+            (buffer_size, window_size, x, y, p, start_address, length)
+
+    @pytest.mark.parametrize(
         "iptag, addr, port",
         [(1, "localhost", 54321),
          (3, "127.0.0.1", 65432),
@@ -2562,15 +2590,17 @@ class TestMemoryIO(object):
         calls = []
         offset = 0
         for n_bytes in lengths:
-            sdram_file.read(n_bytes)
+            buf = bytearray(n_bytes)
+            sdram_file.read_into(buf, n_bytes)
             assert sdram_file.tell() == offset + n_bytes
             assert sdram_file.address == start_address + offset + n_bytes
-            calls.append(mock.call(start_address + offset, n_bytes, x, y, 0))
+            calls.append(mock.call(start_address + offset,
+                                   buf, n_bytes, x, y, 0))
             offset = offset + n_bytes
 
         # Check the reads caused the appropriate calls to the machine
         # controller.
-        mock_controller.read.assert_has_calls(calls)
+        mock_controller.read_into.assert_has_calls(calls)
 
     @pytest.mark.parametrize("x, y", [(1, 3), (3, 0)])
     @pytest.mark.parametrize("start_address, length, offset",
@@ -2583,17 +2613,21 @@ class TestMemoryIO(object):
         # Assert that reading with no parameter reads the full number of bytes
         sdram_file.seek(offset)
         sdram_file.read()
-        mock_controller.read.assert_called_once_with(
-            start_address + offset, length - offset, x, y, 0)
+        assert mock_controller.read_into.call_count == 1
+        args = mock_controller.read_into.call_args[0]
+        assert args[0] == start_address + offset
+        assert args[2] == length - offset
+        assert args[3] == x
+        assert args[4] == y
+        assert args[5] == 0
 
     def test_read_beyond(self, mock_controller):
         sdram_file = MemoryIO(mock_controller, 0, 0,
                               start_address=0, end_address=10)
-        sdram_file.read(100)
-        mock_controller.read.assert_called_with(0, 10, 0, 0, 0)
+        assert len(sdram_file.read(100)) == 10
 
         assert sdram_file.read(1) == b''
-        assert mock_controller.read.call_count == 1
+        assert mock_controller.read_into.call_count == 1
 
     @pytest.mark.parametrize("x, y", [(4, 2), (255, 1)])
     @pytest.mark.parametrize("start_address", [0x60000004, 0x61000003])
@@ -2811,6 +2845,7 @@ class TestMemoryIO(object):
         "flush_event",
         [lambda filelike: filelike.flush(),
          lambda filelike: filelike.read(1),
+         lambda filelike: filelike.read_into(bytearray(1), 1),
          lambda filelike: filelike.close()]
     )
     def test_coalescing_writes(self, get_node, flush_event):

--- a/tests/machine_control/test_machine_controller.py
+++ b/tests/machine_control/test_machine_controller.py
@@ -982,26 +982,26 @@ class TestMachineController(object):
          (256, 5, 1, 4, 5, 0x67801000, 2, b"\x10\x23"),
          ]
     )
-    def test_read_into(self, buffer_size, window_size, x, y, p,
-                       start_address, length, data):
+    def test_readinto(self, buffer_size, window_size, x, y, p,
+                      start_address, length, data):
         # Create the mock controller
         cn = MachineController("localhost")
         cn._scp_data_length = buffer_size
         cn._window_size = window_size
         cn.connections[None] = mock.Mock(spec_set=SCPConnection)
 
-        def mock_read_into(buffer, *args, **kwargs):
+        def mock_readinto(buffer, *args, **kwargs):
             buffer[:] = data
-        cn.connections[None].read_into.side_effect = mock_read_into
+        cn.connections[None].readinto.side_effect = mock_readinto
 
         # Perform the read and ensure that values are passed on as appropriate
         with cn(x=x, y=y, p=p):
             read_data = bytearray(length)
-            cn.read_into(start_address, read_data, length)
+            cn.readinto(start_address, read_data, length)
             assert data == read_data
 
-        assert len(cn.connections[None].read_into.mock_calls) == 1
-        assert cn.connections[None].read_into.mock_calls[0][1][1:] == \
+        assert len(cn.connections[None].readinto.mock_calls) == 1
+        assert cn.connections[None].readinto.mock_calls[0][1][1:] == \
             (buffer_size, window_size, x, y, p, start_address, length)
 
     @pytest.mark.parametrize(
@@ -2591,7 +2591,7 @@ class TestMemoryIO(object):
         offset = 0
         for n_bytes in lengths:
             buf = bytearray(n_bytes)
-            sdram_file.read_into(buf, n_bytes)
+            sdram_file.readinto(buf, n_bytes)
             assert sdram_file.tell() == offset + n_bytes
             assert sdram_file.address == start_address + offset + n_bytes
             calls.append(mock.call(start_address + offset,
@@ -2600,7 +2600,7 @@ class TestMemoryIO(object):
 
         # Check the reads caused the appropriate calls to the machine
         # controller.
-        mock_controller.read_into.assert_has_calls(calls)
+        mock_controller.readinto.assert_has_calls(calls)
 
     @pytest.mark.parametrize("x, y", [(1, 3), (3, 0)])
     @pytest.mark.parametrize("start_address, length, offset",
@@ -2613,8 +2613,8 @@ class TestMemoryIO(object):
         # Assert that reading with no parameter reads the full number of bytes
         sdram_file.seek(offset)
         sdram_file.read()
-        assert mock_controller.read_into.call_count == 1
-        args = mock_controller.read_into.call_args[0]
+        assert mock_controller.readinto.call_count == 1
+        args = mock_controller.readinto.call_args[0]
         assert args[0] == start_address + offset
         assert args[2] == length - offset
         assert args[3] == x
@@ -2627,7 +2627,7 @@ class TestMemoryIO(object):
         assert len(sdram_file.read(100)) == 10
 
         assert sdram_file.read(1) == b''
-        assert mock_controller.read_into.call_count == 1
+        assert mock_controller.readinto.call_count == 1
 
     @pytest.mark.parametrize("x, y", [(4, 2), (255, 1)])
     @pytest.mark.parametrize("start_address", [0x60000004, 0x61000003])
@@ -2845,7 +2845,7 @@ class TestMemoryIO(object):
         "flush_event",
         [lambda filelike: filelike.flush(),
          lambda filelike: filelike.read(1),
-         lambda filelike: filelike.read_into(bytearray(1), 1),
+         lambda filelike: filelike.readinto(bytearray(1), 1),
          lambda filelike: filelike.close()]
     )
     def test_coalescing_writes(self, get_node, flush_event):

--- a/tests/machine_control/test_scp_connection.py
+++ b/tests/machine_control/test_scp_connection.py
@@ -446,6 +446,7 @@ class TestBursts(object):
             mock_conn.send_scp_burst(512, 8, packets)
 
 
+@pytest.mark.parametrize("read_into", [True, False])
 @pytest.mark.parametrize(
     "buffer_size, window_size, x, y, p", [(128, 1, 0, 0, 1), (256, 5, 1, 2, 3)]
 )
@@ -469,7 +470,7 @@ class TestBursts(object):
      (256, DataType.word, 0x60000004)
      ])
 def test_read(buffer_size, window_size, x, y, p, n_bytes,
-              data_type, start_address):
+              data_type, start_address, read_into):
     mock_conn = SCPConnection("localhost")
 
     # Construct the expected calls, and hence the expected return packets
@@ -510,8 +511,13 @@ def test_read(buffer_size, window_size, x, y, p, n_bytes,
         send_scp_burst.side_effect = ccs
 
         # Read an amount of memory specified by the size.
-        data = mock_conn.read(buffer_size, window_size, x, y, p,
-                              start_address, n_bytes)
+        if read_into:
+            data = bytearray(n_bytes)
+            mock_conn.read_into(data, buffer_size, window_size, x, y, p,
+                                start_address, n_bytes)
+        else:
+            data = mock_conn.read(buffer_size, window_size, x, y, p,
+                                  start_address, n_bytes)
         assert data == ccs.read_data
 
     # send_burst_scp should have been called once, each element in the iterator

--- a/tests/machine_control/test_scp_connection.py
+++ b/tests/machine_control/test_scp_connection.py
@@ -446,7 +446,7 @@ class TestBursts(object):
             mock_conn.send_scp_burst(512, 8, packets)
 
 
-@pytest.mark.parametrize("read_into", [True, False])
+@pytest.mark.parametrize("readinto", [True, False])
 @pytest.mark.parametrize(
     "buffer_size, window_size, x, y, p", [(128, 1, 0, 0, 1), (256, 5, 1, 2, 3)]
 )
@@ -470,7 +470,7 @@ class TestBursts(object):
      (256, DataType.word, 0x60000004)
      ])
 def test_read(buffer_size, window_size, x, y, p, n_bytes,
-              data_type, start_address, read_into):
+              data_type, start_address, readinto):
     mock_conn = SCPConnection("localhost")
 
     # Construct the expected calls, and hence the expected return packets
@@ -511,10 +511,10 @@ def test_read(buffer_size, window_size, x, y, p, n_bytes,
         send_scp_burst.side_effect = ccs
 
         # Read an amount of memory specified by the size.
-        if read_into:
+        if readinto:
             data = bytearray(n_bytes)
-            mock_conn.read_into(data, buffer_size, window_size, x, y, p,
-                                start_address, n_bytes)
+            mock_conn.readinto(data, buffer_size, window_size, x, y, p,
+                               start_address, n_bytes)
         else:
             data = mock_conn.read(buffer_size, window_size, x, y, p,
                                   start_address, n_bytes)


### PR DESCRIPTION
A rebase of @mossblaser's #177 

When finished, this PR fixes #142. This is a branch off the fault-tollerant-rig-ps branch and is intended for merging after #176.

* [x] Facilities will be added to discover (and use) multiple Ethernet connections
* [x] A set of read_into() methods will need to be added to allow creation of the
   read buffer in advance.
* [ ] The begin_burst function will simply set a flag.
* [ ] For each connection there will be a queue of read/write requests.
* [ ] All read/write requests should be wrapped in a lambda(?) and placed in the
   buffer. For conventional reads, a buffer should be created and then
   read_into called with that buffer.
* [ ] When not in a burst, the buffer will be emptied immediately (or a fast path
   used...).
* [ ] The end_burst function will spawn some threads and in each thread work on
   processing the queues.