### PR TITLE
Fix bug in machine boot kwargs

### DIFF
--- a/rig/machine_control/boot.py
+++ b/rig/machine_control/boot.py
@@ -62,7 +62,7 @@ spin5_boot_options = {
 def boot(hostname, boot_port=consts.BOOT_PORT,
          scamp_binary=None, sark_struct=None,
          boot_delay=0.05, post_boot_delay=2.0,
-         **sv_overrides):
+         sv_overrides=dict(), **kwargs):
     """Boot a SpiNNaker machine of the given size.
 
     Parameters
@@ -83,9 +83,9 @@ def boot(hostname, boot_port=consts.BOOT_PORT,
         Number of seconds to wait after sending last piece of boot data to give
         SC&MP time to re-initialise the Ethernet interface. Note that this does
         *not* wait for the system to fully boot.
-    **sv_overrides : {name: value, ...}
-        Any additional keyword arguments may be used to override the default
-        values in the 'sv' struct defined in the struct file.
+    sv_overrides : {name: value, ...}
+        Values used to override the defaults in the 'sv' struct defined in the
+        struct file.
 
     Notes
     -----
@@ -115,6 +115,7 @@ def boot(hostname, boot_port=consts.BOOT_PORT,
         struct_data = f.read()
     structs = struct_file.read_struct_file(struct_data)
     sv = structs[b"sv"]
+    sv_overrides.update(kwargs)  # Allow non-explicit keyword arguments for SV
     sv.update_default_values(**sv_overrides)
     sv.update_default_values(unix_time=int(time.time()),
                              boot_sig=int(time.time()),

--- a/rig/machine_control/machine_controller.py
+++ b/rig/machine_control/machine_controller.py
@@ -302,9 +302,9 @@ class MachineController(ContextMixin):
             fully booted before returning. If False, this check is skipped and
             the function returns as soon as the machine's Ethernet interface is
             likely to be up (but not necessarily before booting has completed).
-        **sv_overrides : {name: value, ...}
-            Any additional keyword arguments may be used to override the
-            default values in the 'sv' struct defined in the struct file.
+        sv_overrides : {name: value, ...}
+            Additional arguments used to override the default values in the
+            'sv' struct defined in the struct file.
 
         Returns
         -------


### PR DESCRIPTION
Some of the keyword arguments used to boot SpiNNaker machines were overloaded. In particular, `boot_delay` is present both in the `sv` struct and in the list of arguments expected by `boot`. This commit fixes this issue by making it possible to set the SV overrides explicitly.

Note that the API changes are backwards compatible, this only adds to the commands accepted by `boot`.

---

### Example of problem

```python
mc.boot(boot_delay=10) 
```

If it was intended that this value were used to modify the value in the SV struct this will not happen. Instead the value of `boot_delay` is used to change the delay between transmitting boot packets to the SpiNNaker machine.

After this commit the correct call is

```python
mc.boot(sv_overrides={"boot_delay": 10})
```

### Tests

This is hard to test well, so I've opted for not adding further tests. I can probably be persuaded to change my mind.

Thanks @lplana for spotting this!