### PR TITLE
Make get_chip_info forward-compatible.

### DIFF
--- a/rig/machine_control/machine_controller.py
+++ b/rig/machine_control/machine_controller.py
@@ -1816,7 +1816,7 @@ class MachineController(ContextMixin):
         info = self._send_scp(x, y, 0, SCPCommands.info, expected_args=3)
         num_cores = info.arg1 & 0x1F
         core_states = [consts.AppState(c)
-                       for c in struct.unpack("<18B", info.data)]
+                       for c in struct.unpack("<18B", info.data[:18])]
         working_links = set(link for link in Links
                             if (info.arg1 >> (8 + link)) & 1)
         largest_free_rtr_mc_block = (info.arg1 >> 14) & 0x7FF

--- a/rig/machine_control/machine_controller.py
+++ b/rig/machine_control/machine_controller.py
@@ -1816,7 +1816,7 @@ class MachineController(ContextMixin):
         info = self._send_scp(x, y, 0, SCPCommands.info, expected_args=3)
         num_cores = info.arg1 & 0x1F
         core_states = [consts.AppState(c)
-                       for c in struct.unpack("<18B", info.data[:18])]
+                       for c in struct.unpack_from("<18B", info.data)]
         working_links = set(link for link in Links
                             if (info.arg1 >> (8 + link)) & 1)
         largest_free_rtr_mc_block = (info.arg1 >> 14) & 0x7FF

--- a/tests/machine_control/test_machine_controller.py
+++ b/tests/machine_control/test_machine_controller.py
@@ -2357,6 +2357,10 @@ class TestMachineController(object):
 
         data = struct.pack("<18B", *(core_states + ([0] * (18 - num_cores))))
 
+        # Add extra data to the block to simulate possible future additions to
+        # these fields.
+        data += b"FOOBARBAZ"
+
         cn = MachineController("localhost")
         cn._send_scp = mock.Mock()
         cn._send_scp.return_value = mock.Mock(arg1=arg1, arg2=arg2, arg3=arg3,


### PR DESCRIPTION
New releases of SC&MP are anticipated to add new fields to the data payload of
the chip_info command response. This patch fixes makes rig ignore any
additional data (rather than crashing...).