### PR TITLE
Make a_star return Routes, not Links.

### DIFF
--- a/rig/place_and_route/route/ner.py
+++ b/rig/place_and_route/route/ner.py
@@ -232,7 +232,7 @@ def a_star(sink, heuristic_source, sources, machine, wrap_around):
 
     Returns
     -------
-    [(:py:class:`~rig.links.Links`, (x, y)), ...]
+    [(:py:class:`~rig.routing_table.Routes`, (x, y)), ...]
         A path starting with a coordinate in `sources` and terminating at
         connected neighbour of `sink` (i.e. the path does not include `sink`).
         The direction given is the link down which to proceed from the given
@@ -302,10 +302,10 @@ def a_star(sink, heuristic_source, sources, machine, wrap_around):
 
     # Reconstruct the discovered path, starting from the source we found and
     # working back until the sink.
-    path = [(visited[selected_source][0], selected_source)]
+    path = [(Routes(visited[selected_source][0]), selected_source)]
     while visited[path[-1][1]][1] != sink:
         node = visited[path[-1][1]][1]
-        direction = visited[node][0]
+        direction = Routes(visited[node][0])
         path.append((direction, node))
 
     return path

--- a/tests/place_and_route/route/test_ner.py
+++ b/tests/place_and_route/route/test_ner.py
@@ -357,6 +357,9 @@ def test_a_star():
                 path = a_star(sink, heuristic_source, sources,
                               machine, wrap_around)
 
+                # Should be returning Routes, not Links
+                assert all(isinstance(d, Routes) for d, n in path)
+
                 # Path should start at one of the sources
                 assert path[0][1] in sources
 
@@ -396,8 +399,11 @@ def test_a_star_impossible():
 
     # Ensure, conversely, we can get a route from (1, 0) to (0, 0) thus showing
     # we're obeying link liveness in the correct direction.
-    assert a_star((0, 0), (1, 0), set([(1, 0)]), machine, True) \
-        == [(Links.west, (1, 0))]
+    path = a_star((0, 0), (1, 0), set([(1, 0)]), machine, True)
+    assert path == [(Routes.west, (1, 0))]
+
+    # Should be returning Routes, not Links
+    assert all(isinstance(d, Routes) for d, n in path)
 
 
 def test_avoid_dead_links_no_change():


### PR DESCRIPTION
Previously, use of A* would result in routing trees with some routes described
with Links objects, not Routes. For most of human history this didn't cause
anything to blow-up but with newer more sophisticated routing table generation
everything blows up. Whoops.