### PR TITLE
Memory io improvements

### DIFF
--- a/docs/source/control.rst
+++ b/docs/source/control.rst
@@ -21,7 +21,7 @@ introductory tutorials:
     :inherited-members:
 
 .. automodule:: rig.machine_control.machine_controller
-    :members: SystemInfo, ChipInfo, CoreInfo, ProcessorStatus, IPTag, RouterDiagnostics, SpiNNakerBootError, SpiNNakerMemoryError, SpiNNakerRouterError, SpiNNakerLoadingError
+    :members: SystemInfo, ChipInfo, CoreInfo, ProcessorStatus, IPTag, RouterDiagnostics, SpiNNakerBootError, SpiNNakerMemoryError, SpiNNakerRouterError, SpiNNakerLoadingError, TruncationWarning
     :special-members:
 
 .. automodule:: rig.machine_control.utils

--- a/docs/source/control.rst
+++ b/docs/source/control.rst
@@ -17,8 +17,11 @@ introductory tutorials:
     :members:
     :special-members:
 
+.. autoclass:: rig.machine_control.machine_controller.MemoryIO
+    :inherited-members:
+
 .. automodule:: rig.machine_control.machine_controller
-    :members: SystemInfo, ChipInfo, CoreInfo, ProcessorStatus, IPTag, MemoryIO, RouterDiagnostics, SpiNNakerBootError, SpiNNakerMemoryError, SpiNNakerRouterError, SpiNNakerLoadingError
+    :members: SystemInfo, ChipInfo, CoreInfo, ProcessorStatus, IPTag, RouterDiagnostics, SpiNNakerBootError, SpiNNakerMemoryError, SpiNNakerRouterError, SpiNNakerLoadingError
     :special-members:
 
 .. automodule:: rig.machine_control.utils

--- a/rig/machine_control/machine_controller.py
+++ b/rig/machine_control/machine_controller.py
@@ -2584,10 +2584,9 @@ class SlicedMemoryIO(object):
         if self.address + len(bytes) > self._end_address:
             n_bytes = self._end_address - self.address
 
-            if len(bytes) > n_bytes:
-                warnings.warn("write truncated from {} to {} bytes".format(
-                    len(bytes), n_bytes), TruncationWarning)
-                bytes = bytes[:n_bytes]
+            warnings.warn("write truncated from {} to {} bytes".format(
+                len(bytes), n_bytes), TruncationWarning)
+            bytes = bytes[:n_bytes]
 
         if len(bytes) == 0:
             return 0

--- a/rig/machine_control/machine_controller.py
+++ b/rig/machine_control/machine_controller.py
@@ -2584,13 +2584,13 @@ class SlicedMemoryIO(object):
         if self.address + len(bytes) > self._end_address:
             n_bytes = self._end_address - self.address
 
-            if n_bytes <= 0:
-                return 0
-
             if len(bytes) > n_bytes:
                 warnings.warn("write truncated from {} to {} bytes".format(
                     len(bytes), n_bytes), TruncationWarning)
                 bytes = bytes[:n_bytes]
+
+        if len(bytes) == 0:
+            return 0
 
         # Perform the write and increment the offset
         self._parent._perform_write(self.address, bytes)

--- a/tests/machine_control/test_machine_controller.py
+++ b/tests/machine_control/test_machine_controller.py
@@ -15,7 +15,7 @@ from rig.machine_control.consts import (
 from rig.machine_control.machine_controller import (
     MachineController, SpiNNakerBootError, SpiNNakerMemoryError, MemoryIO,
     SpiNNakerRouterError, SpiNNakerLoadingError, SystemInfo, CoreInfo,
-    ChipInfo, ProcessorStatus, unpack_routing_table_entry,
+    ChipInfo, ProcessorStatus, unpack_routing_table_entry, TruncationWarning
 )
 from rig.machine_control.packets import SCPPacket
 from rig.machine_control.scp_connection import \
@@ -2428,7 +2428,7 @@ class TestMachineController(object):
 
             m = cn.get_machine(1, 2)
 
-            # Should be flagged as deprecated
+            # Should be flagged as truncated
             assert len(w) == 1
             assert issubclass(w[0].category, DeprecationWarning)
 
@@ -2695,11 +2695,21 @@ class TestMemoryIO(object):
     def test_read_beyond(self, mock_controller):
         sdram_file = MemoryIO(mock_controller, 0, 0,
                               start_address=0, end_address=10)
-        sdram_file.read(100)
-        mock_controller.read.assert_called_with(0, 10, 0, 0, 0)
+        # Should be clamped (and a warning produced)
+        sdram_file.seek(1)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            sdram_file.read(10)
+
+            # Should be flagged as truncated
+            assert len(w) == 1
+            assert issubclass(w[0].category, TruncationWarning)
+        mock_controller.read.assert_called_with(1, 9, 0, 0, 0)
+        mock_controller.read.reset_mock()
 
         assert sdram_file.read(1) == b''
-        assert mock_controller.read.call_count == 1
+        assert mock_controller.read.call_count == 0
 
     @pytest.mark.parametrize("x, y", [(4, 2), (255, 1)])
     @pytest.mark.parametrize("start_address", [0x60000004, 0x61000003])
@@ -2732,7 +2742,15 @@ class TestMemoryIO(object):
         sdram_file = MemoryIO(mock_controller, 0, 0,
                               start_address=0, end_address=10)
 
-        assert sdram_file.write(b"\x00\x00" * 12) == 10
+        sdram_file.seek(1)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            assert sdram_file.write(b"\x00\x00" * 12) == 9
+
+            # Should be flagged as deprecated
+            assert len(w) == 1
+            assert issubclass(w[0].category, TruncationWarning)
 
         assert sdram_file.write(b"\x00") == 0
         sdram_file.flush()

--- a/tests/machine_control/test_machine_controller.py
+++ b/tests/machine_control/test_machine_controller.py
@@ -2711,6 +2711,12 @@ class TestMemoryIO(object):
         assert sdram_file.read(1) == b''
         assert mock_controller.read.call_count == 0
 
+    def test_empty_read(self, mock_controller):
+        sdram_file = MemoryIO(mock_controller, 0, 0,
+                              start_address=0, end_address=10)
+        assert sdram_file.read(0) == b""
+        assert mock_controller.read.call_count == 0
+
     @pytest.mark.parametrize("x, y", [(4, 2), (255, 1)])
     @pytest.mark.parametrize("start_address", [0x60000004, 0x61000003])
     @pytest.mark.parametrize("lengths", [[1, 2], [1], [3, 2, 4]])
@@ -2756,6 +2762,12 @@ class TestMemoryIO(object):
         sdram_file.flush()
 
         assert mock_controller.write.call_count == 1
+
+    def test_empty_write(self, mock_controller):
+        sdram_file = MemoryIO(mock_controller, 0, 0,
+                              start_address=0, end_address=10)
+        assert sdram_file.write(b"") == 0
+        assert mock_controller.write.call_count == 0
 
     @pytest.mark.parametrize("use_with", (False, True))
     def test_close(self, mock_controller, use_with):


### PR DESCRIPTION
`MemoryIO` reads/writes which are truncated now produce a warning. These can, if desired, be turned into exceptions by an application.