### PR TITLE
Indicate if the tag is in use when allocating SDRAM fails

### DIFF
--- a/rig/machine_control/consts.py
+++ b/rig/machine_control/consts.py
@@ -109,6 +109,7 @@ class SCPReturnCodes(enum.IntEnum):
     p2p_timeout = 0x8e  # Eth chip <--> destination comms timeout (Fatal)
     pkt_tx = 0x8f  # Pkt Tx failed (Fatal)
 
+
 RETRYABLE_SCP_RETURN_CODES = set([
     SCPReturnCodes.sum,
     SCPReturnCodes.p2p_busy,

--- a/tests/place_and_route/place/test_rcm.py
+++ b/tests/place_and_route/place/test_rcm.py
@@ -85,8 +85,8 @@ def test_dfs():
     v4 = "v4"
     v5 = "v5"
     vertices_neighbours = {
-        v0: {v1: 1.0}, v1: {v0: 1.0},
-        v1: {v2: 1.0, v3: 1.0}, v2: {v1: 1.0}, v3: {v1: 1.0},
+        v0: {v1: 1.0},
+        v1: {v0: 1.0, v2: 1.0, v3: 1.0}, v2: {v1: 1.0}, v3: {v1: 1.0},
         v4: {v5: 1.0}, v5: {v4: 1.0},
     }
     assert set(_dfs(v0, vertices_neighbours)) == set([v0, v1, v2, v3])

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -162,6 +162,7 @@ def test_shortest_mesh_path():
             assert shortest_mesh_path(end, start) == neg_minimised, \
                 (end, start, neg_minimised)
 
+
 # A series of hexagonal vectors along with their possibly multiple (torus)
 # minimal counterparts in the specified torus size for testing hexagonal
 # coordinate minimisation-related functions.


### PR DESCRIPTION
Allocating SDRAM can fail either because there is insufficient memory available or because the requested tag is already in use. This commit modifies the `sdram_alloc` method so that it reads the allocation table to determine the cause of the failure and reports this in the error that is raised.

This should make diagnosing memory allocation failures easier.

In addition some Flake8 fixes, and Flake8 threw up a fault in a test which I *might* have fixed correctly. @mossblaser would you mind glancing at the last commit if you have time?