### PR TITLE
Add support for Semantic Version label postfixes.

### DIFF
--- a/rig/machine_control/bmp_controller.py
+++ b/rig/machine_control/bmp_controller.py
@@ -190,7 +190,7 @@ class BMPController(ContextMixin):
         can_id = (sver.arg1 >> 8) & 0xff
         board_id = sver.arg1 & 0xff
 
-        # arg2 (version field unpacked seperately)
+        # arg2 (version field unpacked separately)
         buffer_size = (sver.arg2 & 0xffff)
 
         software_name, version, version_labels = \
@@ -408,7 +408,7 @@ class BMPInfo(collections.namedtuple(
         The position of the board in a frame. (This should correspond exactly
         with a board's board-coordinate.
     version : (major, minor, patch)
-        Software version number. See also: ``software_version_labels``.
+        Software version number. See also: ``version_labels``.
     buffer_size : int
         Maximum supported size (in bytes) of the data portion of an SCP packet.
     build_date : int

--- a/rig/machine_control/bmp_controller.py
+++ b/rig/machine_control/bmp_controller.py
@@ -4,13 +4,14 @@ import time
 import struct
 import collections
 
-from .scp_connection import SCPConnection
+from rig.machine_control.scp_connection import SCPConnection
 
-from . import consts
+from rig.machine_control import consts
 
-from .consts import SCPCommands, LEDAction, BMPInfoType, BMP_V_SCALE_2_5, \
-    BMP_V_SCALE_3_3, BMP_V_SCALE_12, BMP_TEMP_SCALE, BMP_MISSING_TEMP, \
-    BMP_MISSING_FAN
+from rig.machine_control.consts import SCPCommands, LEDAction, BMPInfoType, \
+    BMP_V_SCALE_2_5, BMP_V_SCALE_3_3, BMP_V_SCALE_12, BMP_TEMP_SCALE, \
+    BMP_MISSING_TEMP, BMP_MISSING_FAN
+from rig.machine_control.common import unpack_sver_response_version
 
 from rig.utils.contexts import ContextMixin, Required
 
@@ -189,23 +190,14 @@ class BMPController(ContextMixin):
         can_id = (sver.arg1 >> 8) & 0xff
         board_id = sver.arg1 & 0xff
 
-        # arg2
-        version = (sver.arg2 >> 16)
+        # arg2 (version field unpacked seperately)
         buffer_size = (sver.arg2 & 0xffff)
 
-        # Version string tacked on the end
-        version_string = sver.data.decode("utf-8")
-
-        if version < 0xFFFF:
-            # Old-style version
-            version = (version // 100, version % 100, 0)
-        else:
-            # New-style version number is appended to the version string.
-            version_string, _, version = version_string.partition("\0")
-            version = tuple(map(int, version.strip("\0").split(".")))
+        software_name, version, version_labels = \
+            unpack_sver_response_version(sver)
 
         return BMPInfo(code_block, frame_id, can_id, board_id, version,
-                       buffer_size, sver.arg3, version_string.rstrip("\0"))
+                       buffer_size, sver.arg3, software_name, version_labels)
 
     @ContextMixin.use_contextual_arguments()
     def set_power(self, state, cabinet, frame, board,
@@ -398,7 +390,7 @@ class BMPController(ContextMixin):
 
 class BMPInfo(collections.namedtuple(
     'BMPInfo', "code_block frame_id can_id board_id version buffer_size "
-               "build_date version_string")):
+               "build_date version_string version_labels")):
     """Information returned about a BMP by sver.
 
     Parameters
@@ -416,7 +408,7 @@ class BMPInfo(collections.namedtuple(
         The position of the board in a frame. (This should correspond exactly
         with a board's board-coordinate.
     version : (major, minor, patch)
-        Software version number.
+        Software version number. See also: ``software_version_labels``.
     buffer_size : int
         Maximum supported size (in bytes) of the data portion of an SCP packet.
     build_date : int
@@ -426,6 +418,10 @@ class BMPInfo(collections.namedtuple(
         Human readable, textual version information split in to two fields by a
         "/". In the first field is the kernel (e.g. BC&MP) and the second the
         hardware platform (e.g. Spin5-BMP).
+    version_labels : string
+        Any additional labels or build information associated with the software
+        version. (See also: ``version`` and the `Semantic Versioning
+        <http://semver.org/>`_ specification).
     """
 
 

--- a/rig/machine_control/common.py
+++ b/rig/machine_control/common.py
@@ -1,0 +1,62 @@
+"""Internal-use functions shared between the
+:py:class:`~rig.machine_control.MachineController` and
+:py:class:`~rig.machine_control.BMPController` objects.
+"""
+
+import re
+
+
+VERSION_NUMBER_REGEX = re.compile(r"^(\d+)[.](\d+)[.](\d+)(\D.*)?$")
+"""A regular expression which splits up the key parts of a SemVer-like version
+number. Captures the following groups:
+
+1. The major version.
+2. The minor version.
+3. The patch level.
+4. The pre-release version and any other build metadata.
+"""
+
+
+def unpack_sver_response_version(packet):
+    """For internal use. Unpack the version-related parts of an sver (aka
+    CMD_VERSION) response.
+
+    Parameters
+    ----------
+    packet : :py:class:`~rig.machine_control.packets.SCPPacket`
+        The packet recieved in response to the version command.
+
+    Returns
+    -------
+    software_name : string
+        The name of the software running on the remote machine.
+    (major, minor, patch) : (int, int, int)
+        The numerical part of the semantic version number.
+    labels : string
+        Any labels in the version number (e.g. '-dev'). May be an empty string.
+    """
+    software_name = packet.data.decode("utf-8")
+
+    legacy_version_field = packet.arg2 >> 16
+
+    if legacy_version_field != 0xFFFF:
+        # Legacy version encoding: just encoded in decimal fixed-point in the
+        # integer.
+        major = legacy_version_field // 100
+        minor = legacy_version_field % 100
+        patch = 0
+        labels = ""
+    else:
+        # Semantic Version encoding: packed after the null-terminator of the
+        # software name in the version string.
+        software_name, _, version_number = software_name.partition("\0")
+
+        match = VERSION_NUMBER_REGEX.match(version_number.rstrip("\0"))
+        assert match, "Malformed version number: {}".format(version_number)
+
+        major = int(match.group(1))
+        minor = int(match.group(2))
+        patch = int(match.group(3))
+        labels = match.group(4) or ""
+
+    return (software_name.rstrip("\0"), (major, minor, patch), labels)

--- a/rig/machine_control/machine_controller.py
+++ b/rig/machine_control/machine_controller.py
@@ -15,6 +15,7 @@ from rig.machine_control.consts import \
     SCPCommands, NNCommands, NNConstants, AppFlags, LEDAction
 from rig.machine_control import boot, consts, regions, struct_file
 from rig.machine_control.scp_connection import SCPConnection, SCPError
+from rig.machine_control.common import unpack_sver_response_version
 
 from rig import routing_table
 
@@ -474,23 +475,14 @@ class MachineController(ContextMixin):
         pcpu = (sver.arg1 >> 8) & 0xff
         vcpu = sver.arg1 & 0xff
 
-        # arg2 => version number and buffer size
-        version = (sver.arg2 >> 16)
+        # arg2 => version number (parsed seperately) and buffer size
         buffer_size = (sver.arg2 & 0xffff)
 
-        # Version string tacked on the end
-        version_string = sver.data.decode("utf-8")
-
-        if version < 0xFFFF:
-            # Old-style version
-            version = (version // 100, version % 100, 0)
-        else:
-            # New-style version number is appended to the version string.
-            version_string, _, version = version_string.partition("\0")
-            version = tuple(map(int, version.strip("\0").split(".")))
+        software_name, version, version_labels = \
+            unpack_sver_response_version(sver)
 
         return CoreInfo(p2p_address, pcpu, vcpu, version, buffer_size,
-                        sver.arg3, version_string.rstrip("\0"))
+                        sver.arg3, software_name, version_labels)
 
     @ContextMixin.use_contextual_arguments()
     def get_ip_address(self, x, y):
@@ -1987,7 +1979,7 @@ class MachineController(ContextMixin):
 
 class CoreInfo(collections.namedtuple(
     'CoreInfo', "position physical_cpu virt_cpu software_version buffer_size "
-                "build_date version_string")):
+                "build_date version_string software_version_labels")):
     """Information returned about a core by sver.
 
     Parameters
@@ -2000,7 +1992,8 @@ class CoreInfo(collections.namedtuple(
         The virtual ID of the core. This is the number used by all high-level
         software APIs.
     software_version : (major, minor, patch)
-        Software version number.
+        The numerical components of the software version number. See also:
+        ``software_version_labels``.
     buffer_size : int
         Maximum supported size (in bytes) of the data portion of an SCP packet.
     build_date : int
@@ -2010,6 +2003,10 @@ class CoreInfo(collections.namedtuple(
         Human readable, textual version information split in to two fields by a
         "/". In the first field is the kernal (e.g. SC&MP or SARK) and the
         second the hardware platform (e.g. SpiNNaker).
+    software_version_labels : string
+        Any additional labels or build information associated with the software
+        version. (See also: ``software_version`` and the `Semantic Versioning
+        <http://semver.org/>`_ specification).
     """
 
 

--- a/rig/machine_control/machine_controller.py
+++ b/rig/machine_control/machine_controller.py
@@ -475,7 +475,7 @@ class MachineController(ContextMixin):
         pcpu = (sver.arg1 >> 8) & 0xff
         vcpu = sver.arg1 & 0xff
 
-        # arg2 => version number (parsed seperately) and buffer size
+        # arg2 => version number (parsed separately) and buffer size
         buffer_size = (sver.arg2 & 0xffff)
 
         software_name, version, version_labels = \

--- a/rig/scripts/rig_info.py
+++ b/rig/scripts/rig_info.py
@@ -27,9 +27,10 @@ def get_spinnaker_info(mc):
     yield ""
 
     info = mc.get_software_version(255, 255)
-    yield "Software: {} v{} (Built {})".format(
+    yield "Software: {} v{}{} (Built {})".format(
         info.version_string.split("/")[0],
         ".".join(map(str, info.software_version)),
+        info.software_version_labels,
         datetime.fromtimestamp(info.build_date, tz=utc).strftime(
             '%Y-%m-%d %H:%M:%S'),
     )
@@ -104,9 +105,10 @@ def get_bmp_info(bc):
     yield ""
 
     info = bc.get_software_version()
-    yield "Software: {} v{} (Built {})".format(
+    yield "Software: {} v{}{} (Built {})".format(
         info.version_string.split("/")[0],
         ".".join(map(str, info.version)),
+        info.version_labels,
         datetime.fromtimestamp(info.build_date, tz=utc).strftime(
             '%Y-%m-%d %H:%M:%S'),
     )

--- a/tests/machine_control/test_bmp_controller.py
+++ b/tests/machine_control/test_bmp_controller.py
@@ -23,7 +23,7 @@ def live_controller(bmp_ip):
 def sver_response():
     return BMPInfo(code_block=1, frame_id=2, can_id=3, board_id=4,
                    version=(1, 2, 0), buffer_size=512, build_date=1234,
-                   version_string="Hello, World!")
+                   version_string="Hello, World!", version_labels="")
 
 
 @pytest.fixture(scope="module",

--- a/tests/machine_control/test_machine_control_common.py
+++ b/tests/machine_control/test_machine_control_common.py
@@ -1,0 +1,35 @@
+import pytest
+from mock import Mock
+
+from rig.machine_control.packets import SCPPacket
+
+from rig.machine_control.common import unpack_sver_response_version
+
+
+@pytest.mark.parametrize("new_style", [True, False])
+@pytest.mark.parametrize("labels", ["", "-dev"])
+def test_unpack_sver_response_version(new_style, labels):
+    packet = Mock(spec_set=SCPPacket)
+
+    if new_style:
+        packet.arg2 = 0xFFFF << 16
+        packet.data = "My Software\0001.2.3{}\0".format(labels).encode("ASCII")
+    else:
+        packet.arg2 = 123 << 16
+        packet.data = b"My Software\0"
+
+    software_name, (major, minor, patch), actual_labels = \
+        unpack_sver_response_version(packet)
+
+    assert software_name == "My Software"
+
+    if new_style:
+        assert major == 1
+        assert minor == 2
+        assert patch == 3
+        assert actual_labels == labels
+    else:
+        assert major == 1
+        assert minor == 23
+        assert patch == 0
+        assert actual_labels == ""

--- a/tests/scripts/test_rig_info.py
+++ b/tests/scripts/test_rig_info.py
@@ -59,6 +59,7 @@ def test_spinnaker(monkeypatch, capsys, torus):
     info = mock.Mock(spec_set=CoreInfo)
     info.version_string = "Mock/SpiNNaker"
     info.software_version = (1, 33, 7)
+    info.software_version_labels = "-dev"
     info.build_date = 0
     mc.get_software_version.return_value = info
 
@@ -108,7 +109,7 @@ def test_spinnaker(monkeypatch, capsys, torus):
 
     assert "SpiNNaker" in stdout  # Hardware type
     assert "Mock" in stdout  # Software name
-    assert "v1.33.7" in stdout  # Software version
+    assert "v1.33.7-dev" in stdout  # Software version
     assert "1970" in stdout  # Software builid date
     assert "4x8" in stdout  # System dimensions
     assert "Working chips: 31" in stdout  # Live chip count
@@ -133,6 +134,7 @@ def test_bmp(monkeypatch, capsys, tmp_ext_0, tmp_ext_1, fan_0, fan_1):
     info = mock.Mock()
     info.version_string = "Mock/BMP"
     info.version = (1, 33, 7)
+    info.version_labels = "-dev"
     info.build_date = 0
     info.code_block = 7331
     info.board_id = 1234
@@ -164,7 +166,7 @@ def test_bmp(monkeypatch, capsys, tmp_ext_0, tmp_ext_1, fan_0, fan_1):
 
     assert "BMP" in stdout  # Hardware type
     assert "Mock" in stdout  # Software name
-    assert "v1.33.7" in stdout  # Software version
+    assert "v1.33.7-dev" in stdout  # Software version
     assert "1970" in stdout  # Software builid date
     assert "7331" in stdout  # Code block used
     assert "1234" in stdout  # Slot number


### PR DESCRIPTION
Adds a new field to the CoreInfo and BMPInfo namedtuples which contains any
version postfixes (e.g. -dev or build numbers).

Also refactors version-number parsing so that the implementation is shared
between BMPController and MachineController.