### PR TITLE
Improve type cast utilities

### DIFF
--- a/rig/type_casts.py
+++ b/rig/type_casts.py
@@ -65,7 +65,7 @@ def float_to_fp(signed, n_bits, n_frac):
             The value to convert.
         """
         int_val = int(scale * value)
-        return np.clip(int_val, min_v, max_v)
+        return max((min(max_v, int_val), min_v))
 
     return bitsk
 


### PR DESCRIPTION
New methods `float_to_fp` and `fp_to_float` work with signed and unsigned values as expected. New methods and `NumpyFloatToFixConverter` can now have negative numbers of fractional bits or more fractional bits than can be represented in the result - as requested by @neworderofjamie.