### PR TITLE
Make geometry functions return ints, not Numpy look-alikes

### DIFF
--- a/rig/geometry.py
+++ b/rig/geometry.py
@@ -268,7 +268,7 @@ def spinn5_local_eth_coord(x, y, w, h):
         Height of the system in chips.
     """
     dx, dy = SPINN5_ETH_OFFSET[y % 12][x % 12]
-    return ((x + dx) % w), ((y + dy) % h)
+    return ((x + int(dx)) % w), ((y + int(dy)) % h)
 
 
 SPINN5_ETH_OFFSET = np.array([
@@ -317,7 +317,7 @@ def spinn5_chip_coord(x, y):
     y : int
     """
     dx, dy = SPINN5_ETH_OFFSET[y % 12][x % 12]
-    return (-dx, -dy)
+    return (-int(dx), -int(dy))
 
 
 def spinn5_fpga_link(x, y, link):

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -409,6 +409,11 @@ def test_spinn5_local_eth_coord():
     assert spinn5_local_eth_coord(1, 0, 2, 2) == (0, 0)
     assert spinn5_local_eth_coord(1, 1, 2, 2) == (0, 0)
 
+    # Types are normal Python integers
+    x, y = spinn5_local_eth_coord(1, 1, 12, 12)
+    assert isinstance(x, int)
+    assert isinstance(y, int)
+
 
 @pytest.mark.parametrize("dx", [0, 12, 24, 36])
 @pytest.mark.parametrize("dy", [0, 12, 24, 36])
@@ -431,6 +436,11 @@ def test_spinn5_chip_coord(dx, dy):
     assert spinn5_chip_coord(4 + dx, 8 + dy) == (0, 0)
     assert spinn5_chip_coord(3 + dx, 7 + dy) == (7, 3)
     assert spinn5_chip_coord(0 + dx, 4 + dy) == (4, 0)
+
+    # Types are normal Python integers
+    x, y = spinn5_chip_coord(3, 7)
+    assert isinstance(x, int)
+    assert isinstance(y, int)
 
 
 def test_spinn5_fpga_link():


### PR DESCRIPTION
This was causing bugs in other software (spalloc_server) which attempts to
serialise output from these functions as JSON. Regardless, this unintended and
non-obvious bit of behaviour is now resolved.