### PR TITLE
Add optimised RouteSet data type

### DIFF
--- a/rig/routing_table/__init__.py
+++ b/rig/routing_table/__init__.py
@@ -1,5 +1,5 @@
 # Basic routing table datastructures
-from rig.routing_table.entries import RoutingTableEntry, Routes
+from rig.routing_table.entries import RoutingTableEntry, Routes, RouteSet
 
 # Common exceptions produced by algorithms in this module
 from rig.routing_table.exceptions import (MinimisationFailedError,

--- a/rig/routing_table/utils.py
+++ b/rig/routing_table/utils.py
@@ -1,6 +1,7 @@
 from collections import defaultdict, namedtuple, OrderedDict
 
-from rig.routing_table import RoutingTableEntry, MultisourceRouteError
+from rig.routing_table import (
+    RoutingTableEntry, MultisourceRouteError, RouteSet)
 from six import iteritems
 import warnings
 
@@ -69,7 +70,8 @@ def routing_tree_to_tables(routes, net_keys):
             else:
                 # Otherwise create a new route set
                 route_sets[(x, y)][(key, mask)] = \
-                    InOutPair({in_direction}, set(out_directions))
+                    InOutPair(RouteSet({in_direction}),
+                              RouteSet(out_directions))
 
     # Construct the routing tables from the route sets
     routing_tables = defaultdict(list)


### PR DESCRIPTION
Adds a new RouteSet data type that should reduce the amount of memory required to represent the 'source' and 'destination' fields of routing table entries, and should speed up construction of routing tables from routing trees.

 - [ ] Make use of this data structure when writing routing tables to SpiNNaker
 - [ ] Make use of structure when unpacking routing tables from SpiNNaker
 - [ ] Check there are no instances where the assumption that a `RoutingTableEntry` or the structures in routing table construction break when given one of these items rather than a set - @mossblaser?