### PR TITLE
Fix sequential placer SameChipConstraint edge-cases.

### DIFF
--- a/rig/place_and_route/place/sequential.py
+++ b/rig/place_and_route/place/sequential.py
@@ -101,14 +101,17 @@ def place(vertices_resources, nets, machine, constraints,
         # Must modify the vertex_order to substitute the merged vertices
         # inserted by apply_reserve_resource_constraint.
         vertex_order = list(vertex_order)
-        for merged_vertex in reversed(substitutions):
+        for merged_vertex in substitutions:
             # Swap the first merged vertex for its MergedVertex object and
             # remove all other vertices from the merged set
             vertex_order[vertex_order.index(merged_vertex.vertices[0])] \
                 = merged_vertex
             # Remove all other vertices in the MergedVertex
+            already_removed = set([merged_vertex.vertices[0]])
             for vertex in merged_vertex.vertices[1:]:
-                vertex_order.remove(vertex)
+                if vertex not in already_removed:
+                    vertex_order.remove(vertex)
+                    already_removed.add(vertex)
 
     # The set of vertices which have not been constrained, in iteration order
     movable_vertices = (v for v in (vertices_resources


### PR DESCRIPTION
Prior to this fix, if a placement problem contains overlapping or duplicate-containing `SameChipConstraints`, the `sequential` placer (and thus all other placers built on it, e.g. `hilbert` and `breadth_first`) would fall over.

Though these smell of 'edge-case' they are actually very common in PyNN SpiNNaker's netlists...  The generic placer test suite has been updated with a test case which include these behaviours..