### PR TITLE
Fix ordering of flood-fill regions

### DIFF
--- a/rig/machine_control/regions.py
+++ b/rig/machine_control/regions.py
@@ -80,7 +80,7 @@ def compress_flood_fill_regions(targets):
         for p in cores:
             t.add_core(x, y, p)
 
-    return t.get_regions_and_coremasks()
+    return sorted(t.get_regions_and_coremasks())
 
 
 class RegionCoreTree(object):

--- a/tests/machine_control/test_regions.py
+++ b/tests/machine_control/test_regions.py
@@ -82,7 +82,6 @@ def test_get_regions_and_cores_for_floodfill_ordering():
     }
 
     # Test the ordering across the subregions
-    seen_fills = collections.defaultdict(set)
     last = (0, 0)
     for (region, cores) in compress_flood_fill_regions(targets):
         assert (region, cores) >= last

--- a/tests/machine_control/test_regions.py
+++ b/tests/machine_control/test_regions.py
@@ -43,10 +43,10 @@ def test_get_regions_and_cores_for_floodfill():
 
     # Test
     seen_fills = collections.defaultdict(set)
-    last = 0
+    last = (0, 0)
     for (region, cores) in compress_flood_fill_regions(targets):
-        assert (region << 32) | cores >= last
-        last = (region << 32) | cores
+        assert (region, cores) >= last
+        last = (region, cores)
 
         # Extract the data from the region
         level = (region >> 16) & 0x3
@@ -66,6 +66,27 @@ def test_get_regions_and_cores_for_floodfill():
                         {i for i in range(18) if cores & (1 << i)})
 
     assert seen_fills == targets
+
+
+def test_get_regions_and_cores_for_floodfill_ordering():
+    """This test explicitly checks that ordering across subregions works
+    correctly. Two level-3 regions are created in the level-2 region
+    originating at (0, 0). Importantly these two lower-level regions are
+    arranged in increasing order on the x-axis. A further level-3 region is
+    then created *in a different level-2 subregion* at x=0 and y=64.
+    """
+    targets = {
+        (0, 0): {1},
+        (4, 0): {1},
+        (0, 64): {1},
+    }
+
+    # Test the ordering across the subregions
+    seen_fills = collections.defaultdict(set)
+    last = (0, 0)
+    for (region, cores) in compress_flood_fill_regions(targets):
+        assert (region, cores) >= last
+        last = (region, cores)
 
 
 class TestRegionCoreTree(object):


### PR DESCRIPTION
This is a bug that only appears with flood fills of large machines,
which is why it has only just shown up. The problem occurs because a
RegionTree iterates over its subregions recursively, whereas the entire
tree should be iterated over in increasing y before x.

For example, the selected regions:

	.... .... .... ....
	.... .... .... ....
	.... .... .... ....
	2... .... .... ....

	.... .... .... ....
	.... .... .... ....
	.... .... .... ....
	13.. .... .... ....

Should be produced in the order (1, 2, 3) but are actually produced in
the order (1, 3, 2) causing SC&MP to ignore region transmitted after 2.

This commit fixes the problem by including an additional call to
`sorted` in `compress_flood_fill_regions`. Ideally some better iteration
over the tree could be implemented. This needs further thought so I
suggest this fix for now.

Thanks to @lplana for bringing this bug to my attention.