### PR TITLE
Scale HPWL by sqrt(n) in SA placer.

### DIFF
--- a/rig/place_and_route/place/sa/python_kernel.py
+++ b/rig/place_and_route/place/sa/python_kernel.py
@@ -191,7 +191,8 @@ def _net_cost(net, placements, has_wrap_around_links, machine):
 
         return (((machine.width - x_max_delta) +
                  (machine.height - y_max_delta)) *
-                net.weight)
+                net.weight *
+                math.sqrt(len(net.sinks) + 1))
     else:
         # When no wrap-around links, find the bounding box around the vertices
         # in the net and return the HPWL weighted by the net weight.
@@ -203,7 +204,9 @@ def _net_cost(net, placements, has_wrap_around_links, machine):
             x2 = x if x > x2 else x2
             y2 = y if y > y2 else y2
 
-        return ((x2 - x1) + (y2 - y1)) * float(net.weight)
+        return (((x2 - x1) + (y2 - y1)) *
+                float(net.weight) *
+                math.sqrt(len(net.sinks) + 1))
 
 
 def _vertex_net_cost(vertex, v2n, placements, has_wrap_around_links, machine):

--- a/tests/place_and_route/place/sa/test_python_kernel.py
+++ b/tests/place_and_route/place/sa/test_python_kernel.py
@@ -2,6 +2,8 @@ import pytest
 
 from itertools import cycle
 
+from math import sqrt
+
 from mock import Mock, call
 
 from six import iteritems, next
@@ -39,23 +41,23 @@ def test__net_cost_no_wrap():
     # Should report cost 1 for a net to a chip one cell away
     assert pk._net_cost(Net(l2v[(1, 1)][0],
                             l2v[(1, 0)][0]),
-                        placements, False, machine) == 1.0
+                        placements, False, machine) == 1.0 * sqrt(2)
     assert pk._net_cost(Net(l2v[(1, 1)][0],
                             l2v[(2, 1)][0]),
-                        placements, False, machine) == 1.0
+                        placements, False, machine) == 1.0 * sqrt(2)
 
     # Should report cost for a square net
     assert pk._net_cost(Net(l2v[(1, 1)][0],
                             l2v[(2, 2)][0]),
-                        placements, False, machine) == 2.0
+                        placements, False, machine) == 2.0 * sqrt(2)
     assert pk._net_cost(Net(l2v[(0, 0)][0],
                             l2v[(2, 2)][0]),
-                        placements, False, machine) == 4.0
+                        placements, False, machine) == 4.0 * sqrt(2)
 
     # Should account for the weight
     assert pk._net_cost(Net(l2v[(0, 0)][0],
                             l2v[(2, 2)][0], 0.5),
-                        placements, False, machine) == 4.0 / 2.0
+                        placements, False, machine) == 4.0 * 0.5 * sqrt(2)
 
 
 def test__net_cost_with_wrap():
@@ -80,34 +82,34 @@ def test__net_cost_with_wrap():
     # Should report cost 1 for a net to a chip one cell away
     assert pk._net_cost(Net(l2v[(1, 1)][0],
                             l2v[(1, 0)][0]),
-                        placements, True, machine) == 1.0
+                        placements, True, machine) == 1.0 * sqrt(2)
     assert pk._net_cost(Net(l2v[(1, 1)][0],
                             l2v[(2, 1)][0]),
-                        placements, True, machine) == 1.0
+                        placements, True, machine) == 1.0 * sqrt(2)
     # ...with wrapping
     assert pk._net_cost(Net(l2v[(2, 2)][0],
                             l2v[(2, 0)][0]),
-                        placements, True, machine) == 1.0
+                        placements, True, machine) == 1.0 * sqrt(2)
     assert pk._net_cost(Net(l2v[(2, 2)][0],
                             l2v[(0, 2)][0]),
-                        placements, True, machine) == 1.0
+                        placements, True, machine) == 1.0 * sqrt(2)
 
     # Should report cost for a square net
     assert pk._net_cost(Net(l2v[(1, 1)][0],
                             l2v[(2, 2)][0]),
-                        placements, True, machine) == 2.0
+                        placements, True, machine) == 2.0 * sqrt(2)
     assert pk._net_cost(Net(l2v[(0, 0)][0],
                             [l2v[(1, 1)][0], l2v[(2, 2)][0]]),
-                        placements, True, machine) == 4.0
+                        placements, True, machine) == 4.0 * sqrt(3)
     # With wrapping
     assert pk._net_cost(Net(l2v[(0, 0)][0],
                             l2v[(2, 2)][0]),
-                        placements, True, machine) == 2.0
+                        placements, True, machine) == 2.0 * sqrt(2)
 
     # Should account for the weight
     assert pk._net_cost(Net(l2v[(0, 0)][0],
                             l2v[(2, 2)][0], 0.5),
-                        placements, True, machine) == 2.0 / 2.0
+                        placements, True, machine) == 2.0 * 0.5 * sqrt(2)
 
 
 @pytest.mark.parametrize("resources,expectation",


### PR DESCRIPTION
This change makes the cost estimation function used by the SA placer more
accurate resulting in marginally better placements (see
project-rig/rig_c_sa#4).