### PR TITLE
Routing algorithm performance improvement

### DIFF
--- a/rig/place_and_route/route/ner.py
+++ b/rig/place_and_route/route/ner.py
@@ -148,7 +148,7 @@ def ner_net(source, destinations, width, height, wrap_around=False, radius=10):
             this_node = RoutingTree((x, y))
             route[(x, y)] = this_node
 
-            last_node.children.add((Routes(direction), this_node))
+            last_node.children.append((Routes(direction), this_node))
             last_node = this_node
 
     return (route[source], route)
@@ -219,7 +219,7 @@ def copy_and_disconnect_tree(root, machine):
                                           new_node.chip,
                                           machine):
                 # Is connected via working link
-                new_parent.children.add((direction, new_node))
+                new_parent.children.append((direction, new_node))
             else:
                 # Link to parent is dead (or original parent was dead and the
                 # new parent is not adjacent)
@@ -432,10 +432,10 @@ def avoid_dead_links(root, machine, wrap_around=False):
                         node.children.remove(dn[0])
                         # A node can only have one parent so we can stop now.
                         break
-            last_node.children.add((Routes(last_direction), new_node))
+            last_node.children.append((Routes(last_direction), new_node))
             last_node = new_node
             last_direction = direction
-        last_node.children.add((last_direction, lookup[child]))
+        last_node.children.append((last_direction, lookup[child]))
 
     return (root, lookup)
 
@@ -486,19 +486,18 @@ def route(vertices_resources, nets, machine, constraints, placements,
             if sink in route_to_endpoint:
                 # Sinks with route-to-endpoint constraints must be routed
                 # in the according directions.
-                tree_node.children.add((route_to_endpoint[sink], sink))
+                tree_node.children.append((route_to_endpoint[sink], sink))
             else:
                 cores = allocations.get(sink, {}).get(core_resource, None)
                 if cores is not None:
                     # Sinks with the core_resource resource specified must be
                     # routed to that set of cores.
                     for core in range(cores.start, cores.stop):
-                        tree_node.children.add((Routes.core(core), sink))
+                        tree_node.children.append((Routes.core(core), sink))
                 else:
                     # Sinks without that resource are simply included without
                     # an associated route
-                    tree_node.children.add((None, sink))
-
+                    tree_node.children.append((None, sink))
         routes[net] = root
 
     return routes

--- a/rig/place_and_route/route/ner.py
+++ b/rig/place_and_route/route/ner.py
@@ -129,7 +129,7 @@ def ner_net(source, destinations, width, height, wrap_around=False, radius=10):
         # node it would create a cycle in the route which would be VeryBad(TM).
         # As a result, we work backward through the route and truncate it at
         # the first point where the route intersects with a connected node.
-        ldf = list(longest_dimension_first(vector, neighbour, width, height))
+        ldf = longest_dimension_first(vector, neighbour, width, height)
         i = len(ldf)
         for direction, (x, y) in reversed(ldf):
             i -= 1

--- a/rig/place_and_route/route/ner.py
+++ b/rig/place_and_route/route/ner.py
@@ -179,6 +179,7 @@ def ner_net(source, destinations, width, height, wrap_around=False, radius=10):
                 else:
                     distance = shortest_mesh_path_length(
                         to_xyz(candidate_neighbour), to_xyz(destination))
+
                 if distance <= radius and (neighbour is None or
                                            distance < neighbour_distance):
                     neighbour = candidate_neighbour

--- a/rig/place_and_route/route/ner.py
+++ b/rig/place_and_route/route/ner.py
@@ -311,6 +311,29 @@ def a_star(sink, heuristic_source, sources, machine, wrap_around):
     return path
 
 
+def route_has_dead_links(root, machine):
+    """Quickly determine if a route uses any dead links.
+
+    Parameters
+    ----------
+    root : :py:class:`~rig.place_and_route.routing_tree.RoutingTree`
+        The root of the RoutingTree which contains nothing but RoutingTrees
+        (i.e. no vertices and links).
+    machine : :py:class:`~rig.place_and_route.Machine`
+        The machine in which the routes exist.
+
+    Returns
+    -------
+    bool
+        True if the route uses any dead/missing links, False otherwise.
+    """
+    for direction, (x, y), routes in root.traverse():
+        for route in routes:
+            if (x, y, route) not in machine:
+                return True
+    return False
+
+
 def avoid_dead_links(root, machine, wrap_around=False):
     """Modify a RoutingTree to route-around dead links in a Machine.
 
@@ -429,7 +452,8 @@ def route(vertices_resources, nets, machine, constraints, placements,
                                wrap_around, radius)
 
         # Fix routes to avoid dead chips/links
-        root, lookup = avoid_dead_links(root, machine, wrap_around)
+        if route_has_dead_links(root, machine):
+            root, lookup = avoid_dead_links(root, machine, wrap_around)
 
         # Add the sinks in the net to the RoutingTree
         for sink in net.sinks:

--- a/rig/place_and_route/route/ner.py
+++ b/rig/place_and_route/route/ner.py
@@ -100,19 +100,92 @@ def ner_net(source, destinations, width, height, wrap_around=False, radius=10):
         # We shall attempt to find our nearest neighbouring placed node.
         neighbour = None
 
-        # Try to find nodes nearby by searching an enlarging concentric ring of
-        # nodes.
-        for x, y in memoized_concentric_hexagons(radius):
-            x += destination[0]
-            y += destination[1]
-            if wrap_around:
-                x %= width
-                y %= height
-            if (x, y) in route:
-                neighbour = (x, y)
-                break
+        # Try to find a nearby (within radius hops) node in the routing tree
+        # that we can route to (falling back on just routing to the source).
+        #
+        # In an implementation according to the algorithm's original
+        # specification looks for nodes at each point in a growing set of rings
+        # of concentric hexagons. If it doesn't find any destinations this
+        # means an awful lot of checks: 1261 for the default radius of 20.
+        #
+        # An alternative (but behaviourally identical) implementation scans the
+        # list of all route nodes created so far and finds the closest node
+        # which is < radius hops (falling back on the origin if no node is
+        # closer than radius hops).  This implementation requires one check per
+        # existing route node. In most routes this is probably a lot less than
+        # 1261 since most routes will probably have at most a few hundred route
+        # nodes by the time the last destination is being routed.
+        #
+        # Which implementation is best is a difficult question to answer:
+        # * In principle nets with quite localised connections (e.g.
+        #   nearest-neighbour or centroids traffic) may route slightly more
+        #   quickly with the original algorithm since it may very quickly find
+        #   a neighbour.
+        # * In nets which connect very spaced-out destinations the second
+        #   implementation may be quicker since in such a scenario it is
+        #   unlikely that a neighbour will be found.
+        # * In extremely high-fan-out nets (e.g. broadcasts), the original
+        #   method is very likely to perform *far* better than the alternative
+        #   method since most iterations will complete immediately while the
+        #   alternative method must scan *all* the route vertices.
+        # As such, it should be clear that neither method alone is 'best' and
+        # both have degenerate performance in certain completely reasonable
+        # styles of net. As a result, a simple heuristic is used to decide
+        # which technique to use.
+        #
+        # The following micro-benchmarks are crude estimate of the
+        # runtime-per-iteration of each approach (at least in the case of a
+        # torus topology)::
+        #
+        #     $ # Original approach
+        #     $ python -m timeit --setup 'x, y, w, h, r = 1, 2, 5, 10, \
+        #                                     {x:None for x in range(10)}' \
+        #                        'x += 1; y += 1; x %= w; y %= h; (x, y) in r'
+        #     1000000 loops, best of 3: 0.207 usec per loop
+        #     $ # Alternative approach
+        #     $ python -m timeit --setup 'from rig.geometry import \
+        #                                 shortest_torus_path_length' \
+        #                        'shortest_torus_path_length( \
+        #                             (0, 1, 2), (3, 2, 1), 10, 10)'
+        #     1000000 loops, best of 3: 0.666 usec per loop
+        #
+        # From this we can approximately suggest that the alternative approach
+        # is 3x more expensive per iteration. A very crude heuristic is to use
+        # the original approach when the number of route nodes is more than
+        # 1/3rd of the number of routes checked by the original method.
+        concentric_hexagons = memoized_concentric_hexagons(radius)
+        if len(concentric_hexagons) < len(route) / 3:
+            # Original approach: Start looking for route nodes in a concentric
+            # spiral pattern out from the destination node.
+            for x, y in concentric_hexagons:
+                x += destination[0]
+                y += destination[1]
+                if wrap_around:
+                    x %= width
+                    y %= height
+                if (x, y) in route:
+                    neighbour = (x, y)
+                    break
+        else:
+            # Alternative approach: Scan over every route node and check to see
+            # if any are < radius, picking the closest one if so.
+            neighbour = None
+            neighbour_distance = None
+            for candidate_neighbour in route:
+                if wrap_around:
+                    distance = shortest_torus_path_length(
+                        to_xyz(candidate_neighbour), to_xyz(destination),
+                        width, height)
+                else:
+                    distance = shortest_mesh_path_length(
+                        to_xyz(candidate_neighbour), to_xyz(destination))
+                if distance <= radius and (neighbour is None or
+                                           distance < neighbour_distance):
+                    neighbour = candidate_neighbour
+                    neighbour_distance = distance
 
-        # Fall back on routing directly to the source if nothing was found
+        # Fall back on routing directly to the source if no nodes within radius
+        # hops of the destination was found.
         if neighbour is None:
             neighbour = source
 

--- a/rig/place_and_route/route/utils.py
+++ b/rig/place_and_route/route/utils.py
@@ -7,7 +7,7 @@ from rig.links import Links
 
 
 def longest_dimension_first(vector, start=(0, 0), width=None, height=None):
-    """Generate the (x, y) steps on a longest-dimension first route.
+    """List the (x, y) steps on a longest-dimension first route.
 
     Note that when multiple dimensions are the same magnitude, one will be
     chosen at random with uniform probability.
@@ -26,9 +26,9 @@ def longest_dimension_first(vector, start=(0, 0), width=None, height=None):
         The height of the topology beyond which we wrap around (0 <= y <
         height).  If None, no wrapping on the Y axis will occur.
 
-    Generates
-    ---------
-    (:py:class:`~rig.links.Links`, (x, y))
+    Returns
+    -------
+    [(:py:class:`~rig.links.Links`, (x, y)), ...]
         Produces (in order) a (direction, (x, y)) pair for every hop along the
         longest dimension first route. The direction gives the direction to
         travel in from the previous step to reach the current step. Ties are
@@ -37,6 +37,8 @@ def longest_dimension_first(vector, start=(0, 0), width=None, height=None):
         destination position.
     """
     x, y = start
+
+    out = []
 
     for dimension, magnitude in sorted(enumerate(vector),
                                        key=(lambda x:
@@ -66,7 +68,9 @@ def longest_dimension_first(vector, start=(0, 0), width=None, height=None):
 
             direction = Links.from_vector((dx, dy))
 
-            yield (direction, (x, y))
+            out.append((direction, (x, y)))
+
+    return out
 
 
 def links_between(a, b, machine):

--- a/tests/place_and_route/route/test_ner.py
+++ b/tests/place_and_route/route/test_ner.py
@@ -41,14 +41,14 @@ def test_ner_net_childless():
     # Childless net: results should just contain the source node
     root, lookup = ner_net((0, 0), [], 1, 1)
     assert root.chip == (0, 0)
-    assert root.children == set()
+    assert root.children == []
     assert lookup[(0, 0)] is root
     assert len(lookup) == 1
 
     # Childless net at non-zero coordinate
     root, lookup = ner_net((0, 1), [], 2, 2)
     assert root.chip == (0, 1)
-    assert root.children == set()
+    assert root.children == []
     assert lookup[(0, 1)] is root
     assert len(lookup) == 1
 
@@ -226,17 +226,17 @@ def test_route_has_dead_links():
 
     # Tree not going through a dead link should be OK
     t11 = RoutingTree((1, 1))
-    t00 = RoutingTree((0, 0), {(Routes.north_east, t11)})
+    t00 = RoutingTree((0, 0), [(Routes.north_east, t11)])
     assert route_has_dead_links(t00, machine) is False
 
     # Tree not going in opposite direction to dead link should be fine
     t00 = RoutingTree((0, 0))
-    t01 = RoutingTree((0, 1), {(Routes.south, t00)})
+    t01 = RoutingTree((0, 1), [(Routes.south, t00)])
     assert route_has_dead_links(t01, machine) is False
 
     # Tree going via dead link should fail
     t01 = RoutingTree((0, 1))
-    t00 = RoutingTree((0, 0), {(Routes.north, t01)})
+    t00 = RoutingTree((0, 0), [(Routes.north, t01)])
     assert route_has_dead_links(t00, machine) is True
 
 
@@ -257,14 +257,14 @@ def test_copy_and_disconnect_tree():
     # Tree with nothing broken
     t11 = RoutingTree((1, 2))
     t10 = RoutingTree((0, 2))
-    t1 = RoutingTree((0, 1), set([(Routes.north, t10),
-                                  (Routes.north_east, t11)]))
+    t1 = RoutingTree((0, 1), [(Routes.north, t10),
+                              (Routes.north_east, t11)])
     t01 = RoutingTree((2, 0))
     t00 = RoutingTree((2, 1))
-    t0 = RoutingTree((1, 0), set([(Routes.north_east, t00),
-                                  (Routes.east, t01)]))
-    t = RoutingTree((0, 0), set([(Routes.east, t0),
-                                 (Routes.north, t1)]))
+    t0 = RoutingTree((1, 0), [(Routes.north_east, t00),
+                              (Routes.east, t01)])
+    t = RoutingTree((0, 0), [(Routes.east, t0),
+                             (Routes.north, t1)])
     test_cases.append((t0, working_machine, set()))
 
     # Tree with broken link
@@ -273,9 +273,9 @@ def test_copy_and_disconnect_tree():
     # Tree with a broken chip
     t3 = RoutingTree((1, 2))
     t2 = RoutingTree((2, 1))
-    t1 = RoutingTree((1, 1), set([(Routes.east, t2),
-                                  (Routes.north, t3)]))
-    t0 = RoutingTree((0, 0), set([(Routes.north_east, t1)]))
+    t1 = RoutingTree((1, 1), [(Routes.east, t2),
+                              (Routes.north, t3)])
+    t0 = RoutingTree((0, 0), [(Routes.north_east, t1)])
     test_cases.append((t0, dead_chip_machine,
                        set([((0, 0), (2, 1)), ((0, 0), (1, 2))])))
 
@@ -457,14 +457,14 @@ def test_avoid_dead_links_no_change():
     test_cases.append(RoutingTree((0, 0)))
 
     # A routing tree which goes near (but avoids) the dead chip and link
-    t002 = RoutingTree((1, 3), set([]))
-    t001 = RoutingTree((0, 3), set([]))
-    t000 = RoutingTree((1, 2), set([]))
-    t00 = RoutingTree((0, 2), set([(Routes.east, t000),
-                                   (Routes.north, t001),
-                                   (Routes.north_east, t002)]))
-    t0 = RoutingTree((0, 1), set([(Routes.north, t00)]))
-    t = RoutingTree((0, 0), set([(Routes.north, t0)]))
+    t002 = RoutingTree((1, 3), [])
+    t001 = RoutingTree((0, 3), [])
+    t000 = RoutingTree((1, 2), [])
+    t00 = RoutingTree((0, 2), [(Routes.east, t000),
+                               (Routes.north, t001),
+                               (Routes.north_east, t002)])
+    t0 = RoutingTree((0, 1), [(Routes.north, t00)])
+    t = RoutingTree((0, 0), [(Routes.north, t0)])
     test_cases.append(t)
 
     for old_root in test_cases:
@@ -507,41 +507,41 @@ def test_avoid_dead_links_change():
 
     # A routing tree which crosses a dead link
     t1 = RoutingTree((4, 5))
-    t0 = RoutingTree((4, 4), set([(Routes.north, t1)]))
+    t0 = RoutingTree((4, 4), [(Routes.north, t1)])
     test_cases.append(t0)
 
     # A routing tree which is blocked by a dead chip
     t2 = RoutingTree((4, 2))
-    t1 = RoutingTree((4, 1), set([(Routes.north, t2)]))
-    t0 = RoutingTree((4, 0), set([(Routes.north, t1)]))
+    t1 = RoutingTree((4, 1), [(Routes.north, t2)])
+    t0 = RoutingTree((4, 0), [(Routes.north, t1)])
     test_cases.append(t0)
 
     # A subtree tree which is blocked by a wall of chips
     t002 = RoutingTree((3, 3))
     t001 = RoutingTree((2, 3))
     t000 = RoutingTree((3, 2))
-    t00 = RoutingTree((2, 2), set([(Routes.east, t000),
-                                   (Routes.north, t001),
-                                   (Routes.north_east, t002)]))
-    t0 = RoutingTree((1, 1), set([(Routes.north_east, t00)]))
-    t = RoutingTree((0, 0), set([(Routes.north_east, t0)]))
+    t00 = RoutingTree((2, 2), [(Routes.east, t000),
+                               (Routes.north, t001),
+                               (Routes.north_east, t002)])
+    t0 = RoutingTree((1, 1), [(Routes.north_east, t00)])
+    t = RoutingTree((0, 0), [(Routes.north_east, t0)])
     test_cases.append(t)
 
     # A subtree which blocks A* from reaching the start without crossing itself
     # but which doesn't directly encircle the top of the blockage.
-    t55 = RoutingTree((2, 5), set([]))
-    t54 = RoutingTree((3, 5), set([(Routes.west, t55)]))
-    t53 = RoutingTree((4, 5), set([(Routes.west, t54)]))
-    t52 = RoutingTree((5, 2), set([]))
-    t51 = RoutingTree((5, 3), set([(Routes.south, t52)]))
-    t50 = RoutingTree((5, 4), set([(Routes.south, t51)]))
-    t4 = RoutingTree((5, 5), set([(Routes.south, t50),
-                                  (Routes.west, t53)]))
-    t3 = RoutingTree((4, 4), set([(Routes.north_east, t4)]))
-    t2 = RoutingTree((3, 3), set([(Routes.north_east, t3)]))
-    t1 = RoutingTree((2, 2), set([(Routes.north_east, t2)]))
-    t0 = RoutingTree((1, 1), set([(Routes.north_east, t1)]))
-    t = RoutingTree((0, 0), set([(Routes.north_east, t0)]))
+    t55 = RoutingTree((2, 5), [])
+    t54 = RoutingTree((3, 5), [(Routes.west, t55)])
+    t53 = RoutingTree((4, 5), [(Routes.west, t54)])
+    t52 = RoutingTree((5, 2), [])
+    t51 = RoutingTree((5, 3), [(Routes.south, t52)])
+    t50 = RoutingTree((5, 4), [(Routes.south, t51)])
+    t4 = RoutingTree((5, 5), [(Routes.south, t50),
+                              (Routes.west, t53)])
+    t3 = RoutingTree((4, 4), [(Routes.north_east, t4)])
+    t2 = RoutingTree((3, 3), [(Routes.north_east, t3)])
+    t1 = RoutingTree((2, 2), [(Routes.north_east, t2)])
+    t0 = RoutingTree((1, 1), [(Routes.north_east, t1)])
+    t = RoutingTree((0, 0), [(Routes.north_east, t0)])
     test_cases.append(t)
 
     # For each test case just ensure the new tree is a tree and visits all

--- a/tests/place_and_route/route/test_ner.py
+++ b/tests/place_and_route/route/test_ner.py
@@ -4,6 +4,8 @@ import random
 
 from collections import deque
 
+from rig.geometry import concentric_hexagons
+
 from rig.place_and_route.machine import Machine
 
 from rig.links import Links
@@ -14,10 +16,23 @@ from rig.routing_table import Routes
 
 from rig.place_and_route.route.utils import links_between
 
-from rig.place_and_route.route.ner import ner_net, \
-    route_has_dead_links, copy_and_disconnect_tree, a_star, avoid_dead_links
+from rig.place_and_route.route.ner import \
+    ner_net, memoized_concentric_hexagons, route_has_dead_links, \
+    copy_and_disconnect_tree, a_star, avoid_dead_links
 
 from rig.place_and_route.exceptions import MachineHasDisconnectedSubregion
+
+
+def test_memoized_concentric_hexagons():
+    # Should pass calls through
+    out10 = memoized_concentric_hexagons(10)
+    assert out10 == tuple(concentric_hexagons(10))
+    out20 = memoized_concentric_hexagons(20)
+    assert out20 == tuple(concentric_hexagons(20))
+
+    # Should use memoized value
+    assert memoized_concentric_hexagons(10) is out10
+    assert memoized_concentric_hexagons(20) is out20
 
 
 def test_ner_net_childless():

--- a/tests/place_and_route/route/test_route_utils.py
+++ b/tests/place_and_route/route/test_route_utils.py
@@ -8,116 +8,116 @@ from rig.links import Links
 
 def test_longest_dimension_first():
     # Null test
-    assert list(longest_dimension_first((0, 0, 0))) == []
+    assert longest_dimension_first((0, 0, 0)) == []
 
     # Single hop in each dimension
-    assert list(longest_dimension_first((1, 0, 0))) \
+    assert longest_dimension_first((1, 0, 0)) \
         == [(Links.east, (1, 0))]
-    assert list(longest_dimension_first((0, 1, 0))) \
+    assert longest_dimension_first((0, 1, 0)) \
         == [(Links.north, (0, 1))]
-    assert list(longest_dimension_first((0, 0, 1))) \
+    assert longest_dimension_first((0, 0, 1)) \
         == [(Links.south_west, (-1, -1))]
 
     # Negative single hop in each dimension
-    assert list(longest_dimension_first((-1, 0, 0))) \
+    assert longest_dimension_first((-1, 0, 0)) \
         == [(Links.west, (-1, 0))]
-    assert list(longest_dimension_first((0, -1, 0))) \
+    assert longest_dimension_first((0, -1, 0)) \
         == [(Links.south, (0, -1))]
-    assert list(longest_dimension_first((0, 0, -1))) \
+    assert longest_dimension_first((0, 0, -1)) \
         == [(Links.north_east, (1, 1))]
 
     # Single hop from alternative starting point
-    assert list(longest_dimension_first((1, 0, 0), (10, 100))) \
+    assert longest_dimension_first((1, 0, 0), (10, 100)) \
         == [(Links.east, (11, 100))]
-    assert list(longest_dimension_first((0, 1, 0), (10, 100))) \
+    assert longest_dimension_first((0, 1, 0), (10, 100)) \
         == [(Links.north, (10, 101))]
-    assert list(longest_dimension_first((0, 0, 1), (10, 100))) \
+    assert longest_dimension_first((0, 0, 1), (10, 100)) \
         == [(Links.south_west, (9, 99))]
 
     # Negative single hop from alternative starting point
-    assert list(longest_dimension_first((-1, 0, 0), (10, 100))) \
+    assert longest_dimension_first((-1, 0, 0), (10, 100)) \
         == [(Links.west, (9, 100))]
-    assert list(longest_dimension_first((0, -1, 0), (10, 100))) \
+    assert longest_dimension_first((0, -1, 0), (10, 100)) \
         == [(Links.south, (10, 99))]
-    assert list(longest_dimension_first((0, 0, -1), (10, 100))) \
+    assert longest_dimension_first((0, 0, -1), (10, 100)) \
         == [(Links.north_east, (11, 101))]
 
     # Test wrap-around of single hop
-    assert list(longest_dimension_first((1, 0, 0), width=1, height=1)) \
+    assert longest_dimension_first((1, 0, 0), width=1, height=1) \
         == [(Links.east, (0, 0))]
-    assert list(longest_dimension_first((0, 1, 0), width=1, height=1)) \
+    assert longest_dimension_first((0, 1, 0), width=1, height=1) \
         == [(Links.north, (0, 0))]
-    assert list(longest_dimension_first((0, 0, 1), width=1, height=1)) \
+    assert longest_dimension_first((0, 0, 1), width=1, height=1) \
         == [(Links.south_west, (0, 0))]
-    assert list(longest_dimension_first((-1, 0, 0), width=1, height=1)) \
+    assert longest_dimension_first((-1, 0, 0), width=1, height=1) \
         == [(Links.west, (0, 0))]
-    assert list(longest_dimension_first((0, -1, 0), width=1, height=1)) \
+    assert longest_dimension_first((0, -1, 0), width=1, height=1) \
         == [(Links.south, (0, 0))]
-    assert list(longest_dimension_first((0, 0, -1), width=1, height=1)) \
+    assert longest_dimension_first((0, 0, -1), width=1, height=1) \
         == [(Links.north_east, (0, 0))]
 
     # Test wrap-around in each direction
-    assert list(longest_dimension_first((2, 0, 0), width=2, height=2)) \
+    assert longest_dimension_first((2, 0, 0), width=2, height=2) \
         == [(Links.east, (1, 0)), (Links.east, (0, 0))]
-    assert list(longest_dimension_first((0, 2, 0), width=2, height=2)) \
+    assert longest_dimension_first((0, 2, 0), width=2, height=2) \
         == [(Links.north, (0, 1)), (Links.north, (0, 0))]
-    assert list(longest_dimension_first((0, 0, 2), width=2, height=2)) \
+    assert longest_dimension_first((0, 0, 2), width=2, height=2) \
         == [(Links.south_west, (1, 1)), (Links.south_west, (0, 0))]
-    assert list(longest_dimension_first((-2, 0, 0), width=2, height=2)) \
+    assert longest_dimension_first((-2, 0, 0), width=2, height=2) \
         == [(Links.west, (1, 0)), (Links.west, (0, 0))]
-    assert list(longest_dimension_first((0, -2, 0), width=2, height=2)) \
+    assert longest_dimension_first((0, -2, 0), width=2, height=2) \
         == [(Links.south, (0, 1)), (Links.south, (0, 0))]
-    assert list(longest_dimension_first((0, 0, -2), width=2, height=2)) \
+    assert longest_dimension_first((0, 0, -2), width=2, height=2) \
         == [(Links.north_east, (1, 1)), (Links.north_east, (0, 0))]
 
     # Test wrap-around with different width & height
-    assert list(longest_dimension_first((0, 0, 1), width=2, height=3)) \
+    assert longest_dimension_first((0, 0, 1), width=2, height=3) \
         == [(Links.south_west, (1, 2))]
 
     # Test multiple hops on single dimension
-    assert list(longest_dimension_first((2, 0, 0))) \
+    assert longest_dimension_first((2, 0, 0)) \
         == [(Links.east, (1, 0)), (Links.east, (2, 0))]
-    assert list(longest_dimension_first((0, 2, 0))) \
+    assert longest_dimension_first((0, 2, 0)) \
         == [(Links.north, (0, 1)), (Links.north, (0, 2))]
-    assert list(longest_dimension_first((0, 0, 2))) \
+    assert longest_dimension_first((0, 0, 2)) \
         == [(Links.south_west, (-1, -1)), (Links.south_west, (-2, -2))]
 
     # Test dimension ordering with all positive magnitudes and some zero
-    assert list(longest_dimension_first((2, 1, 0))) \
+    assert longest_dimension_first((2, 1, 0)) \
         == [(Links.east, (1, 0)), (Links.east, (2, 0)), (Links.north, (2, 1))]
-    assert list(longest_dimension_first((0, 2, 1))) \
+    assert longest_dimension_first((0, 2, 1)) \
         == [(Links.north, (0, 1)), (Links.north, (0, 2)),
             (Links.south_west, (-1, 1))]
-    assert list(longest_dimension_first((1, 0, 2))) \
+    assert longest_dimension_first((1, 0, 2)) \
         == [(Links.south_west, (-1, -1)), (Links.south_west, (-2, -2)),
             (Links.east, (-1, -2))]
-    assert list(longest_dimension_first((0, 1, 2))) \
+    assert longest_dimension_first((0, 1, 2)) \
         == [(Links.south_west, (-1, -1)), (Links.south_west, (-2, -2)),
             (Links.north, (-2, -1))]
 
     # Test dimension ordering with all positive magnitudes and no zeros
-    assert list(longest_dimension_first((3, 2, 1))) \
+    assert longest_dimension_first((3, 2, 1)) \
         == [(Links.east, (1, 0)), (Links.east, (2, 0)), (Links.east, (3, 0)),
             (Links.north, (3, 1)), (Links.north, (3, 2)),
             (Links.south_west, (2, 1))]
-    assert list(longest_dimension_first((1, 3, 2))) \
+    assert longest_dimension_first((1, 3, 2)) \
         == [(Links.north, (0, 1)), (Links.north, (0, 2)),
             (Links.north, (0, 3)), (Links.south_west, (-1, 2)),
             (Links.south_west, (-2, 1)), (Links.east, (-1, 1))]
-    assert list(longest_dimension_first((2, 1, 3))) \
+    assert longest_dimension_first((2, 1, 3)) \
         == [(Links.south_west, (-1, -1)), (Links.south_west, (-2, -2)),
             (Links.south_west, (-3, -3)), (Links.east, (-2, -3)),
             (Links.east, (-1, -3)), (Links.north, (-1, -2))]
-    assert list(longest_dimension_first((1, 2, 3))) \
+    assert longest_dimension_first((1, 2, 3)) \
         == [(Links.south_west, (-1, -1)), (Links.south_west, (-2, -2)),
             (Links.south_west, (-3, -3)), (Links.north, (-3, -2)),
             (Links.north, (-3, -1)), (Links.east, (-2, -1))]
 
     # Test dimension ordering with mixed sign magnitudes
-    assert list(longest_dimension_first((1, -2, 0))) \
+    assert longest_dimension_first((1, -2, 0)) \
         == [(Links.south, (0, -1)), (Links.south, (0, -2)),
             (Links.east, (1, -2))]
-    assert list(longest_dimension_first((-2, 1, 0))) \
+    assert longest_dimension_first((-2, 1, 0)) \
         == [(Links.west, (-1, 0)), (Links.west, (-2, 0)),
             (Links.north, (-2, 1))]
 
@@ -130,7 +130,7 @@ def test_longest_dimension_first():
     generated_y_first = False
     generated_z_first = False
     for _ in range(1000):  # pragma: no branch
-        first_move = list(longest_dimension_first((1, 1, 1)))[0]
+        first_move = longest_dimension_first((1, 1, 1))[0]
         if first_move == (Links.east, (1, 0)):
             generated_x_first = True
         elif first_move == (Links.north, (0, 1)):
@@ -149,7 +149,7 @@ def test_longest_dimension_first():
     # given for a a selection of larger vectors.
     for vector in [(0, 0, 0), (1, 1, 1), (1, -1, 0),  # Test sanity checks
                    (10, 10, 10), (10, -10, 5), (10, 20, 30)]:
-        assert len(list(longest_dimension_first(vector))) \
+        assert len(longest_dimension_first(vector)) \
             == sum(map(abs, vector)), \
             vector
 

--- a/tests/place_and_route/test_routing_tree.py
+++ b/tests/place_and_route/test_routing_tree.py
@@ -9,7 +9,14 @@ class TestRoutingTree(object):
 
     def test_init_default(self):
         # Make sure the default initialiser creates no children
-        assert RoutingTree((0, 0)).children == set()
+        assert RoutingTree((0, 0)).children == []
+
+    def test_chip(self):
+        # Make sure the chip can be accessed like a tuple
+        t = RoutingTree((1, 2))
+        assert t.chip == (1, 2)
+        t.chip = (3, 4)
+        assert t.chip == (3, 4)
 
     def test_iter(self):
         # Singleton
@@ -19,20 +26,20 @@ class TestRoutingTree(object):
         # Multiple Children
         t2 = RoutingTree((2, 0))
         t1 = RoutingTree((1, 0))
-        t0 = RoutingTree((0, 0), set([(Routes.east, t1),
-                                      (Routes.west, t2)]))
+        t0 = RoutingTree((0, 0), [(Routes.east, t1),
+                                  (Routes.west, t2)])
         assert set(t0) == set([t0, t1, t2])
 
         # Grandchildren
         t2 = RoutingTree((2, 0))
-        t1 = RoutingTree((1, 0), set([(Routes.west, t2)]))
-        t0 = RoutingTree((0, 0), set([(Routes.west, t1)]))
+        t1 = RoutingTree((1, 0), [(Routes.west, t2)])
+        t0 = RoutingTree((0, 0), [(Routes.west, t1)])
         assert set(t0) == set([t0, t1, t2])
 
         # Inclusion of other types
         t2 = object()
-        t1 = RoutingTree((1, 0), set([(Routes.west, t2)]))
-        t0 = RoutingTree((0, 0), set([(Routes.west, t1)]))
+        t1 = RoutingTree((1, 0), [(Routes.west, t2)])
+        t0 = RoutingTree((0, 0), [(Routes.west, t1)])
         assert set(t0) == set([t0, t1, t2])
 
     def test_repr(self):
@@ -50,14 +57,14 @@ class TestRoutingTree(object):
         # (0, 0) - east -> (1, 0) - east -> (2, 0)
         #                       \
         #                        \- south -> (1, -1) - east -> (2, -1) -> 2
-        t0 = RoutingTree((2, -1), {(Routes.core(2), None)})
-        t1 = RoutingTree((1, -1), {(Routes.east, t0)})
-        t2 = RoutingTree((1, 1), {(Routes.core(5), None)})
-        t3 = RoutingTree((2, 0), {(None, None)})
-        t4 = RoutingTree((1, 0), {(Routes.north, t2),
+        t0 = RoutingTree((2, -1), [(Routes.core(2), None)])
+        t1 = RoutingTree((1, -1), [(Routes.east, t0)])
+        t2 = RoutingTree((1, 1), [(Routes.core(5), None)])
+        t3 = RoutingTree((2, 0), [(None, None)])
+        t4 = RoutingTree((1, 0), [(Routes.north, t2),
                                   (Routes.east, t3),
-                                  (Routes.south, t1)})
-        tree = RoutingTree((0, 0), {(Routes.east, t4)})
+                                  (Routes.south, t1)])
+        tree = RoutingTree((0, 0), [(Routes.east, t4)])
 
         # Traverse the tree manually
         tip = tree.traverse()

--- a/tests/place_and_route/test_utils.py
+++ b/tests/place_and_route/test_utils.py
@@ -236,13 +236,13 @@ def test_build_application_map():
 def test_build_routing_tables():
     # Single net with a multi-hop route with a fork in the middle
     net = Net(object(), object())
-    r6 = RoutingTree((3, 1), set([(Routes.core_6, net.sinks[0])]))
-    r5 = RoutingTree((5, 0), set([(Routes.core_5, net.sinks[0])]))
-    r4 = RoutingTree((4, 0), set([(Routes.east, r5)]))
-    r3 = RoutingTree((3, 0), set([(Routes.east, r4), (Routes.north, r6)]))
-    r2 = RoutingTree((2, 0), set([(Routes.east, r3)]))
-    r1 = RoutingTree((1, 0), set([(Routes.east, r2)]))
-    r0 = RoutingTree((0, 0), set([(Routes.east, r1)]))
+    r6 = RoutingTree((3, 1), [(Routes.core_6, net.sinks[0])])
+    r5 = RoutingTree((5, 0), [(Routes.core_5, net.sinks[0])])
+    r4 = RoutingTree((4, 0), [(Routes.east, r5)])
+    r3 = RoutingTree((3, 0), [(Routes.east, r4), (Routes.north, r6)])
+    r2 = RoutingTree((2, 0), [(Routes.east, r3)])
+    r1 = RoutingTree((1, 0), [(Routes.east, r2)])
+    r0 = RoutingTree((0, 0), [(Routes.east, r1)])
     routes = {net: r0}
     net_keys = {net: (0xDEAD, 0xBEEF)}
 

--- a/tests/routing_table/test_routing_table_utils.py
+++ b/tests/routing_table/test_routing_table_utils.py
@@ -25,8 +25,8 @@ def test_routing_tree_to_tables():
 
     # Single net with a singleton route ending in a number of links.
     net = Net(object(), object())
-    routes = {net: RoutingTree((1, 1), set([(Routes.north, object()),
-                                            (Routes.core_1, object())]))}
+    routes = {net: RoutingTree((1, 1), [(Routes.north, object()),
+                                        (Routes.core_1, object())])}
     net_keys = {net: (0xDEAD, 0xBEEF)}
     assert routing_tree_to_tables(routes, net_keys) == \
         {(1, 1): [
@@ -38,7 +38,7 @@ def test_routing_tree_to_tables():
     # direction specified should result in a terminus being added but nothing
     # else.
     net = Net(object(), object())
-    routes = {net: RoutingTree((1, 1), set([(None, object())]))}
+    routes = {net: RoutingTree((1, 1), [(None, object())])}
     net_keys = {net: (0xDEAD, 0xBEEF)}
     assert routing_tree_to_tables(routes, net_keys) == \
         {(1, 1): [RoutingTableEntry(set([]), 0xDEAD, 0xBEEF, {None})]}
@@ -46,11 +46,11 @@ def test_routing_tree_to_tables():
     # Single net with a multi-element route
     net = Net(object(), object())
     routes = {net: RoutingTree((1, 1),
-                               set([(Routes.core_1, object()),
-                                    (Routes.east,
-                                     RoutingTree((2, 1),
-                                                 set([(Routes.core_2,
-                                                       object())])))]))}
+                               [(Routes.core_1, object()),
+                                (Routes.east,
+                                 RoutingTree((2, 1),
+                                             [(Routes.core_2,
+                                               object())]))])}
     net_keys = {net: (0xDEAD, 0xBEEF)}
     assert routing_tree_to_tables(routes, net_keys) == \
         {(1, 1): [RoutingTableEntry(set([Routes.east, Routes.core_1]),
@@ -61,11 +61,11 @@ def test_routing_tree_to_tables():
     # Single net with a wrapping route
     net = Net(object(), object())
     routes = {net: RoutingTree((7, 1),
-                               set([(Routes.core_1, net.source),
-                                    (Routes.east,
-                                     RoutingTree((0, 1),
-                                                 set([(Routes.core_2,
-                                                       net.sinks[0])])))]))}
+                               [(Routes.core_1, net.source),
+                                (Routes.east,
+                                 RoutingTree((0, 1),
+                                             [(Routes.core_2,
+                                               net.sinks[0])]))])}
     net_keys = {net: (0xDEAD, 0xBEEF)}
     assert routing_tree_to_tables(routes, net_keys) == \
         {(7, 1): [RoutingTableEntry(set([Routes.east, Routes.core_1]),
@@ -77,9 +77,9 @@ def test_routing_tree_to_tables():
     # in nothing
     net = Net(object(), object())
     r3 = RoutingTree((3, 0))
-    r2 = RoutingTree((2, 0), set([(Routes.east, r3)]))
-    r1 = RoutingTree((1, 0), set([(Routes.east, r2)]))
-    r0 = RoutingTree((0, 0), set([(Routes.east, r1)]))
+    r2 = RoutingTree((2, 0), [(Routes.east, r3)])
+    r1 = RoutingTree((1, 0), [(Routes.east, r2)])
+    r0 = RoutingTree((0, 0), [(Routes.east, r1)])
     routes = {net: r0}
     net_keys = {net: (0xDEAD, 0xBEEF)}
     assert routing_tree_to_tables(routes, net_keys) == \
@@ -93,11 +93,11 @@ def test_routing_tree_to_tables():
     # Single net with a multi-hop route with no direction changes, terminating
     # in a number of cores
     net = Net(object(), object())
-    r3 = RoutingTree((3, 0), set([(Routes.core_2, net.sinks[0]),
-                                  (Routes.core_3, net.sinks[0])]))
-    r2 = RoutingTree((2, 0), set([(Routes.east, r3)]))
-    r1 = RoutingTree((1, 0), set([(Routes.east, r2)]))
-    r0 = RoutingTree((0, 0), set([(Routes.east, r1)]))
+    r3 = RoutingTree((3, 0), [(Routes.core_2, net.sinks[0]),
+                              (Routes.core_3, net.sinks[0])])
+    r2 = RoutingTree((2, 0), [(Routes.east, r3)])
+    r1 = RoutingTree((1, 0), [(Routes.east, r2)])
+    r0 = RoutingTree((0, 0), [(Routes.east, r1)])
     routes = {net: r0}
     net_keys = {net: (0xDEAD, 0xBEEF)}
     assert routing_tree_to_tables(routes, net_keys) == \
@@ -113,13 +113,13 @@ def test_routing_tree_to_tables():
 
     # Single net with a multi-hop route with a fork in the middle
     net = Net(object(), object())
-    r6 = RoutingTree((3, 1), set([(Routes.core_6, net.sinks[0])]))
-    r5 = RoutingTree((5, 0), set([(Routes.core_5, net.sinks[0])]))
-    r4 = RoutingTree((4, 0), set([(Routes.east, r5)]))
-    r3 = RoutingTree((3, 0), set([(Routes.east, r4), (Routes.north, r6)]))
-    r2 = RoutingTree((2, 0), set([(Routes.east, r3)]))
-    r1 = RoutingTree((1, 0), set([(Routes.east, r2)]))
-    r0 = RoutingTree((0, 0), set([(Routes.east, r1)]))
+    r6 = RoutingTree((3, 1), [(Routes.core_6, net.sinks[0])])
+    r5 = RoutingTree((5, 0), [(Routes.core_5, net.sinks[0])])
+    r4 = RoutingTree((4, 0), [(Routes.east, r5)])
+    r3 = RoutingTree((3, 0), [(Routes.east, r4), (Routes.north, r6)])
+    r2 = RoutingTree((2, 0), [(Routes.east, r3)])
+    r1 = RoutingTree((1, 0), [(Routes.east, r2)])
+    r0 = RoutingTree((0, 0), [(Routes.east, r1)])
     routes = {net: r0}
     net_keys = {net: (0xDEAD, 0xBEEF)}
     assert routing_tree_to_tables(routes, net_keys) == \
@@ -140,8 +140,8 @@ def test_routing_tree_to_tables():
     # Multiple nets
     net0 = Net(object(), object())
     net1 = Net(object(), object())
-    routes = {net0: RoutingTree((2, 2), set([(Routes.core_1, net0.sinks[0])])),
-              net1: RoutingTree((2, 2), set([(Routes.core_2, net1.sinks[0])]))}
+    routes = {net0: RoutingTree((2, 2), [(Routes.core_1, net0.sinks[0])]),
+              net1: RoutingTree((2, 2), [(Routes.core_2, net1.sinks[0])])}
     net_keys = {net0: (0xDEAD, 0xBEEF), net1: (0x1234, 0xABCD)}
     tables = routing_tree_to_tables(routes, net_keys)
     assert set(tables) == set([(2, 2)])
@@ -187,11 +187,11 @@ def test_routing_tree_to_tables_repeated_key_mask_merge_allowed():
     net1 = Net(object(), sink)
 
     # Create the routing trees
-    r0 = RoutingTree((2, 1), {(Routes.core(1), sink)})
-    r1 = RoutingTree((1, 1), {(Routes.east, r0)})
+    r0 = RoutingTree((2, 1), [(Routes.core(1), sink)])
+    r1 = RoutingTree((1, 1), [(Routes.east, r0)])
     routes = {
-        net0: RoutingTree((0, 1), {(Routes.east, r1)}),
-        net1: RoutingTree((1, 0), {(Routes.north, r1)}),
+        net0: RoutingTree((0, 1), [(Routes.east, r1)]),
+        net1: RoutingTree((1, 0), [(Routes.north, r1)]),
     }
 
     # Create the keys
@@ -244,15 +244,15 @@ def test_routing_tree_to_tables_repeated_key_mask_fork_not_allowed():
     net1 = Net(object(), [sink0, sink1])
 
     # Create the routing trees
-    r_east = RoutingTree((2, 1), {(Routes.core(1), sink0)})
+    r_east = RoutingTree((2, 1), [(Routes.core(1), sink0)])
     routes = {
-        net0: RoutingTree((0, 1), {
-            (Routes.east, RoutingTree((1, 1), {(Routes.east, r_east)})),
-        }),
-        net1: RoutingTree((1, 1), {
+        net0: RoutingTree((0, 1), [
+            (Routes.east, RoutingTree((1, 1), [(Routes.east, r_east)])),
+        ]),
+        net1: RoutingTree((1, 1), [
             (Routes.east, r_east),
-            (Routes.south, RoutingTree((1, 0), {(Routes.core(1), sink1)})),
-        }),
+            (Routes.south, RoutingTree((1, 0), [(Routes.core(1), sink1)])),
+        ]),
     }
 
     # Create the keys


### PR DESCRIPTION
Routing algorithm performance improvement
=========================================

While performing various experiments I've been bitten by the routing process taking a ridiculous amount of time while performing large experiments. This PR is an effort to reduce this runtime...

**Headline outcomes**:

* Routing is now 2-3x faster
* The returned `RoutingTrees` now take up half as much memory as before.

Implemented:

1. [x] Speed up common-case where no links are broken (2f99746: reduces runtime to 2/3 of original)
2. [x] Optimise `concentric_hexagons`: consider non-generator, memoize concentric hexagon list (d8c05a8: very minor speedup)
3. [x] Optimise `longest_dimension_first`: just return a list (38c0662: not noticable speedup but cleans up code a little)
4. [x] Optimise `RoutingTree` memory usage (2c48ad6: halves memory consumption and yeilds minor speedup)
5. [x] Optimise neighbourhood exploration (294debd: reduces runtime to 3/5ths of original when routing long-distance nets)

Also under consideration for the future, probably not this PR:

* Redefine `RoutingTree` to reduce memory use further: would be a quite breaking change but should mostly only impact routers
* Build C implementation of NER kernel
* Optimise `shortest_torus_paths`: low-hanging fruit but low-impact

Benchmark
---------

To benchmark the performance of the router, a uniform randomly-connected network is created and routed by the script below. This benchmark reflects a 'bad' netlist in which most routes are quite long. This is currently something the router deals with *very* badly in terms of performance.

```python
import random
import time

from math import sqrt, ceil

from rig.place_and_route import allocate, route, Cores, Machine
from rig.place_and_route.place.rand import place
from rig.netlist import Net

# Generate a random network
num_vertices = 10000
nets_per_vertex = 2
fan_out = 4
vertices = [object() for _ in range(num_vertices)]
nets = [Net(v, random.sample(vertices, fan_out))
        for v in vertices
        for _ in range(nets_per_vertex)]

# Generate P&R data-structures
vertices_resources = {v: {Cores: 18} for v in vertices}
w = h = int(ceil(sqrt(num_vertices)))
machine = Machine(w, h)

# Perform a few random placement runs and time the routing time
for _ in range(5):
    placements = place(vertices_resources, nets, machine, [])
    allocations = allocate(vertices_resources, nets, machine, [], placements)
    before = time.time()
    routes = route(vertices_resources, nets, machine, [], placements, allocations)
    print("Routed in {} seconds".format(time.time() - before))
```

On my laptop, using Python 3 and the existing implementation (2f0018a), the results are as follows:

    Routed in 85.41314220428467 seconds
    Routed in 87.82996225357056 seconds
    Routed in 89.84850525856018 seconds
    Routed in 88.47845983505249 seconds
    Routed in 88.14478492736816 seconds

Tweak 1: Optimise common-case where no bad links are encountered
----------------------------------------------------------------

Running under [cProfile](https://docs.python.org/3.5/library/profile.html) the router was spending around 1/3rd of its time in the `avoid_dead_links` method which attempts to modify initially generated routes such that they route around any dead links. This function is rather naively implemented on the assumption that it will usually find a dead link and generates a working-copy of the routing tree as it checks it. Since most routes are not affected by dead links, a new function `route_has_dead_links` is used to quickly check whether dead links are actually present in a routing tree before trying to fix it.

After making this change (2f99746), the results are as follows:

    Routed in 62.89778780937195 seconds
    Routed in 66.00230073928833 seconds
    Routed in 69.11281132698059 seconds
    Routed in 63.75988221168518 seconds
    Routed in 68.9121150970459 seconds

Tweak 2: Cache concentric hexagons sequence
-------------------------------------------

The `concentric_hexagons` function is called once per destination. As a very simple generator the overhead of the generator is measurable. By memoizing this generator's output this overhead can be saved. A simple change resulting in a minor but measurable performance improvement.

After making this change (d8c05a8), the results are as follows:

    Routed in 55.96174383163452 seconds
    Routed in 65.61859607696533 seconds
    Routed in 57.02670741081238 seconds
    Routed in 55.88467574119568 seconds
    Routed in 65.95263361930847 seconds

Tweak 3: Make `longest_dimension_first` just return a list
----------------------------------------------------------

Avoid the need for a generator in a lot loop.

After making this change (38c0662), the results are as follows:

    Routed in 55.16030263900757 seconds
    Routed in 64.66953659057617 seconds
    Routed in 55.68718242645264 seconds
    Routed in 55.36920404434204 seconds
    Routed in 58.20105767250061 seconds

So... probably not significant... That said since the generator's output was
*always* converted to a list anyway this change is beneficial from a
code-clarity point of view at least...

Tweak 4: Optimise `RoutingTree` memory usage
--------------------------------------------

Before diving in and making a whole new complex data type for RoutingTrees that optimises out strings of singleton nodes, I've attempted to shrink the structure which already exists.

Approximate peak memory usage numbers on the benchmark (as measured using [`memory_profiler`](https://pypi.python.org/pypi/memory_profiler)) for each of the changes made are enumerated below:

* Original memory consumption: 1470 MB
* Use a list rather than a set to store children of a `RoutingTree` node: 1150 MB
* Use `__slots__`: 880 MB
* Store chip coordinates as two numbers, not a tuple: 740 MB

After making this change (2c48ad6), the runtime also improves slightly as follows:

    Routed in 51.36526560783386 seconds
    Routed in 53.47503447532654 seconds
    Routed in 51.021536111831665 seconds
    Routed in 53.68679237365723 seconds
    Routed in 50.90719032287598 seconds

Tweak 5: Optimise neighbourhood exploration
-------------------------------------------

When generating routing trees, the NER algorithm searches for nearby vertices (or pieces of route) to route to rather than always routing back to the source of the net. Originally this was achieved by searching in a spiral pattern outward from the destination vertex looking for pieces of route to attach to.  With the default search radius of 20 this requires 1261 checks, all of which are carried out when the destination is more than 20 hops from another part of the route.

A new, alternative implementation instead iterates over every known route segment to find out if any are within the specified search radius. In practice this often results in substantially fewer checks being required. To reap the benefits of both approaches, a simple heuristic automatically selects the approach to use on a route-by-route basis.

A substantial comment in the implementation (near the top of `ner_net()` in `ner.py`) explains this change in greater detail.

After making this change (294debd), the results are as follows:

    Routed in 33.20937418937683 seconds
    Routed in 33.3547580242157 seconds
    Routed in 30.7742702960968 seconds
    Routed in 34.18379735946655 seconds
    Routed in 30.957439184188843 seconds

Regression check for the common case
------------------------------------

As a regression check, the following alternative benchmark models a more well-behaved application in which most routes are very short.

```python
import time

from math import sqrt, ceil

from rig.place_and_route import allocate, route, Cores, Machine
from rig.place_and_route.place.rand import place
from rig.netlist import Net

# Generate a network with regular nearest-neighbour torus connectivity
num_vertices = 10000
w = h = int(ceil(sqrt(num_vertices)))
vertices = [(x, y) for x in range(w) for y in range(h)]
nets = [Net((x, y), [((x+dx)%w, (y+dy)%h) for dx, dy in offsets])
        for x, y in vertices
        for offsets in ([(3, 0), (0, 3), (-3, 0), (0, -3)],
                        [(2, 2), (-2, 2), (-2, -2), (2, -2)])]

# Generate P&R data-structures and manually place the network
vertices_resources = {v: {Cores: 18} for v in vertices}
placements = {v: v for v in vertices}
machine = Machine(w, h)

# Perform a few runs and time the routing time
for _ in range(5):
    allocations = allocate(vertices_resources, nets, machine, [], placements)
    before = time.time()
    routes = route(vertices_resources, nets, machine, [], placements, allocations)
    print("Routed in {} seconds".format(time.time() - before))
```

Before these changes (2f0018a):

    Routed in 10.543296813964844 seconds
    Routed in 10.643112182617188 seconds
    Routed in 10.55341911315918 seconds
    Routed in 10.619398832321167 seconds
    Routed in 10.859185457229614 seconds

After applying tweaks 1-5 (294debd) things have sped up for the common case too!

    Routed in 7.551417112350464 seconds
    Routed in 7.183601140975952 seconds
    Routed in 7.2857115268707275 seconds
    Routed in 7.339511156082153 seconds
    Routed in 6.861915111541748 seconds

