### PR TITLE
Fix rare non-shortest-paths produced by shortest_torus_path

### DIFF
--- a/rig/geometry.py
+++ b/rig/geometry.py
@@ -141,12 +141,12 @@ def shortest_torus_path(source, destination, width, height):
     # Transform to include a random number of 'spirals' on Z axis where
     # possible.
     if abs(x) >= height:
-        max_spirals = x // height
+        max_spirals = (x + height - 1 if x < 0 else x) // height
         d = random.randint(min(0, max_spirals), max(0, max_spirals)) * height
         x -= d
         z -= d
     elif abs(y) >= width:
-        max_spirals = y // width
+        max_spirals = (y + width - 1 if y < 0 else y) // width
         d = random.randint(min(0, max_spirals), max(0, max_spirals)) * width
         y -= d
         z -= d

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -165,6 +165,7 @@ def test_shortest_mesh_path():
 # A series of hexagonal vectors along with their possibly multiple (torus)
 # minimal counterparts in the specified torus size for testing hexagonal
 # coordinate minimisation-related functions.
+# [((dx, dy, dz), set([(dx, dy, dz), ...]), (width, height)), ...]
 test_torus_vectors = [
     # Non-wrapping, already-minimal examples
     ((0, 0, 0), set([(0, 0, 0)]), (10, 10)),
@@ -249,6 +250,10 @@ test_torus_vectors = [
     # Ambiguous: Direct, wrap X, wrap Y (via "diagonal") or wrap X & Y (via
     # "diagonal")
     ((1, 0, 0), set([(1, 0, 0), (-1, 0, 0), (0, 0, -1), (0, 0, 1)]), (2, 1)),
+
+    # Ambiguous: Many possible wraps
+    ((5, 0, 0), set([(5, 0, 0), (3, 0, -2), (1, 0, -4)]), (20, 2)),
+    ((0, 5, 0), set([(0, 5, 0), (0, 3, -2), (0, 1, -4)]), (2, 20)),
 ]
 
 
@@ -298,8 +303,6 @@ def test_shortest_torus_path():
                     unseen_minimiseds.remove(path)
                 except KeyError:
                     pass
-                if not unseen_minimiseds:
-                    break
             assert unseen_minimiseds == set(), \
                 (start, end, width, height, minimiseds)
 
@@ -311,8 +314,6 @@ def test_shortest_torus_path():
                     unseen_neg_minimiseds.remove(path)
                 except KeyError:
                     pass
-                if not unseen_neg_minimiseds:
-                    break
             assert unseen_neg_minimiseds == set(), \
                 (start, end, width, height, neg_minimiseds)
 


### PR DESCRIPTION
Until this patch, rig.geometry.shortest_torus_path would under uncommon
circumstances generate routes whose length was not minimal. This commit fixes
the bug and fixes the test which failed to detect the bug.

This bug manifests if:

* The network aspect ratio was not 1:1 AND
* (The x-offset between the two nodes was negative and larger than the height
  of the system OR the y-offset between the two nodes was negative and larger
  than the width of the system) AND
* A fair N-sided dice roll turned up N (where N is the x-offset divided by the
  height and rounded down or the y-offset divided by the width and rounded
  down).

The bug is caused by "max_spirals" being computed with a divide-and-floor
operation rather than the intended divide-and-truncate operation.

The bug was not detected by the test suite since the test suite as it stands
stops calling the 'shortest_torus_path' function once it has generated all
expected outputs and does not continue calling it to make sure it doesn't
produce any unexpected values. Additionally none of the test vectors in the
tests considered network topologies sufficiently long or tall for this bug to
manifest.

This commit fixes this bug in the shortest_torus_path and fixes the tests so
that this bug could now be detected.

In addition, an check was conducted to validate that shortest_torus_path finds
the same vectors as a brute force search for a very large number of
combinations of network sizes and source/destination pairs. No mismatches were
found. The script used is reproduced below.

    """A brute-force attempt to verify the correctness of the
    rig.geometry.shortest_torus_path function.
    """

    from rig.geometry import shortest_torus_path, shortest_torus_path_length
    from itertools import permutations

    def brute(src, dst, w, h):
        """Attempt to find all possible shortest path vectors between two points by
        brute force.
        """
        # Work out the maximum length of the vector
        dist = shortest_torus_path_length(src, dst, w, h)

        sx, sy, sz = src
        dx, dy, dz = dst

        vectors = set()

        # Now try all possible vectors of this magnitude. Note that no vector will
        # have more than two of its elements non-zero as per the rules of hexagonal
        # torus topologies.
        for dim_a, dim_b in permutations((0, 1, 2), 2):
            for hops in range(dist+1):
                to_try = [0, 0, 0]
                to_try[dim_a] = hops
                to_try[dim_b] = -(dist - hops)

                x, y, z = to_try

                # Only keep vectors which actually successfully reach the
                # destination...
                if (((sx+x)-(sz+z))%w == (dx-dz)%w and
                    ((sy+y)-(sz+z))%h == (dy-dz)%h):
                    vectors.add((x, y, z))

        return vectors

    # Try lots of possible torus sizes
    for w in (1, 3, 4, 7, 8, 15, 16):
        for h in (1, 3, 4, 7, 8, 15, 16):
            print("Trying machine size:", w, h)
            # Try all possible source/destination pairs
            for sx in range(w):
                for sy in range(h):
                    for dx in range(w):
                        for dy in range(h):
                            src = (sx, sy, 0)
                            dst = (dx, dy, 0)

                            # The rig algorithm will emit one of the available
                            # vectors randomly so we call it many times to ensure
                            # we see all the vectors it can produce...
                            rig_solution = set(shortest_torus_path(src, dst, w, h)
                                               for _ in range(500))

                            brute_solution = brute(src, dst, w, h)

                            # If any vectors are missing/extra, shout!
                            if rig_solution != brute_solution:
                                print("Error:", src, dst, w, h)
                                print(sorted(rig_solution))
                                print(sorted(brute_solution))
                                print()