### PR TITLE
Fix C SA LocationConstraints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ install:
         - python setup.py install
         - pip install -r requirements-test.txt
         - pip install codecov
-        - pip install spinnaker_proxy
-before_script:
-        - spinnaker_proxy.py -qct cspc276.cs.man.ac.uk &
-        - export SPINNAKER_PROXY_PID=$!
 script:
         # Run the main test suite against real hardware and against the
         # installed codebase. Note: since we're testing an installed version,
@@ -19,7 +15,7 @@ script:
         # './rig/'.
         - >
             py.test tests/ \
-                    --spinnaker localhost --spinn5 \
+                    --spinnaker spinn-4.cs.man.ac.uk --spinn5 \
                     --bmp spinn-4c.cs.man.ac.uk \
                     --cov "$(./utils/rig_path.py)" \
                     --cov tests \
@@ -32,10 +28,6 @@ script:
         - flake8 rig tests
 after_success:
         - codecov
-after_script:
-        - kill $SPINNAKER_PROXY_PID
-        - sleep 0.5
-        - kill -9 $SPINNAKER_PROXY_PID
 notifications:
         email: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ script:
                     --cov tests \
                     --durations=10
         # Run doctests in code
-        - py.test rig/ --doctest-modules
+        - py.test rig/ --doctest-modules -p no:warnings
         # Run doctests in documentation
         - py.test docs/ --doctest-glob='*_doctest.rst'
         # Code quality check

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -145,12 +145,10 @@ The test suite supports the following commandline arguments:
 
 Booting a SpiNNaker board requires the (reliable) sending of packets to UDP
 port 54321 which is frequently blocked by ISPs and is not reliable (since UDP
-gives no guarantees, especially on the open internet). As a result, a proxy
-server must be used to communicate with the board. A utility such as
-[`spinnaker_proxy`](https://github.com/project-rig/spinnaker_proxy) can be used
-alongside the test suite for this purpose.
-
-See the [Travis setup](.travis.yml) for an example of this in use.
+gives no guarantees, especially on the open internet). As a result on some
+networks, a proxy server must be used to communicate with the board. A utility
+such as [`spinnaker_proxy`](https://github.com/project-rig/spinnaker_proxy) can
+be used alongside the test suite for this purpose if required.
 
 ### Test coverage checking
 

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -91,12 +91,12 @@ will also detect packaging faults (e.g. omitted binaries & support files).
 
 Rigs tests are broken up into three groups which can be run as follows:
 
-    $ py.test tests                                # The Rig test-suite
-    $ py.test rig --doctest-modules                # Doctests in rig source code
-    $ py.test docs --doctest-glob='*_doctest.rst'  # Doctests in Sphinx
-                                                   # documentation whose
-                                                   # filename ends with
-                                                   # '_doctest.rst'.
+    $ py.test tests                                 # The Rig test-suite
+    $ py.test rig --doctest-modules -p no:warnings  # Doctests in rig source code
+    $ py.test docs --doctest-glob='*_doctest.rst'   # Doctests in Sphinx
+                                                    # documentation whose
+                                                    # filename ends with
+                                                    # '_doctest.rst'.
 
 Note: The first command only runs a subset of the full test suite which does not
 require an attached SpiNNaker board.

--- a/rig/place_and_route/place/sa/c_kernel.py
+++ b/rig/place_and_route/place/sa/c_kernel.py
@@ -60,9 +60,14 @@ class CKernel(object):
                 vertices_nets[vertex].add(net)
 
         # Create all vertices and set assign initial positions. Populates a map
-        # from Python vertex object to C sa_vertex_t pointer.
+        # from Python vertex object to C sa_vertex_t pointer. As required by
+        # the C interface, sorts vertices such that moveable vertices are
+        # listed before fixed ones.
+        movable_vertices_set = set(movable_vertices)  # For faster lookup
         self.vertices_c = {}
-        for i, vertex in enumerate(vertices_resources):
+        for i, vertex in enumerate(
+                sorted(vertices_resources,
+                       key=(lambda v: v not in movable_vertices_set))):
             # Create the vertex
             v = rig_c_sa.sa_new_vertex(self.s, len(vertices_nets[vertex]))
             assert v != ffi.NULL

--- a/rig/type_casts.py
+++ b/rig/type_casts.py
@@ -386,7 +386,7 @@ class NumpyFixToFloatConverter(object):
 
         >>> unsigned = np.array([0xf0], dtype=np.uint8)
         >>> kbits(unsigned)
-        array([ 15.])
+        array([15.])
     """
     def __init__(self, n_frac):
         """Create a new converter from fix-point to floating point

--- a/rig/type_casts.py
+++ b/rig/type_casts.py
@@ -385,8 +385,8 @@ class NumpyFixToFloatConverter(object):
         array([-1.])
 
         >>> unsigned = np.array([0xf0], dtype=np.uint8)
-        >>> kbits(unsigned)
-        array([15.])
+        >>> kbits(unsigned)[0]
+        15.0
     """
     def __init__(self, n_frac):
         """Create a new converter from fix-point to floating point

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-import _pytest
 
 from collections import defaultdict
 from toposort import toposort

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,10 +46,8 @@ def pytest_runtest_makereport(item, call):  # pragma: no cover
         if call.excinfo is not None:
             # Don't skip following tests if something was simply
             # skipped/xfailed.
-            # XXX: The pytest API for testing for skip/xfail is "lightly"
-            # defined. This will hopefully be cleaner in future versions.
-            if call.excinfo.type is not _pytest.runner.Skipped and \
-               call.excinfo.type is not _pytest.skipping.XFailed:
+            if call.excinfo.type is not pytest.skip and \
+               call.excinfo.type is not pytest.xfail:
                 parent = item.parent
                 parent._previousfailed = item
 

--- a/tests/machine_control/test_bmp_controller.py
+++ b/tests/machine_control/test_bmp_controller.py
@@ -128,8 +128,8 @@ class TestBMPControllerLive(object):
         assert 5.0 < adc.temp_btm < 100.0
         assert adc.temp_ext_0 is None or 5.0 < adc.temp_ext_0 < 100.0
         assert adc.temp_ext_1 is None or 5.0 < adc.temp_ext_1 < 100.0
-        assert adc.fan_0 is None or 0.0 < adc.fan_0 < 10000.0
-        assert adc.fan_1 is None or 0.0 < adc.fan_1 < 10000.0
+        assert adc.fan_0 is None or 0.0 <= adc.fan_0 < 10000.0
+        assert adc.fan_1 is None or 0.0 <= adc.fan_1 < 10000.0
 
 
 @pytest.mark.order_after("spinnaker_hw_test", "bmp_hw_test")

--- a/tests/machine_control/test_machine_controller.py
+++ b/tests/machine_control/test_machine_controller.py
@@ -15,7 +15,8 @@ from rig.machine_control.consts import (
 from rig.machine_control.machine_controller import (
     MachineController, SpiNNakerBootError, SpiNNakerMemoryError, MemoryIO,
     SpiNNakerRouterError, SpiNNakerLoadingError, SystemInfo, CoreInfo,
-    ChipInfo, ProcessorStatus, unpack_routing_table_entry, TruncationWarning
+    ChipInfo, ProcessorStatus, unpack_routing_table_entry, TruncationWarning,
+    TruncationWarning
 )
 from rig.machine_control.packets import SCPPacket
 from rig.machine_control.scp_connection import \
@@ -2794,7 +2795,8 @@ class TestMemoryIO(object):
         mock_controller.read.assert_called_with(1, 9, 0, 0, 0)
         mock_controller.read.reset_mock()
 
-        assert sdram_file.read(1) == b''
+        with pytest.warns(TruncationWarning):
+            assert sdram_file.read(1) == b''
         assert mock_controller.read.call_count == 0
 
     def test_empty_read(self, mock_controller):
@@ -2844,7 +2846,8 @@ class TestMemoryIO(object):
             assert len(w) == 1
             assert issubclass(w[0].category, TruncationWarning)
 
-        assert sdram_file.write(b"\x00") == 0
+        with pytest.warns(TruncationWarning):
+            assert sdram_file.write(b"\x00") == 0
         sdram_file.flush()
 
         assert mock_controller.write.call_count == 1
@@ -3024,7 +3027,8 @@ class TestMemoryIO(object):
         assert not mock_controller.read.called
 
         # No writes should occur
-        assert sdram_file.write(b"Hello, world!") == 0
+        with pytest.warns(TruncationWarning):
+            assert sdram_file.write(b"Hello, world!") == 0
         assert not mock_controller.write.called
 
         # Slicing should achieve the same thing

--- a/tests/machine_control/test_machine_controller.py
+++ b/tests/machine_control/test_machine_controller.py
@@ -2381,12 +2381,14 @@ class TestMachineController(object):
                              "largest_free_rtr_mc_block,ethernet_up",
                              [((18 | (0b111110 << 8) | (1024 << 14)),
                                18,
-                               set(l for l in Links if l != Links.east),
+                               set(link for link in Links
+                                   if link != Links.east),
                                1024,
                                False),
                               ((18 | (0b011111 << 8) | (0 << 14)),
                                18,
-                               set(l for l in Links if l != Links.south),
+                               set(link for link in Links
+                                   if link != Links.south),
                                0,
                                False),
                               ((17 | (0b111111 << 8) | (123 << 14)),

--- a/tests/machine_control/test_machine_controller.py
+++ b/tests/machine_control/test_machine_controller.py
@@ -15,8 +15,7 @@ from rig.machine_control.consts import (
 from rig.machine_control.machine_controller import (
     MachineController, SpiNNakerBootError, SpiNNakerMemoryError, MemoryIO,
     SpiNNakerRouterError, SpiNNakerLoadingError, SystemInfo, CoreInfo,
-    ChipInfo, ProcessorStatus, unpack_routing_table_entry, TruncationWarning,
-    TruncationWarning
+    ChipInfo, ProcessorStatus, unpack_routing_table_entry, TruncationWarning
 )
 from rig.machine_control.packets import SCPPacket
 from rig.machine_control.scp_connection import \

--- a/tests/place_and_route/route/test_ner.py
+++ b/tests/place_and_route/route/test_ner.py
@@ -425,10 +425,10 @@ def test_a_star_impossible():
 
     # A machine where the only working link is that going west from (1, 0) to
     # (0, 0).
-    machine = Machine(2, 1, dead_links=set((x, 0, l)
-                                           for l in Links for x in range(2)
+    machine = Machine(2, 1, dead_links=set((x, 0, link)
+                                           for link in Links for x in range(2)
                                            if not (x == 1 and
-                                                   l == Links.west)))
+                                                   link == Links.west)))
 
     # Ensure we can't get a route out of (0, 0) to (1, 0) since all links
     # leaving it are dead

--- a/tests/place_and_route/route/test_route_utils.py
+++ b/tests/place_and_route/route/test_route_utils.py
@@ -162,7 +162,7 @@ def test_links_between():
     # If some links are down, these should be omitted
     machine = Machine(1, 1, dead_links=set([(0, 0, Links.north)]))
     assert (links_between((0, 0), (0, 0), machine) ==  # pragma: no branch
-            set(l for l in Links if l != Links.north))
+            set(link for link in Links if link != Links.north))
 
     # Should work the same in large system
     machine = Machine(10, 10, dead_links=set([(4, 4, Links.north)]))

--- a/tests/place_and_route/test_utils.py
+++ b/tests/place_and_route/test_utils.py
@@ -47,7 +47,7 @@ def test_build_machine():
                          if (x, y, c) != (2, 3, 17) else
                          AppState.dead
                          for c in range(17 if (x, y) == (2, 3) else 18)],
-            working_links=(set(l for l in Links if l != Links.north)
+            working_links=(set(link for link in Links if link != Links.north)
                            if (x, y) == (4, 5) else
                            set(Links)),
             largest_free_sdram_block=(0 if (x, y) == (6, 7)

--- a/tests/routing_table/test_routing_table_ordered_covering.py
+++ b/tests/routing_table/test_routing_table_ordered_covering.py
@@ -368,7 +368,8 @@ class TestMinimise(object):
             RTE({Routes.south, Routes.south_west}, 0b0000, 0b1011),
             RTE({Routes.south_west}, 0b0100, 0b0100),
         ]
-        assert table_is_subset_of(table, expected_table), "Test is broken"
+        with pytest.warns(UserWarning):  # Table is non-orthogonal
+            assert table_is_subset_of(table, expected_table), "Test is broken"
 
         # Get the minimised table
         assert minimise(table, target_length=None) == expected_table


### PR DESCRIPTION
@mundya Hope you don't mind coming "out of retirement" to have a quick look over this PR?

This PR fixes a (really extremely embarrassing) bug in the Python interface to the C Kernel for the simulated annealing based placement algorithm. The C interface (as clearly documented in its header) requires that vertices are listed such that moveable vertices are listed first. The Python side of this, however, somehow never actually implemented this sorting step... In this PR, the test suite is fixed to find the bug and the implementation is fixed to add the sort.

Thanks very much to @robert-hardwick in project-rig/rig_c_sa#7 for spotting this bug. I'm really sorry it appeared. Its funny that two years on I could remember that "of course you must sort the vertices" but somehow didn't while actually writing the software... How very embarrassing.

@robert-hardwick Would you be able to check out this branch and check it fixes your issue?


* [x] Fix test suite to find SA bug
* [x] Fix SA wrapper
* [x] Fix new flake8 errors
* [x] Fix new `machine_controller` test warnings
* [x] Fix new ordered covering test warnings (assigned @mundya)
* [x] Run tests against reference hardware setup
* [ ] Diagnose source of failing fan indicator error