### PR TITLE
Skip alias check during default-route removal if possible.

### DIFF
--- a/rig/routing_table/remove_default_routes.py
+++ b/rig/routing_table/remove_default_routes.py
@@ -2,7 +2,7 @@ from rig.routing_table import MinimisationFailedError
 from rig.routing_table.utils import intersect
 
 
-def minimise(table, target_length):
+def minimise(table, target_length, check_for_aliases=True):
     """Remove from the routing table any entries which could be replaced by
     default routing.
 
@@ -13,6 +13,15 @@ def minimise(table, target_length):
         default routing.
     target_length : int or None
         Target length of the routing table.
+    check_for_aliases : bool
+        If True (the default), default-route candidates are checked for aliased
+        entries before suggesting a route may be default routed. This check is
+        required to ensure correctness in the general case but has a runtime
+        complexity of O(N^2) in the worst case for N-entry tables.
+
+        If False, the alias-check is skipped resulting in O(N) runtime. This
+        option should only be used if the supplied table is guaranteed not to
+        contain any aliased entries.
 
     Raises
     ------
@@ -25,10 +34,19 @@ def minimise(table, target_length):
     [:py:class:`~rig.routing_table.RoutingTableEntry`, ...]
         Reduced routing table entries.
     """
-    new_table = list()
+    # If alias checking is required, see if we can cheaply prove that no
+    # aliases exist in the table to skip this costly check.
+    if check_for_aliases:
+        # Aliases cannot exist when all entries share the same mask and all
+        # keys are unique.
+        if len(set(e.mask for e in table)) == 1 and \
+                len(table) == len(set(e.key for e in table)):
+            check_for_aliases = False
 
+    # Generate a new table with default-route entries removed
+    new_table = list()
     for i, entry in enumerate(table):
-        if not _is_defaultable(i, entry, table):
+        if not _is_defaultable(i, entry, table, check_for_aliases):
             # If the entry cannot be removed then add it to the table
             new_table.append(entry)
 
@@ -39,7 +57,7 @@ def minimise(table, target_length):
     return new_table
 
 
-def _is_defaultable(i, entry, table):
+def _is_defaultable(i, entry, table, check_for_aliases=True):
     """Determine if an entry may be removed from a routing table and be
     replaced by a default route.
 
@@ -51,6 +69,9 @@ def _is_defaultable(i, entry, table):
         The entry itself
     table : [RoutingTableEntry, ...]
         The table containing the entry.
+    check_for_aliases : bool
+        If True, the table is checked for aliased entries before suggesting a
+        route may be default routed.
     """
     # May only have one source and sink (which may not be None)
     if (len(entry.sources) == 1 and
@@ -65,7 +86,8 @@ def _is_defaultable(i, entry, table):
             if source.opposite is sink:
                 # And the entry must not be aliased
                 key, mask = entry.key, entry.mask
-                if not any(intersect(key, mask, d.key, d.mask) for
-                           d in table[i+1:]):
+                if not check_for_aliases or \
+                        not any(intersect(key, mask, d.key, d.mask) for
+                                d in table[i+1:]):
                     return True
     return False

--- a/tests/routing_table/test_remove_default_routes.py
+++ b/tests/routing_table/test_remove_default_routes.py
@@ -1,8 +1,10 @@
 import pytest
+from mock import Mock
 
 from rig.routing_table import (Routes, RoutingTableEntry,
                                MinimisationFailedError)
-from rig.routing_table.remove_default_routes import minimise
+from rig.routing_table.remove_default_routes import minimise, _is_defaultable
+from rig.routing_table import remove_default_routes
 
 
 def test_minimise_orthogonal_table():
@@ -37,3 +39,84 @@ def test_minimise_oversized():
         minimise(table, 5)
     assert "10" in str(exc.value)
     assert "5" in str(exc.value)
+
+
+def test_is_defaultable_check_for_aliases():
+    # A table with three entries, the first may be default routed. The second
+    # could be default routable if not for aliasing the second entry.
+    table = [
+        RoutingTableEntry({Routes.north}, 0x1, 0xf, {Routes.south}),
+        RoutingTableEntry({Routes.north}, 0x8, 0xf, {Routes.south}),
+        RoutingTableEntry({Routes.north}, 0x8, 0xf, {Routes.east}),
+    ]
+
+    # The first entry should be defaultable regardless
+    assert _is_defaultable(0, table[0], table, check_for_aliases=True) is True
+    assert _is_defaultable(0, table[0], table, check_for_aliases=False) is True
+
+    # The alias check should disallow removing the second entry since it
+    # aliases the third entry.
+    assert _is_defaultable(1, table[1], table, check_for_aliases=True) is False
+
+    # But skipping the alias check should allow the second entry blindly
+    assert _is_defaultable(1, table[1], table, check_for_aliases=False) is True
+
+
+def test_minimise_check_for_aliases():
+    # A table with three entries, the first may be default routed. The second
+    # could be default routable if not for aliasing the second entry.
+    table = [
+        RoutingTableEntry({Routes.north}, 0x1, 0xf, {Routes.south}),
+        RoutingTableEntry({Routes.north}, 0x8, 0xf, {Routes.south}),
+        RoutingTableEntry({Routes.north}, 0x8, 0xf, {Routes.east}),
+    ]
+
+    # If alias checking is on (the default), only the first entry should be
+    # removed.
+    assert minimise(table, None) == table[1:]
+    assert minimise(table, None, check_for_aliases=True) == table[1:]
+
+    # If alias checking is off the first two entries should be removed (note
+    # that the second entry being removed is actually incorrect but not spotted
+    # when alias checking is disabled).
+    assert minimise(table, None, check_for_aliases=False) == table[2:]
+
+
+def test_minimise_same_mask(monkeypatch):
+    # Wrap the _is_defaultable check to allow checking of calls.
+    is_defaultable = Mock(side_effect=_is_defaultable)
+    monkeypatch.setattr(remove_default_routes, "_is_defaultable",
+                        is_defaultable)
+
+    # If all masks are the same and no keys overlap should skip alias check
+    table = [
+        RoutingTableEntry({Routes.north}, 0x1, 0xf, {Routes.south}),
+        RoutingTableEntry({Routes.north}, 0x2, 0xf, {Routes.south}),
+        RoutingTableEntry({Routes.north}, 0x3, 0xf, {Routes.south}),
+    ]
+    assert minimise(table, None) == []
+    for call in is_defaultable.mock_calls:
+        assert call[1][3] is False
+    is_defaultable.reset_mock()
+
+    # If some masks differ, should do alias check.
+    table = [
+        RoutingTableEntry({Routes.north}, 0x1, 0xf, {Routes.south}),
+        RoutingTableEntry({Routes.north}, 0x2, 0xf, {Routes.south}),
+        RoutingTableEntry({Routes.north}, 0x3, 0xff, {Routes.south}),
+    ]
+    assert minimise(table, None) == []
+    for call in is_defaultable.mock_calls:
+        assert call[1][3] is True
+    is_defaultable.reset_mock()
+
+    # If some keys are repeated, should do alias check.
+    table = [
+        RoutingTableEntry({Routes.north}, 0x1, 0xf, {Routes.south}),
+        RoutingTableEntry({Routes.north}, 0x2, 0xf, {Routes.south}),
+        RoutingTableEntry({Routes.north}, 0x1, 0xf, {Routes.south}),
+    ]
+    assert minimise(table, None) == [table[0]]
+    for call in is_defaultable.mock_calls:
+        assert call[1][3] is True
+    is_defaultable.reset_mock()


### PR DESCRIPTION
This optimisation makes table generation significantly faster by skipping O(N^2) alias checks during default-route removal when it can be cheaply proven that no aliases exist. In this commit, this is only possible when an input table contains entries with the same mask and no repeated keys.

In some experiments I am doing this brings routing table generation down from over a minute and a half to around 10 seconds.