### PR TITLE
Having a fixed-point format that can't represent a full range of valu…

### DIFF
--- a/rig/type_casts.py
+++ b/rig/type_casts.py
@@ -298,11 +298,8 @@ def validate_fp_params(signed, n_bits, n_frac):
 
     # Check the number of bits is possible
     signed_bit = 1 if signed else 0
-    if signed_bit + n_frac > n_bits or n_frac < 0:
-        raise ValueError(
-            "n_frac: {}: Must be less than {} (and positive).".format(
-                n_frac, n_bits - signed_bit)
-        )
+    if n_frac < 0:
+        raise ValueError("n_frac: {}: Must be positive.".format(n_frac))
 
     # Account for the sign bit
     n_int = n_bits if not signed else n_bits - 1

--- a/rig/type_casts.py
+++ b/rig/type_casts.py
@@ -305,7 +305,7 @@ def validate_fp_params(signed, n_bits, n_frac):
     n_int = n_bits if not signed else n_bits - 1
 
     # Return the min and max values
-    min_v = 0 if not signed else -(1 << (n_int - n_frac))
+    min_v = 0 if not signed else -(2 ** (n_int - n_frac))
     max_v = ((1 << n_int) - 1) / float(1 << n_frac)
 
     return min_v, max_v

--- a/tests/test_type_casts.py
+++ b/tests/test_type_casts.py
@@ -12,8 +12,6 @@ class TestFloatToFix(object):
     """
     @pytest.mark.parametrize(
         "signed, n_bits, n_frac",
-        [(True, 32, 32),  # Too many frac bits
-         (False, 32, 33),
          (False, -1, 3),
          (False, 32, -1),  # Negative
          ])
@@ -23,15 +21,16 @@ class TestFloatToFix(object):
 
     @pytest.mark.parametrize(
         "value, n_bits, n_frac, output",
-        [(0.50, 8, 4, 0x08),
-         (0.50, 8, 5, 0x10),
-         (0.50, 8, 6, 0x20),
-         (0.50, 8, 7, 0x40),
-         (0.50, 8, 8, 0x80),
-         (0.25, 8, 4, 0x04),
-         (0.75, 8, 4, 0x0c),
-         (1.75, 8, 4, 0x1c),
-         (-1.75, 8, 4, 0x00),  # Clipped
+        [(0.50,         8, 4, 0x08),
+         (0.50,         8, 5, 0x10),
+         (0.50,         8, 6, 0x20),
+         (0.50,         8, 7, 0x40),
+         (0.50,         8, 8, 0x80),
+         (0.25,         8, 4, 0x04),
+         (0.75,         8, 4, 0x0c),
+         (1.75,         8, 4, 0x1c),
+         (1.0 / 512.0,  8, 9, 1),
+         (-1.75,        8, 4, 0x00),  # Clipped
          ])
     def test_no_saturate_unsigned(self, value, n_bits, n_frac, output):
         assert float_to_fix(False, n_bits, n_frac)(value) == output

--- a/tests/test_type_casts.py
+++ b/tests/test_type_casts.py
@@ -12,7 +12,7 @@ class TestFloatToFix(object):
     """
     @pytest.mark.parametrize(
         "signed, n_bits, n_frac",
-         (False, -1, 3),
+        [(False, -1, 3),
          (False, 32, -1),  # Negative
          ])
     def test_invalid_parameters(self, signed, n_bits, n_frac):
@@ -78,9 +78,7 @@ class TestFloatToFix(object):
 class TestFixToFloat(object):
     @pytest.mark.parametrize(
         "signed, n_bits, n_frac",
-        [(True, 32, 32),  # Too many frac bits
-         (False, 32, 33),
-         (False, -1, 3),
+        [(False, -1, 3),
          (False, 32, -1),  # Negative
          ])
     def test_invalid_parameters(self, signed, n_bits, n_frac):
@@ -101,9 +99,7 @@ class TestFixToFloat(object):
 class TestNumpyFloatToFixConverter(object):
     @pytest.mark.parametrize(
         "signed, n_bits, n_frac",
-        [(True, 32, 32),  # Too many frac bits
-         (False, 32, 33),
-         (False, 32, -1),
+        [(False, 32, -1),
          (False, -1, 1),
          (False, 31, 30),  # Weird number of bits
          ])


### PR DESCRIPTION
I think it's entirely legitimate to define a fixed point format where the position of the fixed point is not within your representable range small weights 