### PR TITLE
Switch to codecov for coverage checking.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 install:
         - python setup.py install
         - pip install -r requirements-test.txt
-        - pip install python-coveralls
+        - pip install codecov
         - pip install spinnaker_proxy
 before_script:
         - spinnaker_proxy.py -qct cspc276.cs.man.ac.uk &
@@ -31,7 +31,7 @@ script:
         # Code quality check
         - flake8 rig tests
 after_success:
-        - coveralls
+        - codecov
 after_script:
         - kill $SPINNAKER_PROXY_PID
         - sleep 0.5

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -203,7 +203,7 @@ We use [TravisCI](https://travis-ci.org/project-rig/rig) to automatically run
 the whole Rig test test suite against a live SpiNN-5 board on any code pushed
 to the Rig GitHub repository.
 
-[Coveralls](https://coveralls.io/r/project-rig/rig) automatically checks that
+[Codecov](https://codecov.io/github/project-rig/rig) automatically checks that
 the test-coverage of tests executed by TravisCI does not drop below 100%.
 
 ### Test suite novelties

--- a/README.rst
+++ b/README.rst
@@ -13,9 +13,9 @@ Rig
 .. image:: https://travis-ci.org/project-rig/rig.svg?branch=master
    :alt: Build Status
    :target: https://travis-ci.org/project-rig/rig
-.. image:: https://coveralls.io/repos/project-rig/rig/badge.svg?branch=master
+.. image:: https://img.shields.io/codecov/c/github/project-rig/rig/master.svg
    :alt: Coverage Status
-   :target: https://coveralls.io/r/project-rig/rig?branch=master
+   :target: https://codecov.io/github/project-rig/rig
 
 Rig is a Python library which contains a collection of complementary tools for
 developing applications for the massively-parallel

--- a/tests/place_and_route/test_wrapper.py
+++ b/tests/place_and_route/test_wrapper.py
@@ -13,7 +13,7 @@ from rig.machine_control.machine_controller import SystemInfo, ChipInfo
 from rig.machine_control import consts
 
 
-class Vertex(object):
+class Vertex(object):  # pragma: no cover
     """A generic object which is used as the vertex type in these tests.
 
     Explicitly meets the requirements of a vertex object according to the


### PR DESCRIPTION
Previously used coveralls which has been increasingly unreliable.

OK, so I think this change is 100% positive:

* Codecov, like coveralls, is free for open source projects.
* Though it also mistakenly reports coverage on omitted files, it is trivial to inform the webpage that a file should be omitted.
* It actually understands branch coverage(!)
* It actually understands the distinction between branch and PR builds.
* It actually understands that travis runs multiple builds of each branch/PR
* It actually discovers, without hints, where the source files are (even though the coverage file reports them as being somewhere funny)
* Generally much nicer web UI
* Much better documentation