### PR TITLE
Fix accidental-broadcast in circuit simulator example.

### DIFF
--- a/docs/source/circuit_sim_tutorial/05_circuit_simulation/circuit_simulator.py
+++ b/docs/source/circuit_sim_tutorial/05_circuit_simulation/circuit_simulator.py
@@ -292,10 +292,10 @@ class Simulator(object):
         """
         self._components.append(component)
 
-    def _new_wire(self, source, sinks=[]):
+    def _new_wire(self, source, sinks=None):
         """Create a new :py:class:`._Wire` with a unique routing key."""
         # Assign sequential routing key to new nets.
-        wire = _Wire(source, sinks, len(self._wires))
+        wire = _Wire(source, sinks if sinks is not None else [], len(self._wires))
         self._wires.append(wire)
 
         return wire


### PR DESCRIPTION
A classic Python beginner's error: defining a function with a default argument
set to an empty list. As a result, every Wire created is connected to *every*
input in the circuit. How embarrassing.

For small circuits this bug doesn't break anything  since gates ignore packets
with unrecognised keys (hence not being spotted earlier) but for larger
circuits you get dreadful network contention...