### PR TITLE
Add Reverse Cuthill-McKee (RCM) placement algorithm

### DIFF
--- a/docs/source/place_and_route/placement_algorithms.rst
+++ b/docs/source/place_and_route/placement_algorithms.rst
@@ -3,10 +3,12 @@ Placement algorithms
 
 .. autofunction:: rig.place_and_route.place.sa.place
 
-.. autofunction:: rig.place_and_route.place.sequential.place
+.. autofunction:: rig.place_and_route.place.rcm.place
+
+.. autofunction:: rig.place_and_route.place.hilbert.place
 
 .. autofunction:: rig.place_and_route.place.breadth_first.place
 
-.. autofunction:: rig.place_and_route.place.hilbert.place
+.. autofunction:: rig.place_and_route.place.sequential.place
 
 .. autofunction:: rig.place_and_route.place.rand.place

--- a/rig/place_and_route/place/rcm.py
+++ b/rig/place_and_route/place/rcm.py
@@ -1,0 +1,171 @@
+"""Reverse Cuthill-McKee based placement.
+"""
+
+from collections import defaultdict
+
+from six import itervalues
+
+from rig.place_and_route.place.sequential import place as sequential_place
+from rig.links import Links
+from rig.netlist import Net
+
+
+def _get_vertices_neighbours(nets):
+    """Generate a listing of each vertex's immedate neighbours in an undirected
+    interpretation of a graph.
+
+    Returns
+    -------
+    {vertex: {vertex: weight, ...}), ...}
+    """
+    zero_fn = (lambda: 0)
+    vertices_neighbours = defaultdict(lambda: defaultdict(zero_fn))
+    for net in nets:
+        if net.weight != 0:
+            for sink in net.sinks:
+                vertices_neighbours[net.source][sink] += net.weight
+                vertices_neighbours[sink][net.source] += net.weight
+    return vertices_neighbours
+
+
+def _dfs(vertex, vertices_neighbours, _visited=None):
+    """Generate all the vertices connected to the supplied vertex in
+    depth-first-search order.
+    """
+    if _visited is None:
+        _visited = set()
+
+    yield vertex
+    _visited.add(vertex)
+
+    for neighbour in vertices_neighbours[vertex]:
+        if neighbour not in _visited:
+            for vertex in _dfs(neighbour, vertices_neighbours, _visited):
+                yield vertex
+
+
+def _get_connected_subgraphs(vertices, vertices_neighbours):
+    """Break a graph containing unconnected subgraphs into a list of connected
+    subgraphs.
+
+    Returns
+    -------
+    [set([vertex, ...]), ...]
+    """
+    remaining_vertices = set(vertices)
+    subgraphs = []
+    while remaining_vertices:
+        subgraph = set(_dfs(remaining_vertices.pop(), vertices_neighbours))
+        remaining_vertices.difference_update(subgraph)
+        subgraphs.append(subgraph)
+
+    return subgraphs
+
+
+def _cuthill_mckee(vertices, vertices_neighbours):
+    """Yield the Cuthill-McKee order for a connected, undirected graph.
+
+    `Wikipedia
+    <https://en.wikipedia.org/wiki/Cuthill%E2%80%93McKee_algorithm>`_ provides
+    a good introduction to the Cuthill-McKee algorithm. The RCM algorithm
+    attempts to order vertices in a graph such that their adjacency matrix's
+    bandwidth is reduced. In brief the RCM algorithm is a breadth-first search
+    with the following tweaks:
+
+    * The search starts from the vertex with the lowest degree.
+    * Vertices discovered in each layer of the search are sorted by ascending
+      order of their degree in the output.
+
+    .. warning::
+
+        This function must not be called on a disconnected or empty graph.
+
+    Returns
+    -------
+    [vertex, ...]
+    """
+    vertices_degrees = {v: sum(itervalues(vertices_neighbours[v]))
+                        for v in vertices}
+
+    peripheral_vertex = min(vertices, key=(lambda v: vertices_degrees[v]))
+
+    visited = set([peripheral_vertex])
+    cm_order = [peripheral_vertex]
+    previous_layer = set([peripheral_vertex])
+    while len(cm_order) < len(vertices):
+        adjacent = set()
+        for vertex in previous_layer:
+            adjacent.update(vertices_neighbours[vertex])
+        adjacent.difference_update(visited)
+
+        visited.update(adjacent)
+        cm_order.extend(sorted(adjacent, key=(lambda v: vertices_degrees[v])))
+        previous_layer = adjacent
+
+    return cm_order
+
+
+def rcm_vertex_order(vertices_resources, nets):
+    """A generator which iterates over the vertices in Reverse-Cuthill-McKee
+    order.
+
+    For use as a vertex ordering for the sequential placer.
+    """
+    vertices_neighbours = _get_vertices_neighbours(nets)
+    for subgraph_vertices in _get_connected_subgraphs(vertices_resources,
+                                                      vertices_neighbours):
+        cm_order = _cuthill_mckee(subgraph_vertices, vertices_neighbours)
+        for vertex in reversed(cm_order):
+            yield vertex
+
+
+def rcm_chip_order(machine):
+    """A generator which iterates over a set of chips in a machine in
+    Reverse-Cuthil-McKee order.
+
+    For use as a chip ordering for the sequential placer.
+    """
+    # Convert the Machine description into a placement-problem-style-graph
+    vertices = list(machine)
+    nets = []
+    for (x, y) in vertices:
+        neighbours = []
+        for link in Links:
+            if (x, y, link) in machine:
+                dx, dy = link.to_vector()
+                neighbours.append(((x + dx) % machine.width,
+                                   (y + dy) % machine.height))
+        nets.append(Net((x, y), neighbours))
+
+    return rcm_vertex_order(vertices, nets)
+
+
+def place(vertices_resources, nets, machine, constraints):
+    """Assigns vertices to chips in Reverse-Cuthill-McKee (RCM) order.
+
+    The `RCM <https://en.wikipedia.org/wiki/Cuthill%E2%80%93McKee_algorithm>`_
+    algorithm (in graph-centric terms) is a simple breadth-first-search-like
+    heuristic which attempts to yield an ordering of vertices which would yield
+    a 1D placement with low network congestion.  Placement is performed by
+    sequentially assigning vertices in RCM order to chips, also iterated over
+    in RCM order.
+
+    This simple placement scheme is described by Torsten Hoefler and Marc Snir
+    in their paper entitled 'Generic topology mapping strategies for
+    large-scale parallel architectures' published in the Proceedings of the
+    international conference on Supercomputing, 2011.
+
+    This is a thin wrapper around the :py:func:`sequential
+    <rig.place_and_route.place.sequential.place>` placement algorithm which
+    uses an RCM ordering for iterating over chips and vertices.
+
+    Parameters
+    ----------
+    breadth_first : bool
+        Should vertices be placed in breadth first order rather than the
+        iteration order of vertices_resources. True by default.
+    """
+    return sequential_place(vertices_resources, nets,
+                            machine, constraints,
+                            rcm_vertex_order(vertices_resources, nets),
+                            rcm_chip_order(machine))

--- a/rig/place_and_route/place/rcm.py
+++ b/rig/place_and_route/place/rcm.py
@@ -121,11 +121,15 @@ def rcm_vertex_order(vertices_resources, nets):
 
 def rcm_chip_order(machine):
     """A generator which iterates over a set of chips in a machine in
-    Reverse-Cuthil-McKee order.
+    Reverse-Cuthill-McKee order.
 
     For use as a chip ordering for the sequential placer.
     """
     # Convert the Machine description into a placement-problem-style-graph
+    # where the vertices are chip coordinate tuples (x, y) and each net
+    # represents the links leaving each chip. This allows us to re-use the
+    # rcm_vertex_order function above to generate an RCM ordering of chips in
+    # the machine.
     vertices = list(machine)
     nets = []
     for (x, y) in vertices:

--- a/rig/place_and_route/place/rcm.py
+++ b/rig/place_and_route/place/rcm.py
@@ -133,8 +133,15 @@ def rcm_chip_order(machine):
         for link in Links:
             if (x, y, link) in machine:
                 dx, dy = link.to_vector()
-                neighbours.append(((x + dx) % machine.width,
-                                   (y + dy) % machine.height))
+                neighbour = ((x + dx) % machine.width,
+                             (y + dy) % machine.height)
+
+                # In principle if the link to chip is marked as working, that
+                # chip should be working. In practice this might not be the
+                # case (especially for carelessly hand-defined Machine
+                # objects).
+                if neighbour in machine:
+                    neighbours.append(neighbour)
         nets.append(Net((x, y), neighbours))
 
     return rcm_vertex_order(vertices, nets)

--- a/tests/place_and_route/place/test_generic_place.py
+++ b/tests/place_and_route/place/test_generic_place.py
@@ -31,6 +31,7 @@ from rig.place_and_route.place.breadth_first \
 from rig.place_and_route.place.hilbert import place as hilbert_place
 from rig.place_and_route.place.sa import place as sa_place
 from rig.place_and_route.place.rand import place as rand_place
+from rig.place_and_route.place.rcm import place as rcm_place
 
 from rig.place_and_route.place.sa.python_kernel import PythonKernel
 
@@ -58,7 +59,8 @@ ALGORITHMS_UNDER_TEST = [(default_place, {}),
                          # Testing with effort = 0 tests the initial (random)
                          # placement solutions of the SA placer.
                          (sa_place, {"effort": 0.0}),
-                         (rand_place, {})]
+                         (rand_place, {}),
+                         (rcm_place, {})]
 
 
 @pytest.mark.parametrize("algorithm,kwargs", ALGORITHMS_UNDER_TEST)

--- a/tests/place_and_route/place/test_rcm.py
+++ b/tests/place_and_route/place/test_rcm.py
@@ -190,12 +190,12 @@ def test_rcm_vertex_order():
     vertices_resources = {v0: {}, v1: {}, v2: {}, v3: {}}
     nets = [Net(v0, v1), Net(v2, v3)]
     assert list(rcm_vertex_order(vertices_resources, nets)) in (
-        # v1 & v2 first, all possible orders of each pair
+        # v0 & v1 first, all possible orders of each pair
         [v0, v1, v2, v3],
         [v0, v1, v3, v2],
         [v1, v0, v2, v3],
         [v1, v0, v3, v2],
-        # v3 & v4 first, all possible orders of each pair
+        # v2 & v3 first, all possible orders of each pair
         [v2, v3, v0, v1],
         [v3, v2, v0, v1],
         [v2, v3, v1, v0],

--- a/tests/place_and_route/place/test_rcm.py
+++ b/tests/place_and_route/place/test_rcm.py
@@ -1,0 +1,213 @@
+from rig.place_and_route import Machine
+from rig.netlist import Net
+
+from rig.place_and_route.place.rcm import \
+    _get_vertices_neighbours, _dfs, _get_connected_subgraphs, _cuthill_mckee, \
+    rcm_vertex_order, rcm_chip_order
+
+
+def test_get_vertices_neighbours():
+    # Empty problem
+    assert _get_vertices_neighbours([]) == {}
+
+    # Single net should be made bidirectional.
+    v0 = "v0"
+    v1 = "v1"
+    nets = [Net(v0, v1, 2.5)]
+    assert _get_vertices_neighbours(nets) == {
+        v0: {v1: 2.5},
+        v1: {v0: 2.5},
+    }
+
+    # Nets should be summed, in both directions
+    v0 = "v0"
+    v1 = "v1"
+    nets = [Net(v0, v1, 2.5), Net(v1, v0, 0.5)]
+    assert _get_vertices_neighbours(nets) == {
+        v0: {v1: 3.0},
+        v1: {v0: 3.0},
+    }
+
+    # Self-connections should be allowed (and note that their weight doubles in
+    # the same way that other nets gain double their overall weight by becoming
+    # bidirectional).
+    v0 = "v0"
+    v1 = "v1"
+    nets = [Net(v0, [v0, v1], 2.5), Net(v1, v0, 0.5)]
+    assert _get_vertices_neighbours(nets) == {
+        v0: {v0: 5.0, v1: 3.0},
+        v1: {v0: 3.0},
+    }
+
+    # Multicast nets should be rendered as point-to-point relationships between
+    # the source and each sink (rather than an all-to-all connectivity between
+    # vertices in the same multicast net).
+    v0 = "v0"
+    v1 = "v1"
+    v2 = "v2"
+    nets = [Net(v0, [v1, v2], 2.5)]
+    assert _get_vertices_neighbours(nets) == {
+        v0: {v1: 2.5, v2: 2.5},
+        v1: {v0: 2.5},
+        v2: {v0: 2.5},
+    }
+
+    # Zero-weight nets should be omitted
+    v0 = "v0"
+    v1 = "v1"
+    nets = [Net(v0, v1, 0)]
+    assert _get_vertices_neighbours(nets) == {}
+
+    # Non-connected vertices should also 'appear' in the output (thanks to
+    # defaultdict)
+    v0 = "v0"
+    v1 = "v1"
+    v2 = "v2"
+    nets = [Net(v0, v1, 2.5)]
+    vertices_neighbours = _get_vertices_neighbours(nets)
+    assert vertices_neighbours == {
+        v0: {v1: 2.5},
+        v1: {v0: 2.5},
+    }
+    assert vertices_neighbours[v2] == {}
+
+
+def test_dfs():
+    # No neighbours at all!
+    v0 = "v0"
+    assert set(_dfs(v0, {v0: {}})) == set([v0])
+
+    # Disconnected subgraph should not be found
+    v0 = "v0"
+    v1 = "v1"
+    v2 = "v2"
+    v3 = "v3"
+    v4 = "v4"
+    v5 = "v5"
+    vertices_neighbours = {
+        v0: {v1: 1.0}, v1: {v0: 1.0},
+        v1: {v2: 1.0, v3: 1.0}, v2: {v1: 1.0}, v3: {v1: 1.0},
+        v4: {v5: 1.0}, v5: {v4: 1.0},
+    }
+    assert set(_dfs(v0, vertices_neighbours)) == set([v0, v1, v2, v3])
+    assert set(_dfs(v4, vertices_neighbours)) == set([v4, v5])
+
+    # Cycles shouldn't break things
+    v0 = "v0"
+    v1 = "v1"
+    v2 = "v2"
+    vertices_neighbours = {
+        v0: {v1: 1.0, v2: 1.0},
+        v1: {v2: 1.0, v0: 1.0},
+        v2: {v0: 1.0, v1: 1.0},
+    }
+    assert set(_dfs(v0, vertices_neighbours)) == set([v0, v1, v2])
+
+
+def test_get_connected_subgraphs():
+    # Empty graph
+    assert _get_connected_subgraphs([], {}) == []
+
+    # Singleton node
+    assert _get_connected_subgraphs(["v0"], {"v0": {}}) == [set(["v0"])]
+
+    # Unconnected singletons
+    subgraphs = _get_connected_subgraphs(["v0", "v1"], {"v0": {}, "v1": {}})
+    assert len(subgraphs) == 2
+    assert set(["v0"]) in subgraphs
+    assert set(["v1"]) in subgraphs
+
+    # Connected pair
+    v0 = "v0"
+    v1 = "v1"
+    vertices = [v0, v1]
+    vertices_neighbours = {v0: {v1: 1.0}, v1: {v0: 1.0}}
+    assert _get_connected_subgraphs(vertices, vertices_neighbours) ==\
+        [set([v0, v1])]
+
+    # A pair of vertex pairs
+    v0 = "v0"
+    v1 = "v1"
+    v2 = "v2"
+    v3 = "v3"
+    vertices = [v0, v1, v2, v3]
+    vertices_neighbours = {v0: {v1: 1.0}, v1: {v0: 1.0},
+                           v2: {v3: 1.0}, v3: {v2: 1.0}}
+    subgraphs = _get_connected_subgraphs(vertices, vertices_neighbours)
+    assert len(subgraphs) == 2
+    assert set([v0, v1]) in subgraphs
+    assert set([v2, v3]) in subgraphs
+
+
+def test_cuthill_mckee():
+    # Singleton
+    v0 = "v0"
+    assert _cuthill_mckee([v0], {v0: {}}) == [v0]
+
+    # Test a case with a trivial and consistent solution: A linear chain of
+    # vertices connected by weights of increasing value should be ordered in
+    # ascending link order.
+    num = 10
+    vs = ["v{}".format(n) for n in range(num)]
+    vertices_neighbours = {v: {} for v in vs}
+    for i in range(num - 1):
+        vertices_neighbours[vs[i]][vs[i + 1]] = i + 1.0
+        vertices_neighbours[vs[i + 1]][vs[i]] = i + 1.0
+    assert _cuthill_mckee(vs, vertices_neighbours) == vs
+
+
+def test_rcm_vertex_order():
+    # Empty
+    assert list(rcm_vertex_order({}, [])) == []
+
+    # Single vertex
+    v0 = "v0"
+    assert list(rcm_vertex_order({v0: {}}, [])) == [v0]
+
+    # Disconnected pair of vertices
+    v0 = "v0"
+    v1 = "v1"
+    assert list(rcm_vertex_order({v0: {}, v1: {}}, [])) in (
+        [v0, v1],
+        [v1, v0],
+    )
+
+    # Connected pair of vertices
+    v0 = "v0"
+    v1 = "v1"
+    vertices_resources = {v0: {}, v1: {}}
+    nets = [Net(v0, v1)]
+    assert list(rcm_vertex_order(vertices_resources, nets)) in (
+        [v0, v1],
+        [v1, v0],
+    )
+
+    # Seperate pairs of vertices
+    v0 = "v0"
+    v1 = "v1"
+    v2 = "v2"
+    v3 = "v3"
+    vertices_resources = {v0: {}, v1: {}, v2: {}, v3: {}}
+    nets = [Net(v0, v1), Net(v2, v3)]
+    assert list(rcm_vertex_order(vertices_resources, nets)) in (
+        # v1 & v2 first, all possible orders of each pair
+        [v0, v1, v2, v3],
+        [v0, v1, v3, v2],
+        [v1, v0, v2, v3],
+        [v1, v0, v3, v2],
+        # v3 & v4 first, all possible orders of each pair
+        [v2, v3, v0, v1],
+        [v3, v2, v0, v1],
+        [v2, v3, v1, v0],
+        [v3, v2, v1, v0],
+    )
+
+
+def test_rcm_chip_order():
+    # Singleton
+    m = Machine(1, 1)
+    assert list(rcm_chip_order(m)) == [(0, 0)]
+
+    # Many chips
+    m = Machine(4, 2)
+    assert sorted(rcm_chip_order(m)) == sorted(m)

--- a/tests/place_and_route/place/test_rcm.py
+++ b/tests/place_and_route/place/test_rcm.py
@@ -211,3 +211,9 @@ def test_rcm_chip_order():
     # Many chips
     m = Machine(4, 2)
     assert sorted(rcm_chip_order(m)) == sorted(m)
+
+    # With dead chips which can be reached by 'working' links. Should not
+    # happen in practice but often appear in hand-written 'fake' Machine
+    # objects...
+    m = Machine(4, 2, dead_chips={(2, 1)})
+    assert sorted(rcm_chip_order(m)) == sorted(m)


### PR DESCRIPTION
This simple breadth-first-search-like sequential placer can be found in the software placement literature and is believed to perform a reasonable job of placing pipeline-like things.

Sorry to drop you in reviewing this clearly thesis-specific change @mundya ...