### PR TITLE
Add free commands

### DIFF
--- a/rig/machine_control/machine_controller.py
+++ b/rig/machine_control/machine_controller.py
@@ -1021,6 +1021,10 @@ class MachineController(ContextMixin):
         int
             Address of the start of the region.
 
+            The allocated SDRAM remains valid until either the 'stop' signal is
+            sent to the application ID associated with the allocation or
+            :py:meth:`.sdram_free` is called on the address returned.
+
         Raises
         ------
         rig.machine_control.machine_controller.SpiNNakerMemoryError
@@ -1102,6 +1106,26 @@ class MachineController(ContextMixin):
 
         return MemoryIO(self, x, y, start_address, start_address + size,
                         buffer_size=buffer_size)
+
+    @ContextMixin.use_contextual_arguments()
+    def sdram_free(self, ptr, x=Required, y=Required):
+        """Free an allocated block of memory in SDRAM.
+
+        .. note::
+
+            All unfreed SDRAM allocations associated with an application are
+            automatically freed when the 'stop' signal is sent (e.g. after
+            leaving a :py:meth:`.application` block). As such, this method is
+            only useful when specific blocks are to be freed while retaining
+            others.
+
+        Parameters
+        ----------
+        ptr : int
+            Address of the block of memory to free.
+        """
+        self._send_scp(x, y, 0, SCPCommands.alloc_free,
+                       consts.AllocOperations.free_sdram_by_ptr, ptr)
 
     def _get_next_nn_id(self):
         """Get the next nearest neighbour ID."""

--- a/rig/machine_control/machine_controller.py
+++ b/rig/machine_control/machine_controller.py
@@ -1053,18 +1053,10 @@ class MachineController(ContextMixin):
 
     @ContextMixin.use_contextual_arguments()
     def sdram_alloc_as_filelike(self, size, tag=0, x=Required, y=Required,
-                                app_id=Required, buffer_size=0, clear=False):
+                                app_id=Required, clear=False):
         """Like :py:meth:`.sdram_alloc` but returns a :py:class:`file-like
         object <.MemoryIO>` which allows safe reading and writing to the block
         that is allocated.
-
-        Other Parameters
-        ----------------
-        buffer_size : int
-            The number of bytes to store in the write buffer for the file-like.
-            If this is set to anything but `0` (the default) then
-            :py:meth:`~.MemoryIO.flush` should be called to ensure that all
-            writes are completed.
 
         Returns
         -------
@@ -1103,9 +1095,7 @@ class MachineController(ContextMixin):
         """
         # Perform the malloc
         start_address = self.sdram_alloc(size, tag, x, y, app_id, clear)
-
-        return MemoryIO(self, x, y, start_address, start_address + size,
-                        buffer_size=buffer_size)
+        return MemoryIO(self, x, y, start_address, start_address + size)
 
     @ContextMixin.use_contextual_arguments()
     def sdram_free(self, ptr, x=Required, y=Required):
@@ -2402,8 +2392,7 @@ class MemoryIO(object):
         b"Howdy, world"
     """
 
-    def __init__(self, machine_controller, x, y, start_address, end_address,
-                 buffer_size=0, _write_buffer=None):
+    def __init__(self, machine_controller, x, y, start_address, end_address):
         """Create a file-like view onto a subset of the memory-space of a chip.
 
         Parameters
@@ -2419,10 +2408,6 @@ class MemoryIO(object):
             Starting address in memory.
         end_address : int
             End address in memory.
-        buffer_size : int
-            Number of bytes to store in the write buffer.
-        _write_buffer : :py:class:`._WriteBufferChild`
-            Internal use only, the write buffer to use to combine writes.
 
         If `start_address` is greater or equal to `end_address` then
         `end_address` is ignored and `start_address` is used instead.
@@ -2433,23 +2418,12 @@ class MemoryIO(object):
         self._y = y
         self._machine_controller = machine_controller
 
-        # Get, or create, a write buffer
-        if _write_buffer is None:
-            _write_buffer = _WriteBuffer(x, y, 0, machine_controller,
-                                         buffer_size)
-        self._write_buffer = _write_buffer
-
         # Store and clip the addresses
         self._start_address = start_address
         self._end_address = max(start_address, end_address)
 
         # Current offset from start address
         self._offset = 0
-
-    @property
-    def buffer_size(self):
-        """Return the number of bytes in the write buffer."""
-        return self._write_buffer.buffer_size
 
     def close(self):
         """Flush and close the file-like."""
@@ -2500,8 +2474,7 @@ class MemoryIO(object):
             # Construct the new file-like
             return type(self)(
                 self._machine_controller, self._x, self._y,
-                start_address, end_address,
-                _write_buffer=self._write_buffer
+                start_address, end_address
             )
         else:
             raise ValueError("Can only make contiguous slices of MemoryIO")
@@ -2536,9 +2509,6 @@ class MemoryIO(object):
         :py:class:`bytes`
             Data read from SpiNNaker as a bytestring.
         """
-        # Flush this write buffer
-        self.flush()
-
         # If n_bytes is negative then calculate it as the number of bytes left
         if n_bytes < 0:
             n_bytes = self._end_address - self.address
@@ -2588,7 +2558,8 @@ class MemoryIO(object):
             bytes = bytes[:n_bytes]
 
         # Perform the write and increment the offset
-        self._write_buffer.add_new_write(self.address, bytes)
+        self._machine_controller.write(self.address, bytes,
+                                       self._x, self._y, 0)
         self._offset += len(bytes)
         return len(bytes)
 
@@ -2599,7 +2570,7 @@ class MemoryIO(object):
         This must be called to ensure that all writes to SpiNNaker made using
         this file-like object (and its siblings, if any) are completed.
         """
-        self._write_buffer.flush()
+        pass
 
     @_if_not_closed
     def tell(self):
@@ -2650,87 +2621,6 @@ class MemoryIO(object):
                 "from_what: can only take values 0 (from start), "
                 "1 (from current) or 2 (from end) not {}".format(from_what)
             )
-
-
-class _WriteBuffer(object):
-    """Write buffer used by :py:class:`.MemoryIO` to combine multiple writes
-    together.
-    """
-
-    def __init__(self, x, y, p, controller, buffer_size=0):
-        self.x = x
-        self.y = y
-        self.p = p
-        self.controller = controller
-
-        # A buffer of writes
-        self.buffer = bytearray(buffer_size)
-        self.start_address = None
-
-        self.current_end = 0
-        self.buffer_size = buffer_size
-
-    def add_new_write(self, start_address, data):
-        """Add a new write to the buffer."""
-        if len(data) > self.buffer_size:
-            # Perform the write if we couldn't buffer it at all
-            self.flush()  # Flush to ensure ordering is preserved
-            self.controller.write(start_address, data,
-                                  self.x, self.y, self.p)
-            return
-
-        if self.start_address is None:
-            # No value currently buffered, add this one
-            self.start_address = start_address
-
-        # If we can fit this write into the buffer then include it,
-        # otherwise we flush the current buffer and start again
-        start_offset = start_address - self.start_address
-        end_offset = start_offset + len(data)  # Byte AFTER the end of the data
-
-        if start_offset < 0:
-            # The write starts from before this buffer, so we flush and add a
-            # new write
-            self.flush()
-            self.add_new_write(start_address, data)
-        elif (start_offset <= self.current_end and
-                end_offset <= self.buffer_size):
-            # The write is entirely contained within the buffer and starts
-            # within the area of the buffer which already contains data, so we
-            # can just modify the buffer.
-            self.buffer[start_offset:end_offset] = data
-            self.current_end = max(end_offset, self.current_end)
-        else:
-            # The write either starts outside the used area of the buffer, or
-            # would overflow the buffer.
-            if (start_offset < self.buffer_size and
-                    start_offset <= self.current_end):
-                # We would overflow the buffer, so store as much into the
-                # buffer as possible.
-                end = self.buffer_size - start_offset
-                self.buffer[start_offset:] = data[:end]
-                self.current_end = self.buffer_size
-
-                # Then prepare the next block of data for buffering
-                start_address += end
-                data = data[end:]
-
-            # Flush the buffer before storing the next write
-            self.flush()
-            self.add_new_write(start_address, data)
-
-    def flush(self):
-        """Write the current buffer out."""
-        if self.start_address is not None:
-            # Write out all the values from the buffer
-            self.controller.write(
-                self.start_address, self.buffer[:self.current_end],
-                self.x, self.y, self.p
-            )
-
-            # Reset the buffer
-            self.start_address = None
-            self.current_end = 0
 
 
 def unpack_routing_table_entry(packed):

--- a/rig/machine_control/utils.py
+++ b/rig/machine_control/utils.py
@@ -4,9 +4,8 @@ from rig.place_and_route import Cores, SDRAM
 
 
 def sdram_alloc_for_vertices(controller, placements, allocations,
-                             core_as_tag=True, buffer_size=0,
-                             sdram_resource=SDRAM, cores_resource=Cores,
-                             clear=False):
+                             core_as_tag=True, sdram_resource=SDRAM,
+                             cores_resource=Cores, clear=False):
     """Allocate and return a file-like view of a region of SDRAM for each
     vertex which uses SDRAM as a resource.
 
@@ -53,9 +52,6 @@ def sdram_alloc_for_vertices(controller, placements, allocations,
     core_as_tag : bool
         Use the index of the first allocated core as the tag for the region of
         memory, otherwise 0 will be used.
-    buffer_size : int
-        Size of write buffer (in bytes) to allocate to _each_ file-like object
-        created by this method.
     sdram_resource : resource (default :py:class:`~rig.place_and_route.SDRAM`)
         Key used to indicate SDRAM usage in the resources dictionary.
     cores_resource : resource (default :py:class:`~rig.place_and_route.Cores`)
@@ -92,7 +88,7 @@ def sdram_alloc_for_vertices(controller, placements, allocations,
 
             # Get the memory
             vertex_memory[vertex] = controller.sdram_alloc_as_filelike(
-                size, tag, x=x, y=y, buffer_size=buffer_size, clear=clear
+                size, tag, x=x, y=y, clear=clear
             )
 
     return vertex_memory

--- a/tests/machine_control/test_machine_control_utils.py
+++ b/tests/machine_control/test_machine_control_utils.py
@@ -8,9 +8,8 @@ from rig.place_and_route import Cores, SDRAM
 
 
 @pytest.mark.parametrize("core_as_tag", [True, False])
-@pytest.mark.parametrize("buffer_size", [None, 400])
 @pytest.mark.parametrize("clear", [True, False])
-def test_sdram_alloc_for_vertices(core_as_tag, buffer_size, clear):
+def test_sdram_alloc_for_vertices(core_as_tag, clear):
     """Test allocing and getting a map of vertices to file-like objects
     when multiple blocks of memory are requested.
     """
@@ -44,12 +43,9 @@ def test_sdram_alloc_for_vertices(core_as_tag, buffer_size, clear):
 
     # Perform the SDRAM allocation
     with cn(app_id=33):
-        kwargs = dict(core_as_tag=core_as_tag, clear=clear)
-        if buffer_size is not None:
-            kwargs["buffer_size"] = buffer_size
-
         allocs = sdram_alloc_for_vertices(cn, placements, allocations,
-                                          **kwargs)
+                                          core_as_tag=core_as_tag,
+                                          clear=clear)
 
     # Ensure the correct calls were made to sdram_alloc
     cn.sdram_alloc.assert_has_calls([
@@ -67,7 +63,6 @@ def test_sdram_alloc_for_vertices(core_as_tag, buffer_size, clear):
     if core_as_tag:
         assert allocs[vertices[0]]._start_address == 0x67800000
         assert allocs[vertices[0]]._end_address == 0x67800000 + 400
-    assert allocs[vertices[0]].buffer_size == 0 or buffer_size
 
     assert isinstance(allocs[vertices[1]], MemoryIO)
     assert allocs[vertices[1]]._x == 0
@@ -76,7 +71,6 @@ def test_sdram_alloc_for_vertices(core_as_tag, buffer_size, clear):
     if core_as_tag:
         assert allocs[vertices[1]]._start_address == 0x60000000
         assert allocs[vertices[1]]._end_address == 0x60000000 + 200
-    assert allocs[vertices[1]].buffer_size == 0 or buffer_size
 
     assert isinstance(allocs[vertices[2]], MemoryIO)
     assert allocs[vertices[2]]._x == 1
@@ -85,4 +79,3 @@ def test_sdram_alloc_for_vertices(core_as_tag, buffer_size, clear):
     if core_as_tag:
         assert allocs[vertices[2]]._start_address == 0x67800000
         assert allocs[vertices[2]]._end_address == 0x67800000 + 100
-    assert allocs[vertices[2]].buffer_size == 0 or buffer_size


### PR DESCRIPTION
 - [x] Free SDRAM by pointer
 - [x] Free file-like views of SDRAM
 - [x] ~~Free routing table entries~~ we can already remove all routing table entries associated with an app_id (see `MachineController:clear_routing_table_entries`).

Beat you to the punch @neworderofjamie.